### PR TITLE
Playerfixes

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1139,7 +1139,7 @@ dacp_reply_playspec(struct evhttp_request *req, struct evbuffer *evbuf, char **u
   const char *shuffle;
   uint32_t plid;
   uint32_t id;
-  uint32_t pos;
+  int pos;
   int ret;
 
   /* /ctrl-int/1/playspec?database-spec='dmap.persistentid:0x1'&container-spec='dmap.persistentid:0x5'&container-item-spec='dmap.containeritemid:0x9'
@@ -1202,7 +1202,7 @@ dacp_reply_playspec(struct evhttp_request *req, struct evbuffer *evbuf, char **u
 	}
       param++;
 
-      ret = safe_hextou32(param, &pos);
+      ret = safe_hextou32(param, &id);
       if (ret < 0)
 	{
 	  DPRINTF(E_LOG, L_DACP, "Couldn't convert container-item-spec/item-spec to an integer in playspec (%s)\n", param);
@@ -1211,15 +1211,15 @@ dacp_reply_playspec(struct evhttp_request *req, struct evbuffer *evbuf, char **u
 	}
     }
   else
-    pos = 0;
+    id = 0;
 
-  DPRINTF(E_DBG, L_DACP, "Playspec request for playlist %d, start song id %d%s\n", plid, pos, (shuffle) ? ", shuffle" : "");
+  DPRINTF(E_DBG, L_DACP, "Playspec request for playlist %d, start song id %d%s\n", plid, id, (shuffle) ? ", shuffle" : "");
 
   items = NULL;
   if (plid > 0)
     items = queueitem_make_byplid(plid);
-  else if (pos > 0)
-    items = queueitem_make_byid(pos);
+  else if (id > 0)
+    items = queueitem_make_byid(id);
 
   if (!items)
     {
@@ -1228,6 +1228,12 @@ dacp_reply_playspec(struct evhttp_request *req, struct evbuffer *evbuf, char **u
       goto out_fail;
     }
 
+  pos = queueitem_pos(items, id);
+  if (pos < 0)
+    {
+      DPRINTF(E_DBG, L_DACP, "No item with %d found in queue\n", id);
+      pos = 0;
+    }
   DPRINTF(E_DBG, L_DACP, "Playspec start song index is %d\n", pos);
 
   player_get_status(&status);
@@ -1242,7 +1248,7 @@ dacp_reply_playspec(struct evhttp_request *req, struct evbuffer *evbuf, char **u
   if (shuffle)
     dacp_propset_shufflestate(shuffle, NULL);
 
-  ret = player_playback_start_bypos(pos, &id);
+  ret = player_playback_start_bypos(pos, NULL);
   if (ret < 0)
     {
       DPRINTF(E_LOG, L_DACP, "Could not start playback\n");

--- a/src/player.c
+++ b/src/player.c
@@ -1512,7 +1512,7 @@ source_read(uint8_t *buf, int len, uint64_t rtptime)
 	    {
 	      ret = stream_read(cur_streaming, len - nbytes);
 	    }
-	  else
+	  else if (cur_playing)
 	    {
 	      // Reached end of playlist (cur_playing is NULL) send silence and source_check will abort playback if the last item was played
 	      DPRINTF(E_SPAM, L_PLAYER, "End of playlist reached, stream silence until playback of last item ends\n");
@@ -1520,6 +1520,11 @@ source_read(uint8_t *buf, int len, uint64_t rtptime)
 	      evbuffer_add(audio_buf, silence_buf, (len - nbytes));
 	      free(silence_buf);
 	      ret = len - nbytes;
+	    }
+	  else
+	    {
+	      // If cur_streaming and cur_playing are NULL, source_read for all queue items failed. Playback will be aborted in the calling function
+	      return -1;
 	    }
 
 	  if (ret <= 0)


### PR DESCRIPTION
First commit should fix the segfault if reading failed for all queue items, the second commit should fix starting playback of a specific item in a playlist.