### PR TITLE
u8_conv_from_encoding srclen parameter value corrected to use the

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -511,7 +511,7 @@ unicode_fixup_string(char *str, const char *fromcode)
       return str;
     }
 
-  ret = u8_conv_from_encoding(fromcode, iconveh_question_mark, str, len, NULL, NULL, &len);
+  ret = u8_conv_from_encoding(fromcode, iconveh_question_mark, str, len+1, NULL, NULL, &len);
   if (!ret)
     {
       DPRINTF(E_LOG, L_MISC, "Could not convert string '%s' to UTF-8: %s\n", str, strerror(errno));


### PR DESCRIPTION
correct srclen "strlen(str) + 1".

Function documentation reference: "The input is in the memory region
between SRC (inclusive) and SRC + SRCLEN (exclusive)." 

To retrieve a null terminated string we have to provide the source
string including its null termination. Derived from the function
description that is the memory region defined as follows: SRC
(inclusive) and SRC + strlen(str) + 1 (exclusive)

Otherwise the function u8_conv_from_encoding returns a not null
terminated string that (could) causes bufferoverflows.