### PR TITLE
Add support for additional mpd commands

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1535,6 +1535,10 @@ db_query_start(struct query_params *qp)
 	ret = db_build_query_browse(qp, "year", "year", &query);
 	break;
 
+      case Q_BROWSE_DISCS:
+	ret = db_build_query_browse(qp, "disc", "disc", &query);
+	break;
+
       case Q_COUNT_ITEMS:
 	ret = db_build_query_count_items(qp, &query);
 	break;

--- a/src/db.c
+++ b/src/db.c
@@ -1539,6 +1539,10 @@ db_query_start(struct query_params *qp)
 	ret = db_build_query_browse(qp, "disc", "disc", &query);
 	break;
 
+      case Q_BROWSE_TRACKS:
+	ret = db_build_query_browse(qp, "track", "track", &query);
+	break;
+
       case Q_COUNT_ITEMS:
 	ret = db_build_query_count_items(qp, &query);
 	break;

--- a/src/db.h
+++ b/src/db.h
@@ -42,6 +42,7 @@ enum query_type {
   Q_BROWSE_YEARS     = Q_F_BROWSE | (1 << 11),
   Q_COUNT_ITEMS      = (1 << 12),
   Q_BROWSE_DISCS     = Q_F_BROWSE | (1 << 13),
+  Q_BROWSE_TRACKS     = Q_F_BROWSE | (1 << 14),
 };
 
 #define ARTWORK_UNKNOWN   0

--- a/src/db.h
+++ b/src/db.h
@@ -41,6 +41,7 @@ enum query_type {
   Q_GROUP_DIRS       = Q_F_BROWSE | (1 << 10),
   Q_BROWSE_YEARS     = Q_F_BROWSE | (1 << 11),
   Q_COUNT_ITEMS      = (1 << 12),
+  Q_BROWSE_DISCS     = Q_F_BROWSE | (1 << 13),
 };
 
 #define ARTWORK_UNKNOWN   0

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -397,11 +397,13 @@ mpd_add_mediainfo(struct evbuffer *evbuf, struct media_file_info *mfi, int pos_p
       ret = evbuffer_add_printf(evbuf,
 	"Pos: %d\n",
 	pos_pl);
+
+      //TODO mpd does not return the persistent id of a file but instead a unique id in the current playlist
+      ret = evbuffer_add_printf(evbuf,
+	"Id: %d\n",
+	mfi->id);
     }
 
-  ret = evbuffer_add_printf(evbuf,
-    "Id: %d\n",
-    mfi->id);
 
   return ret;
 }
@@ -454,7 +456,6 @@ mpd_add_mediainfo_byid(struct evbuffer *evbuf, int id, int pos_pl)
  *   MUSICBRAINZ_ARTISTID: c5c2ea1c-4bde-4f4d-bd0b-47b200bf99d6
  *   MUSICBRAINZ_ALBUMID: 812f4b87-8ad9-41bd-be79-38151f17a2b4
  *   MUSICBRAINZ_TRACKID: fde95c39-ee51-48f6-a7f9-b5631c2ed156
- *   Id: 1
  *
  * @param evbuf the response event buffer
  * @param mfi media information
@@ -495,8 +496,7 @@ mpd_add_db_media_file_info(struct evbuffer *evbuf, struct db_media_file_info *db
       "Track: %s\n"
       "Date: %s\n"
       "Genre: %s\n"
-      "Disc: %s\n"
-      "Id: %s\n",
+      "Disc: %s\n",
       (dbmfi->virtual_path + 1),
       modified,
       (songlength / 1000),
@@ -509,8 +509,7 @@ mpd_add_db_media_file_info(struct evbuffer *evbuf, struct db_media_file_info *db
       dbmfi->track,
       dbmfi->year,
       dbmfi->genre,
-      dbmfi->disc,
-      dbmfi->id);
+      dbmfi->disc);
 
   return ret;
 }

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2499,6 +2499,50 @@ mpd_command_search(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
   return 0;
 }
 
