### PR TITLE
Add support for mpd idle command

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,7 +119,8 @@ forked_daapd_SOURCES = main.c \
 	scan-wma.c \
 	$(SPOTIFY_SRC) $(LASTFM_SRC) \
 	$(MPD_SRC) \
-	$(FLAC_SRC) $(MUSEPACK_SRC)
+	$(FLAC_SRC) $(MUSEPACK_SRC) \
+	listener.c listener.h
 
 nodist_forked_daapd_SOURCES = \
 	$(ANTLR_SOURCES)

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -2428,7 +2428,7 @@ dacp_init(void)
   event_base_set(evbase_httpd, &updateev);
   event_add(&updateev, NULL);
 
-  listener_add(dacp_playstatus_update_handler);
+  listener_add(dacp_playstatus_update_handler, LISTENER_PLAYER);
 
   return 0;
 

--- a/src/listener.c
+++ b/src/listener.c
@@ -21,7 +21,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#include "logger.h"
 #include "listener.h"
 
 struct listener
@@ -39,6 +38,10 @@ listener_add(notify notify_cb, short events)
   struct listener *listener;
 
   listener = (struct listener*)malloc(sizeof(struct listener));
+  if (!listener)
+    {
+      return -1;
+    }
   listener->notify_cb = notify_cb;
   listener->events = events;
   listener->next = listener_list;
@@ -63,7 +66,9 @@ listener_remove(notify notify_cb)
     }
 
   if (!listener)
-    return 0;
+    {
+      return -1;
+    }
 
   if (prev)
     prev->next = listener->next;
@@ -74,12 +79,10 @@ listener_remove(notify notify_cb)
   return 0;
 }
 
-int
+void
 listener_notify(enum listener_event_type type)
 {
   struct listener *listener;
-
-  DPRINTF(E_DBG, L_MPD, "Notify event type %d\n", type);
 
   listener = listener_list;
   while (listener)
@@ -88,6 +91,4 @@ listener_notify(enum listener_event_type type)
 	listener->notify_cb(type);
       listener = listener->next;
     }
-
-  return 0;
 }

--- a/src/listener.c
+++ b/src/listener.c
@@ -27,18 +27,20 @@
 struct listener
 {
   notify notify_cb;
+  short events;
   struct listener *next;
 };
 
 struct listener *listener_list = NULL;
 
 int
-listener_add(notify notify_cb)
+listener_add(notify notify_cb, short events)
 {
   struct listener *listener;
 
   listener = (struct listener*)malloc(sizeof(struct listener));
   listener->notify_cb = notify_cb;
+  listener->events = events;
   listener->next = listener_list;
   listener_list = listener;
 
@@ -82,7 +84,8 @@ listener_notify(enum listener_event_type type)
   listener = listener_list;
   while (listener)
     {
-      listener->notify_cb(type);
+      if (type & listener->events)
+	listener->notify_cb(type);
       listener = listener->next;
     }
 

--- a/src/listener.c
+++ b/src/listener.c
@@ -51,27 +51,25 @@ listener_remove(notify notify_cb)
   struct listener *listener;
   struct listener *prev;
 
-  listener = listener_list;
   prev = NULL;
-
-  while (listener)
+  for (listener = listener_list; listener; listener = listener->next)
     {
       if (listener->notify_cb == notify_cb)
-	{
-	  if (prev)
-	    prev->next = listener->next;
-	  else
-	    listener_list = NULL;
-
-	  free(listener);
-	  return 0;
-	}
+	break;
 
       prev = listener;
-      listener = listener->next;
     }
 
-  return -1;
+  if (!listener)
+    return 0;
+
+  if (prev)
+    prev->next = listener->next;
+  else
+    listener_list = NULL;
+
+  free(listener);
+  return 0;
 }
 
 int

