### PR TITLE
silence compiler warning in player.c "warning: ignoring return value"

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1804,7 +1804,9 @@ player_playback_cb(int fd, short what, void *arg)
   uint64_t ticks;
 
   /* Acknowledge timer */
-  read(fd, &ticks, sizeof(ticks));
+  ret = read(fd, &ticks, sizeof(ticks));
+  if (ret <= 0)
+    DPRINTF(E_LOG, L_PLAYER, "Error reading timer.\n");
 #endif /* __linux__ */
 
   /* Decide how many packets to send */


### PR DESCRIPTION
The compiler complains about the unread return value of "read":
```
player.c:1807:7: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
   read(fd, &ticks, sizeof(ticks));
```

I think it is good to at least write a log message, if there where no bytes read.