### PR TITLE
Improve playing audiobooks from Retune

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -978,7 +978,11 @@ dacp_reply_playspec(struct evhttp_request *req, struct evbuffer *evbuf, char **u
     {
       /* Start song ID */
       if ((param = evhttp_find_header(query, "item-spec")))
-	plid = 0; // This is a podcast/audiobook - just play a single item, not a playlist
+	{
+	  // This is a podcast (plid == 5) or audiobook (plid == 6)
+	  if (plid != 6)
+	    plid = 0; // This is a podcast - just play a single item, not a playlist (audiobooks are handled in 'player_queue_make_pl')
+	}
       else if (!(param = evhttp_find_header(query, "container-item-spec")))
 	{
 	  DPRINTF(E_LOG, L_DACP, "No container-item-spec/item-spec in playspec request\n");


### PR DESCRIPTION
Currently starting playback for an audiobook item from Retune (uses the playspec daap command) only plays the selected item instead of the whole audiobook. This pr changes this behavior by checking if the given playlist id represents the audiobook playlist (id = 6). If this is the case it loads the specified item and adds the whole album for this item to the queue.

Apple Remote does not have this issue, instead of the playspec command it uses the playqueue-edit command. The playqueue-edit command already handles this special case with the "quirkyquery" code path. 

I do not like the "magic" number 6 (this is the id defined in "Q_PL6" in db.c). This could be changed to always load the playlist and then check the media_kind field. 
Another thing is, that i am not sure how podcasts should be handled. Is it the desired behavior to only add the single item or would it be better to add the whole album?