--- a/src/listener.c
+++ b/src/listener.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 Christian Meffert <christian.meffert@googlemail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "logger.h"
+#include "listener.h"
+
+struct listener
+{
+  notify notify_cb;
+  struct listener *next;
+};
+
+struct listener *listener_list = NULL;
+
+int
+listener_add(notify notify_cb)
+{
+  struct listener *listener;
+
+  listener = (struct listener*)malloc(sizeof(struct listener));
+  listener->notify_cb = notify_cb;
+  listener->next = listener_list;
+  listener_list = listener;
+
+  return 0;
+}
+
+int
+listener_notify(enum listener_event_type type)
+{
+  struct listener *listener;
+
+  DPRINTF(E_DBG, L_MPD, "Notify event type %d\n", type);
+
+  listener = listener_list;
+  while (listener)
+    {
+      listener->notify_cb(type);
+      listener = listener->next;
+    }
+
+  return 0;
+}

--- a/src/listener.c
+++ b/src/listener.c
@@ -46,6 +46,35 @@ listener_add(notify notify_cb)
 }
 
 int
+listener_remove(notify notify_cb)
+{
+  struct listener *listener;
+  struct listener *prev;
+
+  listener = listener_list;
+  prev = NULL;
+
+  while (listener)
+    {
+      if (listener->notify_cb == notify_cb)
+	{
+	  if (prev)
+	    prev->next = listener->next;
+	  else
+	    listener_list = NULL;
+
+	  free(listener);
+	  return 0;
+	}
+
+      prev = listener;
+      listener = listener->next;
+    }
+
+  return -1;
+}
+
+int
 listener_notify(enum listener_event_type type)
 {
   struct listener *listener;

--- a/src/listener.h
+++ b/src/listener.h
@@ -15,6 +15,9 @@ int
 listener_add(notify notify_cb);
 
 int
+listener_remove(notify notify_cb);
+
+int
 listener_notify(enum listener_event_type type);
 
 #endif /* !__LISTENER_H__ */

--- a/src/listener.h
+++ b/src/listener.h
@@ -4,23 +4,51 @@
 
 enum listener_event_type
 {
+  /* The player has been started, stopped or seeked */
   LISTENER_PLAYER    = (1 << 0),
+  /* The current playlist has been modified */
   LISTENER_PLAYLIST  = (1 << 1),
+  /* The volume has been changed */
   LISTENER_VOLUME    = (1 << 2),
+  /* A speaker has been enabled or disabled */
   LISTENER_SPEAKER   = (1 << 3),
+  /* Options like repeat, random has been changed */
   LISTENER_OPTIONS   = (1 << 4),
+  /* The library has been modified */
   LISTENER_DATABASE  = (1 << 5),
 };
 
 typedef void (*notify)(enum listener_event_type type);
 
+/*
+ * Registers the given callback function to the given event types.
+ * This function is not thread safe. Listeners must be added once at startup.
+ *
+ * @param notify_cb Callback function
+ * @param events Event mask, one or more of LISTENER_*
+ * @return 0 on success, -1 on failure
+ */
 int
 listener_add(notify notify_cb, short events);
 
+/*
+ * Removes the given callback function
+ * This function is not thread safe. Listeners must be removed once at shutdown.
+ *
+ * @param notify_cb Callback function
+ * @return 0 on success, -1 if the callback was not registered
+ */
 int
 listener_remove(notify notify_cb);
 
-int
+/*
+ * Calls the callback function of the registered listeners listening for the
+ * given type of event.
+ *
+ * @param type The event type, on of the LISTENER_* values
+ *
+ */
+void
 listener_notify(enum listener_event_type type);
 
 #endif /* !__LISTENER_H__ */

--- a/src/listener.h
+++ b/src/listener.h
@@ -5,8 +5,12 @@
 enum listener_event_type
 {
   LISTENER_NONE = 0,
-  LISTENER_DATABASE = 1,
-  LISTENER_PLAYER = 2,
+  LISTENER_DATABASE,
+  LISTENER_PLAYER,
+  LISTENER_PLAYLIST,
+  LISTENER_VOLUME,
+  LISTENER_SPEAKER,
+  LISTENER_OPTIONS,
 };
 
 typedef void (*notify)(enum listener_event_type type);

--- a/src/listener.h
+++ b/src/listener.h
@@ -1,0 +1,20 @@
+
+#ifndef __LISTENER_H__
+#define __LISTENER_H__
+
+enum listener_event_type
+{
+  LISTENER_NONE = 0,
+  LISTENER_DATABASE = 1,
+  LISTENER_PLAYER = 2,
+};
+
+typedef void (*notify)(enum listener_event_type type);
+
+int
+listener_add(notify notify_cb);
+
+int
+listener_notify(enum listener_event_type type);
+
+#endif /* !__LISTENER_H__ */

--- a/src/listener.h
+++ b/src/listener.h
@@ -4,19 +4,18 @@
 
 enum listener_event_type
 {
-  LISTENER_NONE = 0,
-  LISTENER_DATABASE,
-  LISTENER_PLAYER,
-  LISTENER_PLAYLIST,
-  LISTENER_VOLUME,
-  LISTENER_SPEAKER,
-  LISTENER_OPTIONS,
+  LISTENER_PLAYER    = (1 << 0),
+  LISTENER_PLAYLIST  = (1 << 1),
+  LISTENER_VOLUME    = (1 << 2),
+  LISTENER_SPEAKER   = (1 << 3),
+  LISTENER_OPTIONS   = (1 << 4),
+  LISTENER_DATABASE  = (1 << 5),
 };
 
 typedef void (*notify)(enum listener_event_type type);
 
 int
-listener_add(notify notify_cb);
+listener_add(notify notify_cb, short events);
 
 int
 listener_remove(notify notify_cb);

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -657,13 +657,29 @@ mpd_command_idle(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 
       for (i = 1; i < argc; i++)
 	{
-	  if (0 == strcmp(argv[i], "player"))
+	  if (0 == strcmp(argv[i], "database"))
+	    {
+	      client->types[i - 1] = LISTENER_DATABASE;
+	    }
+	  else if (0 == strcmp(argv[i], "player"))
 	    {
 	      client->types[i - 1] = LISTENER_PLAYER;
 	    }
-	  else if (0 == strcmp(argv[i], "database"))
+	  else if (0 == strcmp(argv[i], "playlist"))
 	    {
-	      client->types[i - 1] = LISTENER_DATABASE;
+	      client->types[i - 1] = LISTENER_PLAYLIST;
+	    }
+	  else if (0 == strcmp(argv[i], "mixer"))
+	    {
+	      client->types[i - 1] = LISTENER_VOLUME;
+	    }
+	  else if (0 == strcmp(argv[i], "output"))
+	    {
+	      client->types[i - 1] = LISTENER_SPEAKER;
+	    }
+	  else if (0 == strcmp(argv[i], "options"))
+	    {
+	      client->types[i - 1] = LISTENER_OPTIONS;
 	    }
 	  else
 	    {
@@ -3829,7 +3845,33 @@ mpd_notify_idle_client(struct idle_client *client, enum listener_event_type type
       return 1;
     }
 
-  evbuffer_add(client->evbuffer, "changed: player\n", 16);
+  switch (type)
+    {
+      case LISTENER_PLAYER:
+	evbuffer_add(client->evbuffer, "changed: player\n", 16);
+	break;
+
+      case LISTENER_PLAYLIST:
+	evbuffer_add(client->evbuffer, "changed: playlist\n", 18);
+	break;
+
+      case LISTENER_VOLUME:
+	evbuffer_add(client->evbuffer, "changed: mixer\n", 15);
+	break;
+
+      case LISTENER_SPEAKER:
+	evbuffer_add(client->evbuffer, "changed: output\n", 16);
+	break;
+
+      case LISTENER_OPTIONS:
+	evbuffer_add(client->evbuffer, "changed: options\n", 17);
+	break;
+
+      default:
+	DPRINTF(E_WARN, L_MPD, "Unsupported event type (%d) in notify idle clients.\n", type);
+	return -1;
+    }
+
   evbuffer_add(client->evbuffer, "OK\n", 3);
 
   return 0;

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -790,7 +790,7 @@ mpd_command_status(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       status.shuffle,
       (status.repeat == REPEAT_SONG ? 1 : 0),
       0 /* consume: not supported by forked-daapd, always return 'off' */,
-      status.plid,
+      status.plversion,
       status.playlistlength,
       state);
 
@@ -1815,6 +1815,7 @@ mpd_command_playlistinfo(struct evbuffer *evbuf, int argc, char **argv, char **e
 static int
 mpd_command_plchanges(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 {
+  DPRINTF(E_WARN, L_MPD, "Ignore command %s\n", argv[0]);
   return 0;
 }
 

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -34,14 +34,10 @@
 #include <stdint.h>
 #include <inttypes.h>
 
-#ifdef HAVE_LIBEVENT2
 # include <event2/event.h>
 # include <event2/buffer.h>
 # include <event2/bufferevent.h>
 # include <event2/listener.h>
-#else
-# include <event.h>
-#endif
 
 #if defined(HAVE_SYS_EVENTFD_H) && defined(HAVE_EVENTFD)
 # define USE_EVENTFD

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -34,6 +34,15 @@
 #include <stdint.h>
 #include <inttypes.h>
 
+#ifdef HAVE_LIBEVENT2
+# include <event2/event.h>
+# include <event2/buffer.h>
+# include <event2/bufferevent.h>
+# include <event2/listener.h>
+#else
+# include <event.h>
+#endif
+
 #if defined(HAVE_SYS_EVENTFD_H) && defined(HAVE_EVENTFD)
 # define USE_EVENTFD
 # include <sys/eventfd.h>
@@ -48,7 +57,6 @@
 #include "conffile.h"
 #include "misc.h"
 #include "listener.h"
-#include "mpd.h"
 
 #include "player.h"
 #include "filescanner.h"

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4098,6 +4098,8 @@ void mpd_deinit(void)
       return;
     }
 
+  listener_remove(mpd_listener_cb);
+
   while (idle_clients)
     {
       temp = idle_clients;

--- a/src/mpd.h
+++ b/src/mpd.h
@@ -2,14 +2,6 @@
 #ifndef __MPD_H__
 #define __MPD_H__
 
-#ifdef HAVE_LIBEVENT2
-# include <event2/event.h>
-# include <event2/buffer.h>
-# include <event2/bufferevent.h>
-# include <event2/listener.h>
-#else
-# include <event.h>
-#endif
 
 int
 mpd_init(void);

--- a/src/player.c
+++ b/src/player.c
@@ -3514,6 +3514,8 @@ speaker_set(struct player_command *cmd)
 	}
     }
 
+  listener_notify(LISTENER_SPEAKER);
+
   if (cmd->raop_pending > 0)
     return 1; /* async */
 
@@ -3559,6 +3561,8 @@ volume_set(struct player_command *cmd)
       if (rd->session)
 	cmd->raop_pending += raop_set_volume_one(rd->session, rd->volume, device_command_cb);
     }
+
+  listener_notify(LISTENER_VOLUME);
 
   if (cmd->raop_pending > 0)
     return 1; /* async */
@@ -3609,6 +3613,8 @@ volume_setrel_speaker(struct player_command *cmd)
 	  break;
         }
     }
+
+  listener_notify(LISTENER_VOLUME);
 
   if (cmd->raop_pending > 0)
     return 1; /* async */
@@ -3669,6 +3675,8 @@ volume_setabs_speaker(struct player_command *cmd)
 	}
     }
 
