### PR TITLE
Fix wrong media kind value for music

### DIFF
--- a/README_SMARTPL.md
+++ b/README_SMARTPL.md
@@ -70,7 +70,7 @@ Valid operands for the enumeration "media_kind" are:
 
 Multiple expressions can be anded or ored together, using the keywords OR and AND. The unary not operator is also supported using the keyword NOT.
 
-Example:
+Examples:
 
 ```
 "techno" {
@@ -111,7 +111,7 @@ This would match all songs added as files to the library that are not placed und
 This would match any podcast and audiobook file that was never played with forked-daapd.
 
 
-## Date oprand syntax
+## Date operand syntax
 
 One example of a valid date is a date in yyyy-mm-dd format:
 

--- a/src/db.h
+++ b/src/db.h
@@ -86,7 +86,7 @@ struct pairing_info {
 };
 
 enum media_kind {
-  MEDIA_KIND_MUSIC = 0,
+  MEDIA_KIND_MUSIC = 1,
   MEDIA_KIND_MOVIE = 2,
   MEDIA_KIND_PODCAST = 4,
   MEDIA_KIND_AUDIOBOOK = 8,


### PR DESCRIPTION
This fixes the wrong media_kind value for music and some typos in the readme file for smart playlists