### PR TITLE
Spotify

### DIFF
--- a/forked-daapd.conf
+++ b/forked-daapd.conf
@@ -163,6 +163,22 @@ spotify {
 	# Set preferred bitrate for music streaming
 	# 0: No preference (default), 1: 96kbps, 2: 160kbps, 3: 320kbps
 #	bitrate = 0
+
+	# Compilations usually have many artists, and if you don't want every
+	# artist to be listed when artist browsing in Remote, you can set
+	# a single name which will be used for all music in the compilation dir
+	# (changing this setting only takes effect after rescan, see the README)
+
+	# Spotify playlists usually have many artist, and if you don't want every
+	# artist to be listed when artist browsing in Remote, you can set the 
+	# artist_override flag to true. This will use the compilation_artist as
+	# album artist for spotify items that are not in the starred playlist.
+#	artist_override = false
+
+	# Like artist_override, the starre_artist_override flag can be set to true,
+	# in order to use the compilation_artist for items in the spotify starred
+	# playlist.
+#	starred_artist_override = false
 }
 
 # SQLite configuration (allows to modify the operation of the SQLite databases)

--- a/forked-daapd.conf
+++ b/forked-daapd.conf
@@ -175,10 +175,22 @@ spotify {
 	# album artist for spotify items that are not in the starred playlist.
 #	artist_override = false
 
-	# Like artist_override, the starre_artist_override flag can be set to true,
+	# Like artist_override, the starred_artist_override flag can be set to true,
 	# in order to use the compilation_artist for items in the spotify starred
 	# playlist.
 #	starred_artist_override = false
+
+	# Similar to the different artists in spotify playlists, the playlist items
+	# belong to different albums, and if you do not want every album to be listed
+	# when browsing in Remote, you can set the album_override flag to true. This
+	# will use the playlist name as album name for spotify items that are not in
+	# the starred playlist. Notice that if an item is in more than one playlist,
+	# it will only appear in one album when browsing (in which album is random).
+#	album_override = false
+
+	# Like album_override, the starred_album_override flag can be set to true,
+	# in order to use the playlist name as album name.
+#	starred_album_override = false
 }
 
 # SQLite configuration (allows to modify the operation of the SQLite databases)