+  listener_notify(LISTENER_VOLUME);
+
   if (cmd->raop_pending > 0)
     return 1; /* async */
 
@@ -3678,6 +3686,9 @@ volume_setabs_speaker(struct player_command *cmd)
 static int
 repeat_set(struct player_command *cmd)
 {
+  if (cmd->arg.mode == repeat)
+    return 0;
+
   switch (cmd->arg.mode)
     {
       case REPEAT_OFF:
@@ -3690,6 +3701,8 @@ repeat_set(struct player_command *cmd)
 	DPRINTF(E_LOG, L_PLAYER, "Invalid repeat mode: %d\n", cmd->arg.mode);
 	return -1;
     }
+
+  listener_notify(LISTENER_OPTIONS);
 
   return 0;
 }
@@ -3711,6 +3724,8 @@ shuffle_set(struct player_command *cmd)
 	DPRINTF(E_LOG, L_PLAYER, "Invalid shuffle mode: %d\n", cmd->arg.intval);
 	return -1;
     }
+
+  listener_notify(LISTENER_OPTIONS);
 
   return 0;
 }
@@ -3856,6 +3871,8 @@ queue_add(struct player_command *cmd)
   if (cur_plid != 0)
     cur_plid = 0;
 
+  listener_notify(LISTENER_PLAYLIST);
+
   return 0;
 }
 
