### PR TITLE
Fix item-id in mpd commands "playlistid", "playlistinfo", "plchanges"

### DIFF
--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4567,7 +4567,7 @@ int mpd_init(void)
       ret = evhttp_bind_socket(evhttpd, http_addr, http_port);
       if (ret < 0)
 	{
-	  DPRINTF(E_FATAL, L_MPD, "Could not bind HTTP artwork server at %s:%d\n", http_addr, port);
+	  DPRINTF(E_FATAL, L_MPD, "Could not bind HTTP artwork server at %s:%d\n", http_addr, http_port);
 
 	  goto bind_fail;
 	}

--- a/src/queue.c
+++ b/src/queue.c
@@ -576,6 +576,10 @@ queue_new_byindex(struct queue *queue, unsigned int index, unsigned int count, c
       qii->shuffle_prev = qii;
 
       queue_add(qi, qii);
+
+      // queue_add(...) changes the queue item-id, reset the item-id to the original value
+      qii->item_id = item->item_id;
+
       i++;
     }
 


### PR DESCRIPTION
The item-ids for the songs in the current playlist are wrong. The original values are overridden in queue_add and need to be restored to the original values (in ympd this leads to the error, that the current playing song is not marked as such in the playqueue).

Additionally, i corrected the log message for failing to bind to the http_port.