--- a/forked-daapd.conf
+++ b/forked-daapd.conf
@@ -164,11 +164,6 @@ spotify {
 	# 0: No preference (default), 1: 96kbps, 2: 160kbps, 3: 320kbps
 #	bitrate = 0
 
-	# Compilations usually have many artists, and if you don't want every
-	# artist to be listed when artist browsing in Remote, you can set
-	# a single name which will be used for all music in the compilation dir
-	# (changing this setting only takes effect after rescan, see the README)
-
 	# Spotify playlists usually have many artist, and if you don't want every
 	# artist to be listed when artist browsing in Remote, you can set the 
 	# artist_override flag to true. This will use the compilation_artist as

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -115,6 +115,8 @@ static cfg_opt_t sec_spotify[] =
     CFG_INT("bitrate", 0, CFGF_NONE),
     CFG_BOOL("artist_override", cfg_false, CFGF_NONE),
     CFG_BOOL("starred_artist_override", cfg_false, CFGF_NONE),
+    CFG_BOOL("album_override", cfg_false, CFGF_NONE),
+    CFG_BOOL("starred_album_override", cfg_false, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -113,6 +113,8 @@ static cfg_opt_t sec_spotify[] =
     CFG_STR("settings_dir", STATEDIR "/cache/" PACKAGE "/libspotify", CFGF_NONE),
     CFG_STR("cache_dir", "/tmp", CFGF_NONE),
     CFG_INT("bitrate", 0, CFGF_NONE),
+    CFG_BOOL("artist_override", cfg_false, CFGF_NONE),
+    CFG_BOOL("starred_artist_override", cfg_false, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -184,6 +184,7 @@ typedef sp_error     (*fptr_sp_session_login_t)(sp_session *session, const char 
 typedef sp_error     (*fptr_sp_session_relogin_t)(sp_session *session);
 typedef sp_error     (*fptr_sp_session_logout_t)(sp_session *session);
 typedef sp_error     (*fptr_sp_session_process_events_t)(sp_session *session, int *next_timeout);
+typedef sp_playlist* (*fptr_sp_session_starred_create_t)(sp_session *session);
 typedef sp_playlistcontainer* (*fptr_sp_session_playlistcontainer_t)(sp_session *session);
 typedef sp_error     (*fptr_sp_session_player_load_t)(sp_session *session, sp_track *track);
 typedef sp_error     (*fptr_sp_session_player_unload_t)(sp_session *session);
@@ -242,6 +243,7 @@ fptr_sp_session_release_t fptr_sp_session_release;
 fptr_sp_session_login_t fptr_sp_session_login;
 fptr_sp_session_relogin_t fptr_sp_session_relogin;
 fptr_sp_session_logout_t fptr_sp_session_logout;
+fptr_sp_session_starred_create_t fptr_sp_session_starred_create;
 fptr_sp_session_playlistcontainer_t fptr_sp_session_playlistcontainer;
 fptr_sp_session_process_events_t fptr_sp_session_process_events;
 fptr_sp_session_player_load_t fptr_sp_session_player_load;
@@ -320,6 +322,7 @@ fptr_assign_all()
    && (fptr_sp_session_preferred_bitrate = dlsym(h, "sp_session_preferred_bitrate"))
    && (fptr_sp_playlistcontainer_add_callbacks = dlsym(h, "sp_playlistcontainer_add_callbacks"))
    && (fptr_sp_playlistcontainer_num_playlists = dlsym(h, "sp_playlistcontainer_num_playlists"))
+   && (fptr_sp_session_starred_create = dlsym(h, "sp_session_starred_create"))
    && (fptr_sp_playlistcontainer_playlist = dlsym(h, "sp_playlistcontainer_playlist"))
    && (fptr_sp_playlist_add_callbacks = dlsym(h, "sp_playlist_add_callbacks"))
    && (fptr_sp_playlist_name = dlsym(h, "sp_playlist_name"))
@@ -1178,6 +1181,9 @@ logged_in(sp_session *sess, sp_error error)
   DPRINTF(E_LOG, L_SPOTIFY, "Login to Spotify succeeded. Reloading playlists.\n");
 
   db_spotify_purge();
+
+  pl = fptr_sp_session_starred_create(sess);
+  fptr_sp_playlist_add_callbacks(pl, &pl_callbacks, NULL);
 
   pc = fptr_sp_session_playlistcontainer(sess);
 

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -596,7 +596,12 @@ spotify_playlist_save(sp_playlist *pl)
 //  sleep(1); // Primitive way of preventing database locking (the mutex wasn't working)
 
   pli = db_pl_fetch_bypath(url);
-  snprintf(title, sizeof(title), "[s] %s", name);
+
+  // The starred playlist has an empty name, set it manually to "Starred"
+  if (*name == '\0')
+    snprintf(title, sizeof(title), "[s] Starred");
+  else
+    snprintf(title, sizeof(title), "[s] %s", name);
 
   snprintf(virtual_path, PATH_MAX, "/spotify:/%s", title);
 


### PR DESCRIPTION
Finally i got myself a spotify premium account. The spotify integration in forked-daapd works flawless for me, thanks for adding support for it!

Two minor inconveniences i try to address with this pr:

1) What i am missing is the "starred" playlist. Digging through the spotify api, the starred playlist needs to be loaded separately. This is done in the first two commits of this pr ( 665c76d + c984bcd ).

2) What i would love to see added in the spotify integration, is a way to avoid the cluttering of the artist and album listings in Remote (showing artists and albums where only one track is part of a spotify playlist).
The solution i came up with for the artist listing is to use the compilation artist for spotify songs (see the forth commit 7cc3659). To avoid the album cluttering, the playlist name is used as album name (see the fifth commit 988283c). Both are optional and can be set separately for starred tracks and not starred tracks.

@ejurgensen please let me know what you think about this.