### PR TITLE
Modified to obtain compilation information from each files

### DIFF
--- a/src/filescanner_ffmpeg.c
+++ b/src/filescanner_ffmpeg.c
@@ -96,6 +96,19 @@ parse_disc(struct media_file_info *mfi, char *disc_string)
   return parse_slash_separated_ints(disc_string, disc, total_discs);
 }
 
+static int
+parse_compilation(struct media_file_info *mfi, char *compilation_string)
+{
+  uint32_t compilation = 0;
+
+  if (safe_atou32(compilation_string, &compilation) == 0)
+    {
+      mfi->compilation = compilation == 1 ? 1 : 0;
+    }
+
+  return 1;
+}
+
 /* Lookup is case-insensitive, first occurrence takes precedence */
 static const struct metadata_map md_map_generic[] =
   {
@@ -118,6 +131,7 @@ static const struct metadata_map md_map_generic[] =
     { "title-sort",   0, mfi_offsetof(title_sort),         NULL },
     { "artist-sort",  0, mfi_offsetof(artist_sort),        NULL },
     { "album-sort",   0, mfi_offsetof(album_sort),         NULL },
+    { "compilation",  0, mfi_offsetof(compilation),        parse_compilation },
 
     { NULL,           0, 0,                                NULL }
   };


### PR DESCRIPTION
Some music files have compilation information.
 (ex http://id3.org/iTunes%20Compilation%20Flag)
So, I try to read and use this information in forked-daapd.