@@ -3896,6 +3913,8 @@ queue_add_next(struct player_command *cmd)
 
   if (cur_plid != 0)
     cur_plid = 0;
+
+  listener_notify(LISTENER_PLAYLIST);
 
   return 0;
 }
@@ -3964,6 +3983,8 @@ queue_move(struct player_command *cmd)
     ps_dst->pl_next = ps_src;
   }
 
+  listener_notify(LISTENER_PLAYLIST);
+
   return 0;
 }
 
@@ -4029,6 +4050,8 @@ queue_remove(struct player_command *cmd)
 
   source_free(ps);
 
+  listener_notify(LISTENER_PLAYLIST);
+
   return 0;
 }
 
@@ -4054,6 +4077,8 @@ queue_clear(struct player_command *cmd)
     }
 
   cur_plid = 0;
+
+  listener_notify(LISTENER_PLAYLIST);
 
   return 0;
 }
@@ -4103,6 +4128,8 @@ queue_empty(struct player_command *cmd)
       source_head->shuffle_next = source_head;
       source_head->shuffle_prev = source_head;
     }
+
+  listener_notify(LISTENER_PLAYLIST);
 
   return 0;
 }

--- a/src/player.c
+++ b/src/player.c
@@ -256,6 +256,7 @@ static struct player_source *shuffle_head;
 static struct player_source *cur_playing;
 static struct player_source *cur_streaming;
 static uint32_t cur_plid;