+static int
+mpd_command_searchadd(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
+{
+  struct query_params qp;
+  struct player_source *ps;
+  int ret;
+
+  if (argc < 3 || ((argc - 1) % 2) != 0)
+    {
+      ret = asprintf(errmsg, "Missing argument(s) for command 'search'");
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_ARG;
+    }
+
+  memset(&qp, 0, sizeof(struct query_params));
+
+  qp.type = Q_ITEMS;
+  qp.sort = S_NAME;
+  qp.idx_type = I_NONE;
+
+  mpd_get_query_params_search(argc - 1, argv + 1, &qp);
+
+  ps = player_queue_make(&qp);
+
+  if (!ps)
+    {
+      ret = asprintf(errmsg, "Failed to add songs to playlist");
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_UNKNOWN;
+    }
+
+  player_queue_add(ps);
+
+  ret = player_playback_start(NULL);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_MPD, "Could not start playback\n");
+    }
+
+  return 0;
+}
+
 /*
  * Command handler function for 'update'
  * Initiates an init-rescan (scans for new files)
@@ -3261,11 +3305,11 @@ static struct command mpd_handlers[] =
       .mpdcommand = "search",
       .handler = mpd_command_search
     },
-    /*
     {
       .mpdcommand = "searchadd",
       .handler = mpd_command_searchadd
     },
+    /*
     {
       .mpdcommand = "searchaddpl",
       .handler = mpd_command_searchaddpl

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3492,30 +3492,26 @@ static struct command mpd_handlers[] =
     /*
      * Client to client
      */
-    /*
     {
       .mpdcommand = "subscribe",
-      .handler = mpd_command_subscribe
+      .handler = mpd_command_ignore
     },
     {
       .mpdcommand = "unsubscribe",
-      .handler = mpd_command_unsubscribe
+      .handler = mpd_command_ignore
     },
-     */
     {
       .mpdcommand = "channels",
       .handler = mpd_command_ignore
     },
-    /*
     {
       .mpdcommand = "readmessages",
-      .handler = mpd_command_readmessages
+      .handler = mpd_command_ignore
     },
     {
       .mpdcommand = "sendmessage",
-      .handler = mpd_command_sendmessage
+      .handler = mpd_command_ignore
     },
-     */
 
     /*
      * NULL command to terminate loop

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3504,10 +3504,12 @@ static struct command mpd_handlers[] =
       .mpdcommand = "unsubscribe",
       .handler = mpd_command_unsubscribe
     },
+     */
     {
       .mpdcommand = "channels",
-      .handler = mpd_command_channels
+      .handler = mpd_command_ignore
     },
