### PR TITLE
[mpd] support serving artwork over http

### DIFF
--- a/forked-daapd.conf
+++ b/forked-daapd.conf
@@ -203,6 +203,18 @@ spotify {
 #	starred_album_override = false
 }
 
+# MPD configuration (only have effect if MPD enabled - see README/INSTALL)
+mpd {
+	# TCP port to listen on for MPD client requests. 
+	# Default port is 6600, set to 0 to disable MPD support.
+#	port = 6600
+
+	# HTTP port to listen for artwork requests (only supported by some MPD clients
+	# and will need additional configuration in the MPD client to work).
+	# Set to 0 to disable serving artwork over http.
+#	http_port = 0
+}
+
 # SQLite configuration (allows to modify the operation of the SQLite databases)
 # Make sure to read the SQLite documentation for the corresponding PRAGMA statements as
 # changing them from the defaults may increase the possibility of database corruptions!

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -139,6 +139,7 @@ static cfg_opt_t sec_sqlite[] =
 static cfg_opt_t sec_mpd[] =
   {
     CFG_INT("port", 6600, CFGF_NONE),
+    CFG_INT("http_port", 0, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/db.c
+++ b/src/db.c
@@ -2315,6 +2315,30 @@ db_file_id_byurl(char *url)
 #undef Q_TMPL
 }
 
+int
+db_file_id_by_virtualpath_match(char *path)
+{
+#define Q_TMPL "SELECT f.id FROM files f WHERE f.virtual_path LIKE '%%%q%%';"
+  char *query;
+  int ret;
+
+  query = sqlite3_mprintf(Q_TMPL, path);
+  if (!query)
+    {
+      DPRINTF(E_LOG, L_DB, "Out of memory for query string\n");
+
+      return 0;
+    }
+
+  ret = db_file_id_byquery(query);
+
+  sqlite3_free(query);
+
+  return ret;
+
+#undef Q_TMPL
+}
+
 void
 db_file_stamp_bypath(char *path, time_t *stamp, int *id)
 {

--- a/src/db.h
+++ b/src/db.h
@@ -452,6 +452,9 @@ db_file_id_byfile(char *filename);
 int
 db_file_id_byurl(char *url);
 
+int
+db_file_id_by_virtualpath_match(char *path);
+
 void
 db_file_stamp_bypath(char *path, time_t *stamp, int *id);
 

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4366,7 +4366,7 @@ artwork_cb(struct evhttp_request *req, void *arg)
       return;
     }
 
-  format = artwork_get_item(evbuffer, itemid, 500, 500);
+  format = artwork_get_item(evbuffer, itemid, 600, 600);
   if (format < 0)
     {
       evhttp_send_error(req, HTTP_NOTFOUND, "Document was not found");


### PR DESCRIPTION
Some MPD clients, like MPDroid or MPoD, have an option to retrieve local cover art. When using MPD as server application. This is achieved by setting up a separate http-server and pointing its document root to the MPD music directory. The cover art for a song must be an image with a defined filename, e. g. "Folder.jpg" (the name is configurable in the MPD clients), in the same directory.

I guess this could also be set up for forked-daapd, but due to the virtual path (with prefix of "file:", "spotify:", ...) would require some more knowledge of setting up a web server (some rewrite rules must be added). The drawback would be, that it would not support embedded artwork and artwork for songs from spotify.

So here is an approach of adding support for it directly in forked-daapd. I added a new config option "http_port" in the mpd section. If it is greater than 0, the mpd thread starts an http-server an listens for artwork requests. 