+static uint32_t cur_plversion;
 static struct evbuffer *audio_buf;
 
 /* Play history */
@@ -2513,6 +2514,7 @@ get_status(struct player_command *cmd)
   status->volume = master_volume;
 
   status->plid = cur_plid;
+  status->plversion = cur_plversion;
 
   switch (player_state)
     {
@@ -3870,6 +3872,7 @@ queue_add(struct player_command *cmd)
 
   if (cur_plid != 0)
     cur_plid = 0;
+  cur_plversion++;
 
   listener_notify(LISTENER_PLAYLIST);
 
@@ -3913,6 +3916,7 @@ queue_add_next(struct player_command *cmd)
 
   if (cur_plid != 0)
     cur_plid = 0;
+  cur_plversion++;
 
   listener_notify(LISTENER_PLAYLIST);
 
@@ -3983,6 +3987,8 @@ queue_move(struct player_command *cmd)
     ps_dst->pl_next = ps_src;
   }
 
+  cur_plversion++;
+
   listener_notify(LISTENER_PLAYLIST);
 
   return 0;
@@ -4050,6 +4056,8 @@ queue_remove(struct player_command *cmd)
 
   source_free(ps);
 
+  cur_plversion++;
+
   listener_notify(LISTENER_PLAYLIST);
 
   return 0;
@@ -4077,6 +4085,7 @@ queue_clear(struct player_command *cmd)
     }
 
   cur_plid = 0;
+  cur_plversion++;
 
   listener_notify(LISTENER_PLAYLIST);
 
@@ -4128,6 +4137,8 @@ queue_empty(struct player_command *cmd)
       source_head->shuffle_next = source_head;
       source_head->shuffle_prev = source_head;
     }
