### PR TITLE
do not execute individual delete queries for cached artwork files during bulk scan

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -31,7 +31,7 @@ cache_daap_threshold(void);
 #define CACHE_ARTWORK_INDIVIDUAL 1
 
 int
-cache_artwork_ping(char *path, time_t mtime);
+cache_artwork_ping(char *path, time_t mtime, int del);
 
 int
 cache_artwork_delete_by_path(char *path);

--- a/src/filescanner.c
+++ b/src/filescanner.c
@@ -844,12 +844,16 @@ process_deferred_playlists(void)
 static void
 process_file(char *file, time_t mtime, off_t size, int type, int flags)
 {
+  int is_bulkscan;
+
+  is_bulkscan = (flags & F_SCAN_BULK);
+
   switch (file_type_get(file))
     {
       case FILE_REGULAR:
 	filescanner_process_media(file, mtime, size, type, NULL);
 
-	cache_artwork_ping(file, mtime);
+	cache_artwork_ping(file, mtime, !is_bulkscan);
 	// TODO [artworkcache] If entry in artwork cache exists for no artwork available, delete the entry if media file has embedded artwork
 
 	counter++;
@@ -878,7 +882,7 @@ process_file(char *file, time_t mtime, off_t size, int type, int flags)
 
       case FILE_ARTWORK:
 	DPRINTF(E_DBG, L_SCAN, "Artwork file: %s\n", file);
-	cache_artwork_ping(file, mtime);
+	cache_artwork_ping(file, mtime, !is_bulkscan);
 
 	// TODO [artworkcache] If entry in artwork cache exists for no artwork available for a album with files in the same directory, delete the entry
 


### PR DESCRIPTION
see title, this also contains the change of the DPRINTF for size_t from %d to %zu