### PR TITLE
Fixed bug that caused icy header metadata to be not correctly encoded

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -465,7 +465,7 @@ unicode_fixup_mfi(struct media_file_info *mfi)
       if (!*field)
 	continue;
 
-      ret = unicode_fixup_string(*field);
+      ret = unicode_fixup_string(*field,"ascii");
       if (ret != *field)
 	{
 	  free(*field);

--- a/src/filescanner.c
+++ b/src/filescanner.c
@@ -588,7 +588,7 @@ fixup_tags(struct media_file_info *mfi)
       /* fname is left untouched by unicode_fixup_mfi() for
        * obvious reasons, so ensure it is proper UTF-8
        */
-      mfi->title = unicode_fixup_string(mfi->fname);
+      mfi->title = unicode_fixup_string(mfi->fname,"ascii");
       if (mfi->title == mfi->fname)
 	mfi->title = strdup(mfi->fname);
     }

--- a/src/misc.c
+++ b/src/misc.c
@@ -486,8 +486,9 @@ m_realpath(const char *pathname)
   return ret;
 }
 
+
 char *
-unicode_fixup_string(char *str)
+unicode_fixup_string(char *str, const char *fromcode)
 {
   uint8_t *ret;
   size_t len;
@@ -510,7 +511,7 @@ unicode_fixup_string(char *str)
       return str;
     }
 
-  ret = u8_conv_from_encoding("ascii", iconveh_question_mark, str, len, NULL, NULL, &len);
+  ret = u8_conv_from_encoding(fromcode, iconveh_question_mark, str, len, NULL, NULL, &len);
   if (!ret)
     {
       DPRINTF(E_LOG, L_MISC, "Could not convert string '%s' to UTF-8: %s\n", str, strerror(errno));

--- a/src/misc.h
+++ b/src/misc.h
@@ -65,7 +65,7 @@ char *
 m_realpath(const char *pathname);
 
 char *
-unicode_fixup_string(char *str);
+unicode_fixup_string(char *str, const char *fromcode);
 
 char *
 trimwhitespace(const char *str);


### PR DESCRIPTION
encoded/converted. Characters above x7F were replaced by '?' character
although the rfc defines a ISO−8859−1 encoding for descriptive
field-content.

According to rfc2616 the field-content is defined as follows:
<the OCTETs making up the field-value and consisting of either *TEXT or
combinations of token, separators, and quoted-string>
The TEXT rule is only used for descriptive field contents and values
that are not intended to be interpreted by the message parser. Words of
*TEXT MAY contain characters from character sets other than ISO- 8859-1
only when encoded according to the rules of RFC 2047.

In the previous implementation the icy metadata was converted based on
fromcode "ascii".

Following incoming icy header field-values should be encoded as
"ISO−8859−1" before adding them to the metadata structure.

- misc.c unicode_fixup_string enhanced by an additional parameter to
define the fromcode
- misc.h unicode_fixup_string prototype updated
- filescanner.c function fixup_tags updated to stay compatible to the
previous implementation using fromcode "ascii"
- db.c function unicode_fixup_mfi updated to stay compatible to the
previous implementation using fromcode "ascii"
- http.c function metadata_header_get enhanced to encode the header
field-content as "ISO−8859−1" to comply with rfc2616