### PR TITLE
[laudio] Make output type for local audio configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,19 +73,21 @@ AC_ARG_ENABLE(lastfm, AS_HELP_STRING([--enable-lastfm], [enable LastFM support (
 
 case "$host" in
 	*-*-linux-*)
+		use_alsa=true
 		use_oss4=false
 		;;
 	*-*-kfreebsd*-*|*-*-freebsd*)
+		use_alsa=false
 		use_oss4=true
 		;;
 esac
 
 AC_ARG_WITH(oss4, AS_HELP_STRING([--with-oss4], [use OSS4 (default Linux=no, FreeBSD=yes)]),
-                  use_oss4=true;
+                  AS_IF([test "x$with_oss4" = "xyes"],[use_oss4=true],[use_oss4=false]);
                   )
 
 AC_ARG_WITH(alsa, AS_HELP_STRING([--with-alsa], [use ALSA (default Linux=yes, FreeBSD=no)]),
-                  use_oss4=false;
+                  AS_IF([test "x$with_alsa" = "xyes"],[use_alsa=true],[use_alsa=false]);
                   )
 
 AC_ARG_ENABLE(mpd, AS_HELP_STRING([--enable-mpd], [enable MPD client protocol support (default=no)]),
@@ -98,7 +100,7 @@ AM_CONDITIONAL(COND_ITUNES, test x$use_itunes = xtrue)
 AM_CONDITIONAL(COND_SPOTIFY, test x$use_spotify = xtrue)
 AM_CONDITIONAL(COND_LASTFM, test x$use_lastfm = xtrue)
 AM_CONDITIONAL(COND_OSS4, test x$use_oss4 = xtrue)
-AM_CONDITIONAL(COND_ALSA, test x$use_oss4 != xtrue)
+AM_CONDITIONAL(COND_ALSA, test x$use_alsa = xtrue)
 AM_CONDITIONAL(COND_MPD, test x$use_mpd = xtrue)
 
 dnl Checks for libraries.
@@ -226,11 +228,15 @@ if test x$use_lastfm = xtrue; then
 		AC_DEFINE(HAVE_MXML_GETOPAQUE, 1, [Define to 1 if your mxml has mxmlGetOpaque.]))
 fi
 
-if test x$use_oss4 != xtrue; then
+if test x$use_alsa = xtrue; then
 	PKG_CHECK_MODULES(ALSA, [ alsa ])
 	AC_DEFINE(LAUDIO_USE_ALSA, 1, [define if local audio output uses ALSA])
-else
+	CPPFLAGS="${CPPFLAGS} -DALSA"
+fi
+
+if test x$use_oss4 = xtrue; then
 	AC_CHECK_HEADER(sys/soundcard.h, , AC_MSG_ERROR([sys/soundcard.h not found]))
+	CPPFLAGS="${CPPFLAGS} -DOSS4"
 fi
 
 case "$host" in

--- a/forked-daapd.conf
+++ b/forked-daapd.conf
@@ -139,6 +139,9 @@ library {
 audio {
 	# Name - used in the speaker list in Remote
 	nickname = "Computer"
+	
+	# Type of the output (alsa, oss4, dummy)
+#	type = "alsa"
 
 	# Audio device name for local audio output
 #	card = "default"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,7 +121,9 @@ forked_daapd_SOURCES = main.c \
 	daap_query.c daap_query.h \
 	player.c player.h \
 	worker.c worker.h \
-	$(ALSA_SRC) $(OSS4_SRC) laudio.h \
+	$(ALSA_SRC) $(OSS4_SRC) \
+	laudio_dummy.c \
+	laudio.c laudio.h \
 	raop.c raop.h \
 	$(RTSP_SRC) \
 	scan-wma.c \

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -92,6 +92,7 @@ static cfg_opt_t sec_library[] =
 static cfg_opt_t sec_audio[] =
   {
     CFG_STR("nickname", "Computer", CFGF_NONE),
+    CFG_STR("type", NULL, CFGF_NONE),
 #ifdef __linux__
     CFG_STR("card", "default", CFGF_NONE),
 #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)

--- a/src/laudio.c
+++ b/src/laudio.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2015 Christian Meffert <christian.meffert@googlemail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include "conffile.h"
+#include "logger.h"
+#include "player.h"
+#include "laudio.h"
+
+#ifdef ALSA
+extern audio_output audio_alsa;
+#endif
+#ifdef OSS4
+extern audio_output audio_oss4;
+#endif
+
+extern audio_output audio_dummy;
+
+static audio_output *outputs[] = {
+#ifdef ALSA
+    &audio_alsa,
+#endif
+#ifdef OSS4
+    &audio_oss4,
+#endif
+    &audio_dummy,
+    NULL
+};
+
+static audio_output *output;
+
+struct pcm_packet
+{
+  uint8_t samples[STOB(AIRTUNES_V2_PACKET_SAMPLES)];
+
+  uint64_t rtptime;
+
+  size_t offset;
+
+  struct pcm_packet *next;
+};
+
+
+
+void
+laudio_write(uint8_t *buf, uint64_t rtptime)
+{
+  output->write(buf, rtptime);
+}
+
+uint64_t
+laudio_get_pos(void)
+{
+  return output->pos();
+}
+
+void
+laudio_set_volume(int vol)
+{
+  output->volume(vol);
+}
+
+int
+laudio_start(uint64_t cur_pos, uint64_t next_pkt)
+{
+  return output->start(cur_pos, next_pkt);
+}
+
+void
+laudio_stop(void)
+{
+  output->stop();
+}
+
+
+int
+laudio_open(void)
+{
+  return output->open();
+}
+
+void
+laudio_close(void)
+{
+  output->close();
+}
+
+
+int
+laudio_init(laudio_status_cb cb)
+{
+  cfg_t *cfg_audio;
+  char *type;
+  int i;
+
+  cfg_audio = cfg_getsec(cfg, "audio");
+  type = cfg_getstr(cfg_audio, "type");
+
+  output = NULL;
+  if (type)
+    {
+      DPRINTF(E_DBG, L_LAUDIO, "Searching for local audio output: '%s'\n", type);
+      for (i = 0; outputs[i]; i++)
+	{
+	  if (0 == strcmp(type, outputs[i]->name))
+	    {
+	      output = outputs[i];
+	    }
+	}
+
+      if (!output)
+	DPRINTF(E_WARN, L_LAUDIO, "No local audio output '%s' available, falling back to default output\n", type);
+    }
+
+  if (!output)
+    {
+      output = outputs[0];
+    }
+
+  DPRINTF(E_INFO, L_LAUDIO, "Local audio output: '%s'\n", output->name);
+
+  return output->init(cb, cfg_audio);
+}
+
+void
+laudio_deinit(void)
+{
+  output->deinit();
+}

--- a/src/laudio.h
+++ b/src/laudio.h
@@ -17,6 +17,39 @@ enum laudio_state
 
 typedef void (*laudio_status_cb)(enum laudio_state status);
 
+typedef struct
+{
+  // Identifier of th audio output
+  char *name;
+
+  // Initialization function called during startup
+  int (*init)(laudio_status_cb cb, cfg_t *cfg_audio);
+
+  // Deinitialization function called at shutdown
+  void (*deinit)(void);
+
+  // Function to open the output called at playback start or speaker activiation
+  int (*open)(void);
+
+  // Function called after opening the output (during playback start or speaker activiation
+  int (*start)(uint64_t cur_pos, uint64_t next_pkt);
+
+  // block of samples
+  void (*write)(uint8_t *buf, uint64_t rtptime);
+
+  // Stopping audio playback
+  void (*stop)(void);
+
+  // Closes the output
+  void (*close)(void);
+
+  // Returns the rtptime of the packet thats is currently playing
+  uint64_t (*pos)();
+
+  // Sets the volum for the output
+  void (*volume)(int vol);
+} audio_output;
+
 void
 laudio_write(uint8_t *buf, uint64_t rtptime);
 

--- a/src/laudio_dummy.c
+++ b/src/laudio_dummy.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015 Christian Meffert <christian.meffert@googlemail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include "conffile.h"
+#include "logger.h"
+#include "misc.h"
+#include "player.h"
+#include "laudio.h"
+
+
+static enum laudio_state pcm_status;
+static laudio_status_cb status_cb;
+
+static struct timespec timer_res;
+static struct timespec ts;
+static uint64_t pcmpos;
+
+
+
+static uint64_t
+laudio_dummy_get_pos(void)
+{
+  struct timespec cur_timer_res;
+  struct timespec cur_ts;
+  uint64_t delta;
+  int ret;
+
+  ret = clock_gettime_with_res(CLOCK_MONOTONIC, &cur_ts, &cur_timer_res);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Couldn't get clock: %s\n", strerror(errno));
+      return -1;
+    }
+
+  delta = (cur_ts.tv_sec - ts.tv_sec) * 1000000 + (cur_ts.tv_nsec - ts.tv_nsec) / 1000;
+  delta = (delta * 44100) / 1000000;
+
+  DPRINTF(E_DBG, L_LAUDIO, "Start: %" PRIu64 ", Pos: %" PRIu64 "\n", pcmpos, delta);
+
+  return (pcmpos + delta);
+}
+
+static void
+laudio_dummy_write(uint8_t *buf, uint64_t rtptime)
+{
+  uint64_t pos;
+
+  pos = laudio_dummy_get_pos();
+
+  if (pcm_status != LAUDIO_RUNNING && pos > (pcmpos + 88200))
+    {
+      pcm_status = LAUDIO_RUNNING;
+      status_cb(LAUDIO_RUNNING);
+    }
+}
+
+static void
+laudio_dummy_set_volume(int vol)
+{
+}
+
+static int
+laudio_dummy_start(uint64_t cur_pos, uint64_t next_pkt)
+{
+  int ret;
+
+  ret = clock_gettime_with_res(CLOCK_MONOTONIC, &ts, &timer_res);
+
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Couldn't get current clock: %s\n", strerror(errno));
+      return -1;
+    }
+
+  pcmpos = cur_pos;
+
+  pcm_status = LAUDIO_STARTED;
+  status_cb(LAUDIO_STARTED);
+
+  return 0;
+}
+
+static void
+laudio_dummy_stop(void)
+{
+  pcm_status = LAUDIO_STOPPING;
+  status_cb(LAUDIO_STOPPING);
+  pcm_status = LAUDIO_OPEN;
+  status_cb(LAUDIO_OPEN);
+}
+
+static int
+laudio_dummy_open(void)
+{
+  pcm_status = LAUDIO_OPEN;
+  status_cb(LAUDIO_OPEN);
+  return 0;
+}
+
+static void
+laudio_dummy_close(void)
+{
+  pcm_status = LAUDIO_CLOSED;
+  status_cb(LAUDIO_CLOSED);
+}
+
+
+static int
+laudio_dummy_init(laudio_status_cb cb, cfg_t *cfg_audio)
+{
+  status_cb = cb;
+  return 0;
+}
+
+static void
+laudio_dummy_deinit(void)
+{
+}
+
+audio_output audio_dummy = {
+    .name = "dummy",
+    .init = &laudio_dummy_init,
+    .deinit = &laudio_dummy_deinit,
+    .start = &laudio_dummy_start,
+    .stop = &laudio_dummy_stop,
+    .open = &laudio_dummy_open,
+    .close = &laudio_dummy_close,
+    .pos = &laudio_dummy_get_pos,
+    .write = &laudio_dummy_write,
+    .volume = &laudio_dummy_set_volume,
+    };

--- a/src/laudio_oss4.c
+++ b/src/laudio_oss4.c
@@ -73,8 +73,8 @@ update_status(enum laudio_state status)
   status_cb(status);
 }
 
-void
-laudio_write(uint8_t *buf, uint64_t rtptime)
+static void
+laudio_oss4_write(uint8_t *buf, uint64_t rtptime)
 {
   struct pcm_packet *pkt;
   int scratch;
@@ -175,8 +175,8 @@ laudio_write(uint8_t *buf, uint64_t rtptime)
     }
 }
 
-uint64_t
-laudio_get_pos(void)
+static uint64_t
+laudio_oss4_get_pos(void)
 {
   int delay;
   int ret;
@@ -192,8 +192,8 @@ laudio_get_pos(void)
   return pcm_pos - BTOS(delay);
 }
 
-void
-laudio_set_volume(int vol)
+static void
+laudio_oss4_set_volume(int vol)
 {
   int oss_vol;
   int ret;
@@ -212,8 +212,8 @@ laudio_set_volume(int vol)
   DPRINTF(E_DBG, L_LAUDIO, "Setting PCM volume to %d (real: %d)\n", vol, (oss_vol & 0xff));
 }
 
-int
-laudio_start(uint64_t cur_pos, uint64_t next_pkt)
+static int
+laudio_oss4_start(uint64_t cur_pos, uint64_t next_pkt)
 {
   int scratch;
   int ret;
@@ -251,8 +251,8 @@ laudio_start(uint64_t cur_pos, uint64_t next_pkt)
   return 0;
 }
 
-void
-laudio_stop(void)
+static void
+laudio_oss4_stop(void)
 {
   struct pcm_packet *pkt;
   int ret;
@@ -276,8 +276,8 @@ laudio_stop(void)
   update_status(LAUDIO_OPEN);
 }
 
-int
-laudio_open(void)
+static int
+laudio_oss4_open(void)
 {
   audio_buf_info bi;
   oss_sysinfo si;
@@ -369,8 +369,8 @@ laudio_open(void)
   return -1;
 }
 
-void
-laudio_close(void)
+static void
+laudio_oss4_close(void)
 {
   struct pcm_packet *pkt;
   int ret;
@@ -396,18 +396,32 @@ laudio_close(void)
 }
 
 
-int
-laudio_init(laudio_status_cb cb)
+static int
+laudio_oss4_init(laudio_status_cb cb, cfg_t *cfg_audio)
 {
   status_cb = cb;
 
-  card_name = cfg_getstr(cfg_getsec(cfg, "audio"), "card");
+  card_name = cfg_getstr(cfg_audio, "card");
 
   return 0;
 }
 
-void
-laudio_deinit(void)
+static void
+laudio_oss4_deinit(void)
 {
   /* EMPTY */
 }
+
+audio_output audio_oss4 = {
+    .name = "oss4",
+    .init = &laudio_oss4_init,
+    .deinit = &laudio_oss4_deinit,
+    .start = &laudio_oss4_start,
+    .stop = &laudio_oss4_stop,
+    .open = &laudio_oss4_open,
+    .close = &laudio_oss4_close,
+    .pos = &laudio_oss4_get_pos,
+    .write = &laudio_oss4_write,
+    .volume = &laudio_oss4_set_volume,
+    };
+


### PR DESCRIPTION
These changes are heavily inspired by the shairport implementation for audio outputs. 
It allows to have multiple audio output implementations instead of one (alsa or oss4) that is determined at compile time. Which implementation is used by forked-daapd is configured in the forked-daapd.conf file. 

In addition to the existing implementations for alsa and oss4, i added a dummy output. 
With the changes in configure.ac it should now be possible to compile without alsa and without oss4 and to only use the dummy output.

I only tested the alsa changes and my knowledge of configure.ac is rather limited ...
What do you think @ejurgensen ? 