### PR TITLE
Fix filepath matching for iTunes library import

### DIFF
--- a/src/filescanner_itunes.c
+++ b/src/filescanner_itunes.c
@@ -281,10 +281,10 @@ find_track_file(char *location)
       return 0;
     }
 
-  plen = strlen("file://localhost/");
+  plen = strlen("file://");
 
   /* Not a local file ... */
-  if (strncmp(location, "file://localhost/", plen) != 0)
+  if (strncmp(location, "file://", plen) != 0)
     return 0;
 
   /* Now search for the library item where the path has closest match to playlist item */


### PR DESCRIPTION
I tried importing my iTunes ratings but noticed that the file path matching didn't work. With this change it works as expected including the directory matching.

Not sure why it matches "localhost" in the first. My iTunes is version 12 on OS X, but as far as I remember iTunes doesn't use "localhost" in its library since the beginning. Rather it's "file:///Users/username/Music/...."