### PR TITLE
Support for mpd command plchanges 

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -287,6 +287,7 @@ static const char *sort_clause[] =
     "ORDER BY f.composer_sort ASC",
     "ORDER BY f.disc ASC",
     "ORDER BY f.track ASC",
+    "ORDER BY f.virtual_path ASC",
   };
 
 static char *db_path;
@@ -1527,6 +1528,10 @@ db_query_start(struct query_params *qp)
 
       case Q_BROWSE_TRACKS:
 	ret = db_build_query_browse(qp, "track", "track", &query);
+	break;
+
+      case Q_BROWSE_VPATH:
+	ret = db_build_query_browse(qp, "virtual_path", "virtual_path", &query);
 	break;
 
       case Q_COUNT_ITEMS:

--- a/src/db.h
+++ b/src/db.h
@@ -27,26 +27,28 @@ enum sort_type {
   S_COMPOSER,
   S_DISC,
   S_TRACK,
+  S_VPATH,
 };
 
 #define Q_F_BROWSE (1 << 15)
 
 enum query_type {
-  Q_ITEMS            = (1 << 0),
-  Q_PL               = (1 << 1),
-  Q_PLITEMS          = (1 << 2),
-  Q_BROWSE_ARTISTS   = Q_F_BROWSE | (1 << 3),
-  Q_BROWSE_ALBUMS    = Q_F_BROWSE | (1 << 4),
-  Q_BROWSE_GENRES    = Q_F_BROWSE | (1 << 5),
-  Q_BROWSE_COMPOSERS = Q_F_BROWSE | (1 << 6),
-  Q_GROUP_ALBUMS     = (1 << 7),
-  Q_GROUP_ARTISTS    = (1 << 8),
-  Q_GROUP_ITEMS      = (1 << 9),
-  Q_GROUP_DIRS       = Q_F_BROWSE | (1 << 10),
-  Q_BROWSE_YEARS     = Q_F_BROWSE | (1 << 11),
-  Q_COUNT_ITEMS      = (1 << 12),
-  Q_BROWSE_DISCS     = Q_F_BROWSE | (1 << 13),
-  Q_BROWSE_TRACKS     = Q_F_BROWSE | (1 << 14),
+  Q_ITEMS            = 1,
+  Q_PL               = 2,
+  Q_PLITEMS          = 3,
+  Q_BROWSE_ARTISTS   = Q_F_BROWSE | 4,
+  Q_BROWSE_ALBUMS    = Q_F_BROWSE | 5,
+  Q_BROWSE_GENRES    = Q_F_BROWSE | 6,
+  Q_BROWSE_COMPOSERS = Q_F_BROWSE | 7,
+  Q_GROUP_ALBUMS     = 8,
+  Q_GROUP_ARTISTS    = 9,
+  Q_GROUP_ITEMS      = 10,
+  Q_GROUP_DIRS       = Q_F_BROWSE | 11,
+  Q_BROWSE_YEARS     = Q_F_BROWSE | 12,
+  Q_COUNT_ITEMS      = 13,
+  Q_BROWSE_DISCS     = Q_F_BROWSE | 14,
+  Q_BROWSE_TRACKS    = Q_F_BROWSE | 15,
+  Q_BROWSE_VPATH     = Q_F_BROWSE | 16,
 };
 
 #define ARTWORK_UNKNOWN   0

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2190,6 +2190,14 @@ mpd_get_query_params_find(int argc, char **argv, struct query_params *qp)
 	  else
 	    c1 = sqlite3_mprintf("(f.track = %d)", num);
 	}
+      else if (0 == strcasecmp(argv[i], "date"))
+	{
+	  ret = safe_atou32(argv[i + 1], &num);
+	  if (ret < 0)
+	    c1 = sqlite3_mprintf("(f.year = 0 OR f.year IS NULL)");
+	  else
+	    c1 = sqlite3_mprintf("(f.year = %d)", num);
+	}
       else if (i == 0 && argc == 1)
 	{
 	  // Special case: a single token is allowed if listing albums for an artist
@@ -2682,6 +2690,14 @@ mpd_get_query_params_search(int argc, char **argv, struct query_params *qp)
 	    DPRINTF(E_WARN, L_MPD, "Track parameter '%s' is not an integer and will be ignored\n", argv[i + 1]);
 	  else
 	    c1 = sqlite3_mprintf("(f.track = %d)", num);
+	}
+      else if (0 == strcasecmp(argv[i], "date"))
+	{
+	  ret = safe_atou32(argv[i + 1], &num);
+	  if (ret < 0)
+	    c1 = sqlite3_mprintf("(f.year = 0 OR f.year IS NULL)");
+	  else
+	    c1 = sqlite3_mprintf("(f.year = %d)", num);
 	}
       else
 	{

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2431,6 +2431,12 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       qp.sort = S_TRACK;
       type = "Track: ";
     }
+  else if (0 == strcasecmp(argv[1], "file"))
+    {
+      qp.type = Q_BROWSE_VPATH;
+      qp.sort = S_VPATH;
+      type = "file: ";
+    }
   else
     {
       DPRINTF(E_WARN, L_MPD, "Unsupported type argument for command 'list': %s\n", argv[1]);
@@ -2457,12 +2463,26 @@ mpd_command_list(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 
   if (qp.type & Q_F_BROWSE)
     {
-      while (((ret = db_query_fetch_string_sort(&qp, &browse_item, &sort_item)) == 0) && (browse_item))
+      if (qp.type == Q_BROWSE_VPATH)
 	{
-	  evbuffer_add_printf(evbuf,
-		"%s%s\n",
-		type,
-		browse_item);
+	  while (((ret = db_query_fetch_string_sort(&qp, &browse_item, &sort_item)) == 0) && (browse_item))
+	    {
+		// Remove the first "/" from the virtual_path
+		evbuffer_add_printf(evbuf,
+		      "%s%s\n",
+		      type,
+		      (browse_item + 1));
+	    }
+	}
+      else
+	{
+	  while (((ret = db_query_fetch_string_sort(&qp, &browse_item, &sort_item)) == 0) && (browse_item))
+	    {
+		evbuffer_add_printf(evbuf,
+		      "%s%s\n",
+		      type,
+		      browse_item);
+	    }
 	}
     }
   else


### PR DESCRIPTION
Some additions to improve the mpd client support:
* Report the whole playqueue in plchanges (instead of ignoring the command), this is needed for clients relying on this command to display the queue (e. g. sonata and hopefully mPad)
* Allow listing the virtual_path in list command (used in sonata during retrieval of albums for an artist)
* Support date argument in find and search commands (avoids duplicate entries in sonata for albums)

@ejurgensen please take a look especially at the change in db.h. I tried to figure out if the enum value could be extended to use 3 bytes instead of 2. What i found searching the web was that an enum has the size of an int. The size of int seems to be platform dependent, so i guess its safer to stay on 2 bytes?