### PR TITLE
Remove file extension for playlists from virtual_path

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -4639,10 +4639,10 @@ db_perthread_deinit(void)
   " VALUES(8, 'Purchased', 0, 'media_kind = 1024', 0, '', 0, 8);"
  */
 
-#define SCHEMA_VERSION_MAJOR 18
+#define SCHEMA_VERSION_MAJOR 19
 #define SCHEMA_VERSION_MINOR 00
 #define Q_SCVER_MAJOR					\
-  "INSERT INTO admin (key, value) VALUES ('schema_version_major', '18');"
+  "INSERT INTO admin (key, value) VALUES ('schema_version_major', '19');"
 #define Q_SCVER_MINOR					\
   "INSERT INTO admin (key, value) VALUES ('schema_version_minor', '00');"
 
@@ -5900,6 +5900,32 @@ static const struct db_init_query db_upgrade_v18_queries[] =
     { U_V18_SCVER_MINOR,    "set schema_version_minor to 00" },
   };
 
+/* Upgrade from schema v18.00 to v19.00 */
+/* Change virtual_path for playlists: remove file extension
+ */
+
+#define U_V19_UPDATE_PLAYLISTS_M3U						\
+  "UPDATE playlists SET virtual_path = replace(virtual_path, '.m3u', '');"
+#define U_V19_UPDATE_PLAYLISTS_PLS						\
+  "UPDATE playlists SET virtual_path = replace(virtual_path, '.pls', '');"
+#define U_V19_UPDATE_PLAYLISTS_SMARTPL						\
+    "UPDATE playlists SET virtual_path = replace(virtual_path, '.smartpl', '');"
+
+#define U_V19_SCVER_MAJOR			\
+  "UPDATE admin SET value = '19' WHERE key = 'schema_version_major';"
+#define U_V19_SCVER_MINOR			\
+  "UPDATE admin SET value = '00' WHERE key = 'schema_version_minor';"
+
+static const struct db_init_query db_upgrade_v19_queries[] =
+  {
+    { U_V19_UPDATE_PLAYLISTS_M3U, "update table playlists" },
+    { U_V19_UPDATE_PLAYLISTS_PLS, "update table playlists" },
+    { U_V19_UPDATE_PLAYLISTS_SMARTPL, "update table playlists" },
+
+    { U_V19_SCVER_MAJOR,    "set schema_version_major to 19" },
+    { U_V19_SCVER_MINOR,    "set schema_version_minor to 00" },
+  };
+
 static int
 db_upgrade(int db_ver)
 {
@@ -5989,6 +6015,13 @@ db_upgrade(int db_ver)
 
     case 1700:
       ret = db_generic_upgrade(db_upgrade_v18_queries, sizeof(db_upgrade_v18_queries) / sizeof(db_upgrade_v18_queries[0]));
+      if (ret < 0)
+	return -1;
+
+      /* FALLTHROUGH */
+
+    case 1800:
+      ret = db_generic_upgrade(db_upgrade_v19_queries, sizeof(db_upgrade_v19_queries) / sizeof(db_upgrade_v19_queries[0]));
       if (ret < 0)
 	return -1;
 

--- a/src/filescanner_playlist.c
+++ b/src/filescanner_playlist.c
@@ -167,6 +167,9 @@ scan_playlist(char *file, time_t mtime)
 
       pli->path = strdup(file);
       snprintf(virtual_path, PATH_MAX, "/file:%s", file);
+      ptr = strrchr(virtual_path, '.');
+      if (ptr)
+	*ptr = '\0';
       pli->virtual_path = strdup(virtual_path);
 
       ret = db_pl_add(pli, &pl_id);

--- a/src/filescanner_smartpl.c
+++ b/src/filescanner_smartpl.c
@@ -165,6 +165,7 @@ scan_smartpl(char *file, time_t mtime)
   struct playlist_info *pli;
   int pl_id;
   char virtual_path[PATH_MAX];
+  char *ptr;
   int ret;
 
   /* Fetch or create playlist */
@@ -182,6 +183,9 @@ scan_smartpl(char *file, time_t mtime)
 
       pli->path = strdup(file);
       snprintf(virtual_path, PATH_MAX, "/file:%s", file);
+      ptr = strrchr(virtual_path, '.');
+      if (ptr)
+	*ptr = '\0';
       pli->virtual_path = strdup(virtual_path);
       pli->type = PL_SMART;
     }


### PR DESCRIPTION
MPD lists stored playlists without the file extension. Including the file extension (like forked-daapd currently does) leads to problems in MPDroid. The playlists are not listed correctly in the app and they cannot be added to the queue.

This pr changes the creation of the virtual path for playlists and updates the virtual path for already stored playlists in the library.

I updated the db version to v19. Would it be better to use v18.01 as the upgrade does not change the db structure?