### PR TITLE
http_icy_metadata_get function enhanced. Icy metadata ISO−8859−1

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -512,7 +512,9 @@ http_icy_metadata_get(AVFormatContext *fmtctx, int packet_only)
   struct http_icy_metadata *metadata;
   struct http_client_ctx ctx;
   struct keyval *kv;
+  char *ptr;
   const char *value;
+  const char *headerenc = "ISO−8859−1";
   int got_header;
   int ret;
 
@@ -547,17 +549,23 @@ http_icy_metadata_get(AVFormatContext *fmtctx, int packet_only)
   got_header = 0;
   if ( (value = keyval_get(ctx.headers, "icy-name")) )
     {
-      metadata->name = strdup(value);
+	  ptr = strdup(value);
+      metadata->name = strdup(unicode_fixup_string(ptr, headerenc));
+      free(ptr);
       got_header = 1;
     }
   if ( (value = keyval_get(ctx.headers, "icy-description")) )
     {
-      metadata->description = strdup(value);
+	  ptr = strdup(value);
+      metadata->description = strdup(unicode_fixup_string(ptr, headerenc));
+      free(ptr);
       got_header = 1;
     }
   if ( (value = keyval_get(ctx.headers, "icy-genre")) )
     {
-      metadata->genre = strdup(value);
+	  ptr = strdup(value);
+      metadata->genre = strdup(unicode_fixup_string(ptr, headerenc));
+      free(ptr);
       got_header = 1;
     }
 


### PR DESCRIPTION
encoding function added to conform to rfc2616. This commit targets
systems that do not have a libavformat version greater than 56 or
55.13.xx. (E.g Raspbian Wheezy). To be able to http request icy metadata
libevent version >= 2.1.4 must be available.