### PR TITLE
Problem opening stream - error code 404

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -187,6 +187,11 @@ http_client_request(struct http_client_ctx *ctx)
     }
 
   if (port <= 0)
+    snprintf(s, PATH_MAX, "%s", hostname);
+  else
+    snprintf(s, PATH_MAX, "%s:%d", hostname, port);
+
+  if (port <= 0)
     port = 80;
 
   if (strlen(path) == 0)
@@ -231,7 +236,6 @@ http_client_request(struct http_client_ctx *ctx)
 #endif
 
   headers = evhttp_request_get_output_headers(req);
-  snprintf(s, PATH_MAX, "%s:%d", hostname, port);
   evhttp_add_header(headers, "Host", s);
   evhttp_add_header(headers, "Content-Length", "0");
   evhttp_add_header(headers, "User-Agent", "forked-daapd/" VERSION);


### PR DESCRIPTION
@ejurgensen i ran into a problem when trying to open the radio streams from deutschlandradio.de (e. g. http://www.deutschlandradio.de/streaming/dkultur.m3u). Playback did not start and the http request from forked-daapd for this uri returned 404 "page not found".

Comparing the requests from vlc to forked-daapd showed that the different values for the header value "Host" caused the problem.

Request from vlc:
```
GET /streaming/dkultur.m3u HTTP/1.1
Host: www.deutschlandradio.de
User-Agent: VLC/2.1.6 LibVLC/2.1.6
Range: bytes=0-
Connection: close
Icy-MetaData: 1
```

Request from forked-daapd:
```
GET /streaming/dkultur.m3u HTTP/1.1
Host: www.deutschlandradio.de:80
Content-Length: 0
User-Agent: forked-daapd/22.3
Icy-MetaData: 1
```

After omitting the port number ":80" in the header value, the streams start without further issues.