### PR TITLE
Fix mpd command "list" for artists and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,8 +491,8 @@ Following table shows what is working for a selection of MPD clients:
 
 |          Client                               |  Type  | Status          |
 | --------------------------------------------- | ------ | --------------- |
-| [mpc](http://www.musicpd.org/clients/mpc/)    | CLI    | Working commands: mpc, add, crop, current, del (ranges are not yet supported), play, next, prev (behaves like cdprev), pause, toggle, cdprev, seek, clear, playlist, ls, load, volume, repeat, random, single, update (initiates an init-rescan, the path argument is not supported)   |
-| [ympd](http://www.ympd.org/)                  | Web    | Everything except "search" should work |
+| [mpc](http://www.musicpd.org/clients/mpc/)    | CLI    | Working commands: mpc, add, crop, current, del (ranges are not yet supported), play, next, prev (behaves like cdprev), pause, toggle, cdprev, seek, clear, outputs, enable, disable, playlist, ls, load, volume, repeat, random, single, search, find, list, update (initiates an init-rescan, the path argument is not supported)   |
+| [ympd](http://www.ympd.org/)                  | Web    | Everything except "add stream" should work |
 
 
 

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2143,7 +2143,7 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       qp.sort = S_ARTIST;
       type = "Artist: ";
     }
-  if (0 == strcasecmp(argv[1], "albumartist"))
+  else if (0 == strcasecmp(argv[1], "albumartist"))
       {
         qp.type = Q_GROUP_ARTISTS;
         qp.sort = S_ARTIST;


### PR DESCRIPTION
While updating the readme section for mpd clients, i noticed that the following command does not work:

```
mpc list artist
```

The second commit fixes this.