+
+  cur_plversion++;
 
   listener_notify(LISTENER_PLAYLIST);
 
@@ -5189,6 +5200,7 @@ player_init(void)
   cur_playing = NULL;
   cur_streaming = NULL;
   cur_plid = 0;
+  cur_plversion = 0;
 
   player_state = PLAY_STOPPED;
   repeat = REPEAT_OFF;

--- a/src/player.c
+++ b/src/player.c
@@ -58,6 +58,7 @@
 #include "raop.h"
 #include "laudio.h"
 #include "worker.h"
+#include "listener.h"
 
 #ifdef LASTFM
 # include "lastfm.h"
@@ -301,6 +302,8 @@ status_update(enum play_status status)
 
   if (update_handler)
     update_handler();
+
+  listener_notify(LISTENER_PLAYER);
 
   if (status == PLAY_PLAYING)
     dev_autoselect = 0;

--- a/src/player.c
+++ b/src/player.c
@@ -1644,6 +1644,10 @@ source_count()
   return ret;
 }
 
+/*
+ * Updates cur_playing and notifies remotes and raop devices about
+ * changes.
+ */
 static uint64_t
 source_check(void)
 {
@@ -1667,6 +1671,7 @@ source_check(void)
       return 0;
     }
 
+  /* If cur_playing is NULL, we are still in the first two seconds after starting the stream */
   if (!cur_playing)
     {
       if (pos >= cur_streaming->output_start)
@@ -1680,8 +1685,12 @@ source_check(void)
       return pos;
     }
 
+  /* Check if we are still in the middle of the current playing song */
   if ((cur_playing->end == 0) || (pos < cur_playing->end))
     return pos;
+
+  /* We have reached the end of the current playing song, update cur_playing to the next song in the queue
+     and initialize stream_start and output_start values. */
 
   r_mode = repeat;
   /* Playlist has only one file, treat REPEAT_ALL as REPEAT_SONG */

--- a/src/player.h
+++ b/src/player.h
@@ -71,7 +71,6 @@ struct player_status {
 };
 
 typedef void (*spk_enum_cb)(uint64_t id, const char *name, int relvol, struct spk_flags flags, void *arg);
-typedef void (*player_status_handler)(void);
 
 struct player_source
 {
@@ -223,9 +222,6 @@ player_queue_plid(uint32_t plid);
 
 struct player_history *
 player_history_get(void);
-
-void
-player_set_update_handler(player_status_handler handler);
 
 int
 player_init(void);

--- a/src/player.h
+++ b/src/player.h
@@ -54,6 +54,8 @@ struct player_status {
 
   /* Playlist id */
   uint32_t plid;
+  /* Playlist version */
+  uint32_t plversion;
   /* Playlist length */
   uint32_t playlistlength;
   /* Playing song id*/

--- a/src/player.h
+++ b/src/player.h
@@ -54,7 +54,10 @@ struct player_status {
 
   /* Playlist id */
   uint32_t plid;
-  /* Playlist version */
+  /* Playlist version
+     After startup plversion is 0 and gets incremented after each change of the playlist
+     (e. g. after adding/moving/removing items). It is used by mpd clients to recognize if
+     they need to update the current playlist. */
   uint32_t plversion;
   /* Playlist length */
   uint32_t playlistlength;


### PR DESCRIPTION
These commits add support for the mpd "idle" command. The idle command is used by mpd to notify clients about changes on the server. There are different notifications like database, player, ... (see full list at http://www.musicpd.org/doc/protocol/command_reference.html#status_commands).
This pr only adds the notifications that inform about changes related to player.c (play status, playlist, volume, speaker).

I wanted to avoid a compile dependencies at all these places in player.c (with the ifdef for mpd, as it is a compile time option) and added a listener/event logic. I also changed the update call for daap/dacp remotes to use this listener/event logic instead of setting a callback function.

With this pr and #149 i had some success using clients like gmpc, cantata or MPDroid (modifying the current playlist is not fully working). 