### PR TITLE
Allow ANTLR 3.5 to work and update script

### DIFF
--- a/scripts/antlr35_install.sh
+++ b/scripts/antlr35_install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-WORKDIR=~/antlr34.tmp
-echo "This script will install antlr 3.4 (and matching libantlr) on your computer."
+WORKDIR=~/antlr35.tmp
+echo "This script will install antlr 3.5 (and matching libantlr) on your computer."
 read -p "Should the script create $WORKDIR and use it for building? [Y/n] " yn
 if [ "$yn" = "n" ]; then
 	exit
@@ -27,7 +27,7 @@ read -p "Should the script build libantlr3c for 64 bit? [Y/n] " yn
 if [ "$yn" != "n" ]; then
 	ENABLE64BIT="--enable-64bit"
 fi
-wget --no-check-certificate https://github.com/antlr/website-antlr3/raw/gh-pages/download/antlr-3.4-complete.jar
+wget --no-check-certificate https://github.com/antlr/website-antlr3/raw/gh-pages/download/antlr-3.5.2-complete.jar
 wget --no-check-certificate https://github.com/antlr/website-antlr3/raw/gh-pages/download/C/libantlr3c-3.4.tar.gz
 tar xzf libantlr3c-3.4.tar.gz
 cd libantlr3c-3.4
@@ -35,10 +35,10 @@ cd libantlr3c-3.4
 cd $WORKDIR
 
 sudo mkdir -p "$PREFIX/share/java"
-sudo install antlr-3.4-complete.jar "$PREFIX/share/java"
+sudo install antlr-3.5.2-complete.jar "$PREFIX/share/java"
 printf "#!/bin/sh
 export CLASSPATH
-CLASSPATH=\$CLASSPATH:$PREFIX/share/java/antlr-3.4-complete.jar:$PREFIX/share/java
+CLASSPATH=\$CLASSPATH:$PREFIX/share/java/antlr-3.5.2-complete.jar:$PREFIX/share/java
 /usr/bin/java org.antlr.Tool \$*
 " > antlr3
 sudo install --mode=755 antlr3 "$PREFIX/bin"

--- a/src/RSP.g
+++ b/src/RSP.g
@@ -43,43 +43,43 @@ strcrit	:	FIELD strop STR			->	^(strop FIELD STR)
 	|	FIELD NOT strop STR		->	^(NOT ^(strop FIELD STR))
 	;
 
-strop	:	EQUAL
-	|	INCLUDES
-	|	STARTSW
-	|	ENDSW
+strop	:	equal=EQUAL
+	|	includes=INCLUDES
+	|	startsw=STARTSW
+	|	endsw=ENDSW
 	;
 
 intcrit	:	FIELD intop INT			->	^(intop FIELD INT)
 	|	FIELD NOT intop INT		->	^(NOT ^(intop FIELD INT))
 	;
 
-intop	:	EQUAL
-	|	LESS
-	|	GREATER
-	|	LTE
-	|	GTE
+intop	:	equal=EQUAL
+	|	less=LESS
+	|	greater=GREATER
+	|	lte=LTE
+	|	gte=GTE
 	;
 
 datecrit:	FIELD dateop datespec		->	^(dateop FIELD datespec)
 	;
 
-dateop	:	BEFORE
-	|	AFTER
+dateop	:	before=BEFORE
+	|	after=AFTER
 	;
 
 datespec:	dateref
 	|	INT dateintval dateop dateref	->	^(dateop dateref INT dateintval)
 	;
 
-dateref	:	DATE
-	|	TODAY
+dateref	:	date=DATE
+	|	today=TODAY
 	;
 
 dateintval
-	:	DAY
-	|	WEEK
-	|	MONTH
-	|	YEAR
+	:	day=DAY
+	|	week=WEEK
+	|	month=MONTH
+	|	year=YEAR
 	;
 
 QUOTE	:	'"';


### PR DESCRIPTION
This involves a harmless backwards-compatible adjustment to the grammar. It is beneficial because 3.4 is broken under Java 8.