### PR TITLE
Add back support for individual media artwork

### DIFF
--- a/forked-daapd.conf
+++ b/forked-daapd.conf
@@ -91,6 +91,11 @@ library {
 	# forked-daapd will look for jpg and png files with these base names
 #	artwork_basenames = { "artwork", "cover", "Folder" }
 
+	# Disable searching for artwork corresponding to individual media file,
+	# and instead only look for album artwork. By default, individual artwork
+	# is enabled.
+#	ownartwork_disable = false
+
 	# File types the scanner should ignore
 	# Non-audio files will never be added to the database, but here you
 	# can prevent the scanner from even probing them. This might improve

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -1246,13 +1246,16 @@ artwork_get_item(int id, int max_w, int max_h, struct evbuffer *evbuf)
   if (!mfi)
     return -1;
 
-  /*
-   * Try the individual artwork first
-   */
-  ret = artwork_get_item_mfi(mfi, max_w, max_h, evbuf);
+  if (cfg_getbool(cfg_getsec(cfg, "library"), "ownartwork_disable"))
+    ret = -1;
+  else
+    /*
+     * Try the individual artwork first
+     */
+    ret = artwork_get_item_mfi(mfi, max_w, max_h, evbuf);
 
   /*
-   * No individual artwork, try group artwork
+   * No individual artwork or individual artwork disabled, try group artwork
    */
   if (ret < 0)
   {

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -1083,7 +1083,7 @@ artwork_get_group_persistentid(int64_t persistentid, int max_w, int max_h, struc
   /*
    * First check if the artwork cache has a cached entry for the given persistent id and requested width/height
    */
-  ret = cache_artwork_get(persistentid, max_w, max_h, &cached, &format, evbuf);
+  ret = cache_artwork_get(CACHE_ARTWORK_GROUP, persistentid, max_w, max_h, &cached, &format, evbuf);
   if (ret == 0 && cached)
     {
       if (format > 0)
@@ -1136,7 +1136,7 @@ artwork_get_group_persistentid(int64_t persistentid, int max_w, int max_h, struc
     DPRINTF(E_LOG, L_ART, "Error fetching Q_GROUP_DIRS results\n");
   else if (got_art > 0)
     {
-      cache_artwork_add(persistentid, max_w, max_h, format, filename, evbuf);
+      cache_artwork_add(CACHE_ARTWORK_GROUP, persistentid, max_w, max_h, format, filename, evbuf);
       return format;
     }
 
@@ -1186,13 +1186,13 @@ artwork_get_group_persistentid(int64_t persistentid, int max_w, int max_h, struc
     }
   else if (got_art > 0)
     {
-      cache_artwork_add(persistentid, max_w, max_h, format, filename, evbuf);
+      cache_artwork_add(CACHE_ARTWORK_GROUP, persistentid, max_w, max_h, format, filename, evbuf);
       return format;
     }
 
   /* Add cache entry for no artwork available */
   if (!got_spotifyitem)
-    cache_artwork_add(persistentid, max_w, max_h, 0, "", evbuf);
+    cache_artwork_add(CACHE_ARTWORK_GROUP, persistentid, max_w, max_h, 0, "", evbuf);
 
   DPRINTF(E_DBG, L_ART, "No artwork found for group %" PRIi64 "\n", persistentid);
 

--- a/src/cache.c
+++ b/src/cache.c
@@ -38,7 +38,7 @@
 #include "cache.h"
 
 
-#define CACHE_VERSION 1
+#define CACHE_VERSION 2
 
 /* The DAAP cache will cache raw daap replies for queries added with
  * cache_add(). Only some query types are supported.
@@ -66,6 +66,7 @@ struct cache_command
     int msec;
 
     char *path;  // artwork path
+    int artwork_type; // individual or group artwork
     int64_t peristentid;
     int max_w;
     int max_h;
@@ -236,6 +237,7 @@ cache_create_tables(void)
 #define T_ARTWORK					\
   "CREATE TABLE IF NOT EXISTS artwork ("		\
   "   id                  INTEGER PRIMARY KEY NOT NULL,"\
+  "   artwork_type        INTEGER NOT NULL DEFAULT 0,"  \
   "   persistentid        INTEGER NOT NULL,"		\
   "   max_w               INTEGER NOT NULL,"		\
   "   max_h               INTEGER NOT NULL,"		\
@@ -245,7 +247,7 @@ cache_create_tables(void)
   "   data                BLOB"				\
   ");"
 #define I_ARTWORK_ID				\
-  "CREATE INDEX IF NOT EXISTS idx_persistentidwh ON artwork(persistentid, max_w, max_h);"
+  "CREATE INDEX IF NOT EXISTS idx_persistentidwh ON artwork(artwork_type, persistentid, max_w, max_h);"
 #define I_ARTWORK_PATH				\
   "CREATE INDEX IF NOT EXISTS idx_pathtime ON artwork(filepath, db_timestamp);"
 #define T_ADMIN_CACHE	\
@@ -1055,7 +1057,7 @@ cache_artwork_add_impl(struct cache_command *cmd)
   int datalen;
   int ret;
 
-  query = "INSERT INTO artwork (id, persistentid, max_w, max_h, format, filepath, db_timestamp, data) VALUES (NULL, ?, ?, ?, ?, ?, ?, ?);";
+  query = "INSERT INTO artwork (id, persistentid, max_w, max_h, format, filepath, db_timestamp, data, artwork_type) VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?);";
 
   ret = sqlite3_prepare_v2(g_db_hdl, query, -1, &stmt, 0);
   if (ret != SQLITE_OK)
@@ -1079,6 +1081,7 @@ cache_artwork_add_impl(struct cache_command *cmd)
   sqlite3_bind_text(stmt, 5, cmd->arg.path, -1, SQLITE_STATIC);
   sqlite3_bind_int(stmt, 6, (uint64_t)time(NULL));
   sqlite3_bind_blob(stmt, 7, data, datalen, SQLITE_STATIC);
+  sqlite3_bind_int(stmt, 8, cmd->arg.artwork_type);
 
   ret = sqlite3_step(stmt);
   if (ret != SQLITE_DONE)
@@ -1104,7 +1107,8 @@ cache_artwork_add_impl(struct cache_command *cmd)
  * If there is a cached entry for the given id and width/height, the parameter cached is set to 1.
  * In this case format and data contain the cached values.
  *
- * @param cmd->arg.persistentid persistent songalbumid or songartistid
+ * @param cmd->arg.artwork_type individual or group artwork
+ * @param cmd->arg.persistentid persistent itemid, songalbumid or songartistid
  * @param cmd->arg.max_w maximum image width
  * @param cmd->arg.max_h maximum image height
  * @param cmd->arg.cached set by this function to 0 if no cache entry exists, otherwise 1
@@ -1115,13 +1119,13 @@ cache_artwork_add_impl(struct cache_command *cmd)
 static int
 cache_artwork_get_impl(struct cache_command *cmd)
 {
-#define Q_TMPL "SELECT a.format, a.data FROM artwork a WHERE a.persistentid = '%" PRIi64 "' AND a.max_w = %d AND a.max_h = %d;"
+#define Q_TMPL "SELECT a.format, a.data FROM artwork a WHERE a.artwork_type = %d AND a.persistentid = '%" PRIi64 "' AND a.max_w = %d AND a.max_h = %d;"
   sqlite3_stmt *stmt;
   char *query;
   int datalen;
   int ret;
 
-  query = sqlite3_mprintf(Q_TMPL, cmd->arg.peristentid, cmd->arg.max_w, cmd->arg.max_h);
+  query = sqlite3_mprintf(Q_TMPL, cmd->arg.artwork_type, cmd->arg.peristentid, cmd->arg.max_w, cmd->arg.max_h);
   if (!query)
     {
       DPRINTF(E_LOG, L_CACHE, "Out of memory for query string\n");
@@ -1462,7 +1466,7 @@ cache_artwork_purge_cruft(time_t ref)
  * @return 0 if successful, -1 if an error occurred
  */
 int
-cache_artwork_add(int64_t persistentid, int max_w, int max_h, int format, char *filename, struct evbuffer *evbuf)
+cache_artwork_add(int artwork_type, int64_t persistentid, int max_w, int max_h, int format, char *filename, struct evbuffer *evbuf)
 {
   struct cache_command cmd;
   int ret;
@@ -1473,6 +1477,7 @@ cache_artwork_add(int64_t persistentid, int max_w, int max_h, int format, char *
   command_init(&cmd);
 
   cmd.func = cache_artwork_add_impl;
+  cmd.arg.artwork_type = artwork_type;
   cmd.arg.peristentid = persistentid;
   cmd.arg.max_w = max_w;
   cmd.arg.max_h = max_h;
@@ -1502,7 +1507,7 @@ cache_artwork_add(int64_t persistentid, int max_w, int max_h, int format, char *
  * @return 0 if successful, -1 if an error occurred
  */
 int
-cache_artwork_get(int64_t persistentid, int max_w, int max_h, int *cached, int *format, struct evbuffer *evbuf)
+cache_artwork_get(int artwork_type, int64_t persistentid, int max_w, int max_h, int *cached, int *format, struct evbuffer *evbuf)
 {
   struct cache_command cmd;
   int ret;
@@ -1513,6 +1518,7 @@ cache_artwork_get(int64_t persistentid, int max_w, int max_h, int *cached, int *
   command_init(&cmd);
 
   cmd.func = cache_artwork_get_impl;
+  cmd.arg.artwork_type = artwork_type;
   cmd.arg.peristentid = persistentid;
   cmd.arg.max_w = max_w;
   cmd.arg.max_h = max_h;

--- a/src/cache.h
+++ b/src/cache.h
@@ -27,6 +27,9 @@ cache_daap_threshold(void);
 
 /* ---------------------------- Artwork cache API  --------------------------- */
 
+#define CACHE_ARTWORK_GROUP 0
+#define CACHE_ARTWORK_INDIVIDUAL 1
+
 int
 cache_artwork_ping(char *path, time_t mtime);
 
@@ -37,10 +40,10 @@ int
 cache_artwork_purge_cruft(time_t ref);
 
 int
-cache_artwork_add(int64_t persistentid, int max_w, int max_h, int format, char *filename, struct evbuffer *evbuf);
+cache_artwork_add(int artwork_type, int64_t persistentid, int max_w, int max_h, int format, char *filename, struct evbuffer *evbuf);
 
 int
-cache_artwork_get(int64_t persistentid, int max_w, int max_h, int *cached, int *format, struct evbuffer *evbuf);
+cache_artwork_get(int artwork_type, int64_t persistentid, int max_w, int max_h, int *cached, int *format, struct evbuffer *evbuf);
 
 
 /* ---------------------------- Cache API  --------------------------- */

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -76,6 +76,7 @@ static cfg_opt_t sec_library[] =
     CFG_STR("name_podcasts", "Podcasts", CFGF_NONE),
     CFG_STR("name_audiobooks", "Audiobooks", CFGF_NONE),
     CFG_STR_LIST("artwork_basenames", "{artwork,cover,Folder}", CFGF_NONE),
+    CFG_BOOL("ownartwork_disable", cfg_false, CFGF_NONE),
     CFG_STR_LIST("filetypes_ignore", "{.db,.ini,.db-journal,.pdf}", CFGF_NONE),
     CFG_BOOL("filescan_disable", cfg_false, CFGF_NONE),
     CFG_BOOL("itunes_overrides", cfg_false, CFGF_NONE),


### PR DESCRIPTION
This pull request re-adds support for individual artwork, including support for caching individual artwork.

The first commit adds back basic support for individual artwork.  When a request for an individual media item's artwork is made, this logic looks first for embedded artwork and then for a jpg or png file in the same path and with the same base name as the media file. If no individual artwork is found, then it proceeds with the existing search for group artwork pertaining to the item (including a search of the cache).

The second and third commits add support for caching individual artwork.  The second commit modifies the artwork cache table and api to allow for distinguishing between individual artwork and group artwork. Because persistent ids for individual media and persistent ids for groups might clash, an addition field in the artwork cache table is necessary to identify the correct artwork for a given item or group.  This commit adds this field, artwork_type, which can be 0 for group artwork and 1 for individual artwork.  It also adds this field to the persistentid index so that selects will be optimized. It modifies the functions cache_artwork_get and cache_artwork_add (and their internal implementing functions) to add a corresponding artwork_type argument.  Finally, it updates artwork.c to make the existing calls to cache_artwork_add and cache_artwork_get pass in an artwork_type parameter.

The third commit modifies the individual artwork logic to look for individual artwork in the cache and then to add the individual artwork to the cache if none was found there.