### PR TITLE
Pairinghelper Fixes

### DIFF
--- a/scripts/pairinghelper.sh
+++ b/scripts/pairinghelper.sh
@@ -12,9 +12,9 @@ fi
 logfile=`awk '$1=="logfile"{print $3}' $conf_path`
 logfile="${logfile%\"}"
 logfile="${logfile#\"}"
-library_path=`awk '$1=="directories"{print $4}' $conf_path`
-library_path="${library_path%\"}"
-library_path="${library_path#\"}"
+library_path=`awk '$1=="directories"{print}' $conf_path`
+library_path="${library_path#*\"}"
+library_path="${library_path%%\"*}"
 
 if [ ! -f $logfile ]; then
 	echo "Error: Couldn't find logfile in $logfile"

--- a/scripts/pairinghelper.sh
+++ b/scripts/pairinghelper.sh
@@ -56,7 +56,7 @@ if [ -z "$pin" ]; then
 fi
 
 echo "Writing pair.remote to $library_path..."
-echo -e "$remote\n$pin" > "$library_path/pair.remote"
+echo "$remote\n$pin" > "$library_path/pair.remote"
 sleep 1
 echo "Removing pair.remote from library again..."
 rm "$library_path/pair.remote"


### PR DESCRIPTION
The pairing helper script didn't work for me because of two issues:

- Library Path had to be without spaces
- Log: [2015-02-26 21:00:16] [  LOG]   remote: Remote '-e remoteXX' not known from mDNS, ignoring

I tried to fix these two issues and want to share this. I hope you like it.

(This is my first pull request ever, so please tell me if I did something wrong :yum:)