+    /*
     {
       .mpdcommand = "readmessages",
       .handler = mpd_command_readmessages

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2867,6 +2867,28 @@ mpd_command_ignore(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 static int
 mpd_command_commands(struct evbuffer *evbuf, int argc, char **argv, char **errmsg);
 
+/*
+ * Command handler function for 'tagtypes'
+ * Returns a lists with supported tags in the form:
+ *   tagtype: Artist
+ */
+static int
+mpd_command_tagtypes(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
+{
+  evbuffer_add_printf(evbuf,
+      "tagtype: Artist\n"
+      "tagtype: AlbumArtist\n"
+      "tagtype: ArtistSort\n"
+      "tagtype: AlbumArtistSort\n"
+      "tagtype: Album\n"
+      "tagtype: Title\n"
+      "tagtype: Track\n"
+      "tagtype: Genre\n"
+      "tagtype: Disc\n");
+
+  return 0;
+}
+
 
 struct command
 {
@@ -3313,12 +3335,10 @@ static struct command mpd_handlers[] =
       .mpdcommand = "notcommands",
       .handler = mpd_command_ignore
     },
-    /*
     {
       .mpdcommand = "tagtypes",
       .handler = mpd_command_tagtypes
     },
-     */
     {
       .mpdcommand = "urlhandlers",
       .handler = mpd_command_ignore

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1991,6 +1991,14 @@ mpd_get_query_params_find(int argc, char **argv, struct query_params *qp)
 	  else
 	    c1 = sqlite3_mprintf("(f.disc = %d)", num);
 	}
+      else if (0 == strcasecmp(argv[i], "track"))
+	{
+	  ret = safe_atou32(argv[i + 1], &num);
+	  if (ret < 0)
+	    DPRINTF(E_WARN, L_MPD, "Track parameter '%s' is not an integer and will be ignored\n", argv[i + 1]);
+	  else
+	    c1 = sqlite3_mprintf("(f.track = %d)", num);
+	}
       else if (i == 0 && argc == 1)
 	{
 	  // Special case: a single token is allowed if listing albums for an artist
@@ -2226,6 +2234,12 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       qp.sort = S_NONE;
       type = "Disc: ";
     }
+  else if (0 == strcasecmp(argv[1], "track"))
+    {
+      qp.type = Q_BROWSE_TRACKS;
+      qp.sort = S_NONE;
+      type = "Track: ";
+    }
   else
     {
       DPRINTF(E_WARN, L_MPD, "Unsupported type argument for command 'list': %s\n", argv[1]);
@@ -2449,6 +2463,14 @@ mpd_get_query_params_search(int argc, char **argv, struct query_params *qp)
 	    DPRINTF(E_WARN, L_MPD, "Disc parameter '%s' is not an integer and will be ignored\n", argv[i + 1]);
 	  else
 	    c1 = sqlite3_mprintf("(f.disc = %d)", num);
+	}
+      else if (0 == strcasecmp(argv[i], "track"))
+	{
+	  ret = safe_atou32(argv[i + 1], &num);
+	  if (ret < 0)
+	    DPRINTF(E_WARN, L_MPD, "Track parameter '%s' is not an integer and will be ignored\n", argv[i + 1]);
+	  else
+	    c1 = sqlite3_mprintf("(f.track = %d)", num);
 	}
       else
 	{

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1925,6 +1925,7 @@ mpd_get_query_params_find(int argc, char **argv, struct query_params *qp)
   int start_pos;
   int end_pos;
   int i;
+  uint32_t num;
   int ret;
 
   c1 = NULL;
@@ -1981,6 +1982,14 @@ mpd_get_query_params_find(int argc, char **argv, struct query_params *qp)
       else if (0 == strcasecmp(argv[i], "genre"))
 	{
 	  c1 = sqlite3_mprintf("(f.genre = '%q')", argv[i + 1]);
+	}
+      else if (0 == strcasecmp(argv[i], "disc"))
+	{
+	  ret = safe_atou32(argv[i + 1], &num);
+	  if (ret < 0)
+	    DPRINTF(E_WARN, L_MPD, "Disc parameter '%s' is not an integer and will be ignored\n", argv[i + 1]);
+	  else
+	    c1 = sqlite3_mprintf("(f.disc = %d)", num);
 	}
       else if (i == 0 && argc == 1)
 	{
@@ -2211,6 +2220,12 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       qp.sort = S_NONE;
       type = "Genre: ";
     }
+  else if (0 == strcasecmp(argv[1], "disc"))
+    {
+      qp.type = Q_BROWSE_DISCS;
+      qp.sort = S_NONE;
+      type = "Disc: ";
+    }
   else
     {
       DPRINTF(E_WARN, L_MPD, "Unsupported type argument for command 'list': %s\n", argv[1]);
@@ -2369,6 +2384,7 @@ mpd_get_query_params_search(int argc, char **argv, struct query_params *qp)
   int start_pos;
   int end_pos;
   int i;
+  uint32_t num;
   int ret;
 
   c1 = NULL;
@@ -2425,6 +2441,14 @@ mpd_get_query_params_search(int argc, char **argv, struct query_params *qp)
       else if (0 == strcasecmp(argv[i], "genre"))
 	{
 	  c1 = sqlite3_mprintf("(f.genre LIKE '%%%q%%')", argv[i + 1]);
+	}
+      else if (0 == strcasecmp(argv[i], "disc"))
+	{
+	  ret = safe_atou32(argv[i + 1], &num);
+	  if (ret < 0)
+	    DPRINTF(E_WARN, L_MPD, "Disc parameter '%s' is not an integer and will be ignored\n", argv[i + 1]);
+	  else
+	    c1 = sqlite3_mprintf("(f.disc = %d)", num);
 	}
       else
 	{

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3318,10 +3318,12 @@ static struct command mpd_handlers[] =
       .mpdcommand = "tagtypes",
       .handler = mpd_command_tagtypes
     },
+     */
     {
       .mpdcommand = "urlhandlers",
-      .handler = mpd_command_urlhandlers
+      .handler = mpd_command_ignore
     },
+    /*
     {
       .mpdcommand = "decoders",
       .handler = mpd_command_decoders

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3309,11 +3309,11 @@ static struct command mpd_handlers[] =
       .mpdcommand = "commands",
       .handler = mpd_command_commands
     },
-    /*
     {
       .mpdcommand = "notcommands",
-      .handler = mpd_command_notcommands
+      .handler = mpd_command_ignore
     },
+    /*
     {
       .mpdcommand = "tagtypes",
       .handler = mpd_command_tagtypes

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1760,7 +1760,7 @@ mpd_command_listplaylistinfo(struct evbuffer *evbuf, int argc, char **argv, char
       ret = asprintf(errmsg, "Playlist not found for path '%s'", argv[1]);
       if (ret < 0)
 	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
-      return ACK_ERROR_ARG;
+      return ACK_ERROR_NO_EXIST;
     }
 
   memset(&qp, 0, sizeof(struct query_params));

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1978,6 +1978,10 @@ mpd_get_query_params_find(int argc, char **argv, struct query_params *qp)
 	{
 	  c1 = sqlite3_mprintf("(f.title = '%q')", argv[i + 1]);
 	}
+      else if (0 == strcasecmp(argv[i], "genre"))
+	{
+	  c1 = sqlite3_mprintf("(f.genre = '%q')", argv[i + 1]);
+	}
       else if (i == 0 && argc == 1)
 	{
 	  // Special case: a single token is allowed if listing albums for an artist
@@ -2201,6 +2205,12 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       qp.sort = S_YEAR;
       type = "Date: ";
     }
+  else if (0 == strcasecmp(argv[1], "genre"))
+    {
+      qp.type = Q_BROWSE_GENRES;
+      qp.sort = S_NONE;
+      type = "Genre: ";
+    }
   else
     {
       DPRINTF(E_WARN, L_MPD, "Unsupported type argument for command 'list': %s\n", argv[1]);
@@ -2225,7 +2235,7 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       return ACK_ERROR_UNKNOWN;
     }
 
-  if (qp.type == Q_BROWSE_YEARS)
+  if (qp.type & Q_F_BROWSE)
     {
       while (((ret = db_query_fetch_string_sort(&qp, &browse_item, &sort_item)) == 0) && (browse_item))
 	{
@@ -2411,6 +2421,10 @@ mpd_get_query_params_search(int argc, char **argv, struct query_params *qp)
       else if (0 == strcasecmp(argv[i], "title"))
 	{
 	  c1 = sqlite3_mprintf("(f.title LIKE '%%%q%%')", argv[i + 1]);
+	}
+      else if (0 == strcasecmp(argv[i], "genre"))
+	{
+	  c1 = sqlite3_mprintf("(f.genre LIKE '%%%q%%')", argv[i + 1]);
 	}
       else
 	{

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3892,7 +3892,7 @@ int mpd_init(void)
     }
   evconnlistener_set_error_cb(listener, mpd_accept_error_cb);
 
-  DPRINTF(E_INFO, L_MPD, "cache thread init\n");
+  DPRINTF(E_INFO, L_MPD, "mpd thread init\n");
 
   ret = pthread_create(&tid_mpd, NULL, mpd, NULL);
   if (ret < 0)

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3411,12 +3411,10 @@ static struct command mpd_handlers[] =
     /*
      * Stickers
      */
-    /*
     {
       .mpdcommand = "sticker",
-      .handler = mpd_command_sticker
+      .handler = mpd_command_ignore
     },
-     */
 
     /*
      * Connection settings

--- a/src/player.c
+++ b/src/player.c
@@ -759,7 +759,7 @@ metadata_check_icy(void)
 
 /* Audio sources */
 /* Thread: httpd (DACP) */
-static struct player_source *
+struct player_source *
 player_queue_make(struct query_params *qp)
 {
   struct db_media_file_info dbmfi;

--- a/src/player.c
+++ b/src/player.c
@@ -760,7 +760,7 @@ metadata_check_icy(void)
 /* Audio sources */
 /* Thread: httpd (DACP) */
 static struct player_source *
-player_queue_make(struct query_params *qp, const char *sort)
+player_queue_make(struct query_params *qp)
 {
   struct db_media_file_info dbmfi;
   struct player_source *q_head;
@@ -769,16 +769,6 @@ player_queue_make(struct query_params *qp, const char *sort)
   uint32_t id;
   uint32_t song_length;
   int ret;
-
-  if (sort)
-    {
-      if (strcmp(sort, "name") == 0)
-	qp->sort = S_NAME;
-      else if (strcmp(sort, "album") == 0)
-	qp->sort = S_ALBUM;
-      else if (strcmp(sort, "artist") == 0)
-	qp->sort = S_ARTIST;
-    }
 
   ret = db_query_start(qp);
   if (ret < 0)
@@ -1039,7 +1029,17 @@ player_queue_make_daap(struct player_source **head, const char *query, const cha
       qp.filter = daap_query_parse_sql(query);
     }
 
-  ps = player_queue_make(&qp, sort);
+  if (sort)
+    {
+      if (strcmp(sort, "name") == 0)
+	qp.sort = S_NAME;
+      else if (strcmp(sort, "album") == 0)
+	qp.sort = S_ALBUM;
+      else if (strcmp(sort, "artist") == 0)
+	qp.sort = S_ARTIST;
+    }
+
+  ps = player_queue_make(&qp);
 
   if (qp.filter)
     free(qp.filter);
@@ -1093,7 +1093,7 @@ player_queue_make_pl(int plid, uint32_t *id)
 
   qp.idx_type = I_NONE;
 
-  ps = player_queue_make(&qp, NULL);
+  ps = player_queue_make(&qp);
 
   if (qp.filter)
     free(qp.filter);
@@ -1145,7 +1145,7 @@ player_queue_make_mpd(char *path, int recursive)
 	DPRINTF(E_DBG, L_PLAYER, "Out of memory\n");
     }
 
-  ps = player_queue_make(&qp, NULL);
+  ps = player_queue_make(&qp);
 
   sqlite3_free(qp.filter);
   return ps;

--- a/src/player.c
+++ b/src/player.c
@@ -770,8 +770,6 @@ player_queue_make(struct query_params *qp, const char *sort)
   uint32_t song_length;
   int ret;
 
-  qp->idx_type = I_NONE;
-
   if (sort)
     {
       if (strcmp(sort, "name") == 0)
@@ -960,6 +958,7 @@ player_queue_make_daap(struct player_source **head, const char *query, const cha
   qp.offset = 0;
   qp.limit = 0;
   qp.sort = S_NONE;
+  qp.idx_type = I_NONE;
 
   if (quirk)
     {
@@ -1091,6 +1090,8 @@ player_queue_make_pl(int plid, uint32_t *id)
     }
   else
     return NULL;
+
+  qp.idx_type = I_NONE;
 
   ps = player_queue_make(&qp, NULL);
 

--- a/src/player.h
+++ b/src/player.h
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 
+#include "db.h"
+
 /* AirTunes v2 packet interval in ns */
 /* (352 samples/packet * 1e9 ns/s) / 44100 samples/s = 7981859 ns/packet */
 # define AIRTUNES_V2_STREAM_PERIOD 7981859
@@ -181,6 +183,9 @@ player_repeat_set(enum repeat_mode mode);
 
 int
 player_shuffle_set(int enable);
+
+struct player_source *
+player_queue_make(struct query_params *qp);
 
 int
 player_queue_make_daap(struct player_source **head, const char *query, const char *queuefilter, const char *sort, int quirk);


### PR DESCRIPTION
These commits add support for additional mpd commands (like findadd or searchadd) and improve support for some commands like find or search. See individual commit messages for details.

The change in player.c exposes the generic player_queue_make function. This allows to keep the logic for building the query in mpd.c instead of moving it to the player (like it is done for player_queue_make_daap, player_queue_make_mpd). I was not sure if it would be good to move these two methods out of the player and into the daap/mpd files, so i kept them where they are.

@ejurgensen it would be great, if you could take a look at the changes