### PR TITLE
[mpd] Add support for moveid and close command

### DIFF
--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1748,6 +1748,57 @@ mpd_command_deleteid(struct evbuffer *evbuf, int argc, char **argv, char **errms
   return 0;
 }
 
+static int
+mpd_command_move(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
+{
+  return 0;
+}
+
+static int
+mpd_command_moveid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
+{
+  uint32_t songid;
+  uint32_t to_pos;
+  int ret;
+
+  if (argc < 3)
+    {
+      ret = asprintf(errmsg, "Missing argument for command 'moveid'");
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_ARG;
+    }
+
+  ret = safe_atou32(argv[1], &songid);
+  if (ret < 0)
+    {
+      ret = asprintf(errmsg, "Argument doesn't convert to integer: '%s'", argv[1]);
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_ARG;
+    }
+
+  ret = safe_atou32(argv[2], &to_pos);
+  if (ret < 0)
+    {
+      ret = asprintf(errmsg, "Argument doesn't convert to integer: '%s'", argv[2]);
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_ARG;
+    }
+
+  ret = player_queue_move_byitemid(songid, to_pos);
+  if (ret < 0)
+    {
+      ret = asprintf(errmsg, "Failed to move song with id '%s' to index '%s'", argv[1], argv[2]);
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_UNKNOWN;
+    }
+
+  return 0;
+}
+
 /*
  * Command handler function for 'playlistid'
  * Displays a list of all songs in the queue, or if the optional argument is given, displays information
@@ -3561,7 +3612,6 @@ static struct command mpd_handlers[] =
       .mpdcommand = "deleteid",
       .handler = mpd_command_deleteid
     },
-    /*
     {
       .mpdcommand = "move",
       .handler = mpd_command_move
@@ -3570,7 +3620,6 @@ static struct command mpd_handlers[] =
       .mpdcommand = "moveid",
       .handler = mpd_command_moveid
     },
-    */
     // According to the mpd protocol the use of "playlist" is deprecated
     {
       .mpdcommand = "playlist",

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3839,11 +3839,11 @@ static struct command mpd_handlers[] =
     /*
      * Connection settings
      */
-    /*
     {
       .mpdcommand = "close",
-      .handler = mpd_command_close
+      .handler = mpd_command_ignore
     },
+    /*
     {
       .mpdcommand = "kill",
       .handler = mpd_command_kill
@@ -3998,6 +3998,7 @@ mpd_read_cb(struct bufferevent *bev, void *ctx)
   struct command *command;
   enum command_list_type listtype;
   int idle_cmd;
+  int close_cmd;
   char *argv[COMMAND_ARGV_MAX];
   int argc;
 
@@ -4009,6 +4010,7 @@ mpd_read_cb(struct bufferevent *bev, void *ctx)
   DPRINTF(E_SPAM, L_MPD, "Received MPD command sequence\n");
 
   idle_cmd = 0;
+  close_cmd = 0;
 
   listtype = COMMAND_LIST_NONE;
   ncmd = 0;
@@ -4057,6 +4059,8 @@ mpd_read_cb(struct bufferevent *bev, void *ctx)
 	idle_cmd = 1;
       else if (0 == strcmp(argv[0], "noidle"))
 	idle_cmd = 0;
+      else if (0 == strcmp(argv[0], "close"))
+	close_cmd = 1;
 
       /*
        * Find the command handler and execute the command function
@@ -4104,7 +4108,7 @@ mpd_read_cb(struct bufferevent *bev, void *ctx)
    * If everything was successful add OK line to signal clients end of message.
    * If an error occured the necessary ACK line should already be added to the response buffer.
    */
-  if (ret == 0 && idle_cmd == 0)
+  if (ret == 0 && idle_cmd == 0 && close_cmd == 0)
     {
       evbuffer_add(output, "OK\n", 3);
     }

--- a/src/player.c
+++ b/src/player.c
@@ -159,6 +159,14 @@ struct playerqueue_add_param
   int pos;
 };
 
+struct playerqueue_move_param
+{
+  uint32_t item_id;
+  int from_pos;
+  int to_pos;
+  int count;
+};
+
 struct icy_artwork
 {
   uint32_t id;
@@ -198,11 +206,11 @@ struct player_command
     enum repeat_mode mode;
     uint32_t id;
     int intval;
-    int ps_pos[2];
     struct icy_artwork icy;
     struct playback_start_param playback_start_param;
     struct playerqueue_get_param queue_get_param;
     struct playerqueue_add_param queue_add_param;
+    struct playerqueue_move_param queue_move_param;
   } arg;
 
   int ret;
@@ -3405,8 +3413,8 @@ playerqueue_move_bypos(struct player_command *cmd)
 {
   struct player_source *ps_playing;
 
-  DPRINTF(E_DBG, L_PLAYER, "Moving song from position %d to be the next song after %d\n", cmd->arg.ps_pos[0],
-      cmd->arg.ps_pos[1]);
+  DPRINTF(E_DBG, L_PLAYER, "Moving song from position %d to be the next song after %d\n",
+      cmd->arg.queue_move_param.from_pos, cmd->arg.queue_move_param.to_pos);
 
   ps_playing = source_now_playing();
 
@@ -3416,7 +3424,22 @@ playerqueue_move_bypos(struct player_command *cmd)
       return -1;
     }
 
-  queue_move_bypos(queue, ps_playing->item_id, cmd->arg.ps_pos[0], cmd->arg.ps_pos[1], shuffle);
+  queue_move_bypos(queue, ps_playing->item_id, cmd->arg.queue_move_param.from_pos, cmd->arg.queue_move_param.to_pos, shuffle);
+
+  cur_plversion++;
+
+  listener_notify(LISTENER_PLAYLIST);
+
+  return 0;
+}
+
+static int
+playerqueue_move_byitemid(struct player_command *cmd)
+{
+  DPRINTF(E_DBG, L_PLAYER, "Moving song with item-id %d to be the next song after index %d\n",
+      cmd->arg.queue_move_param.item_id, cmd->arg.queue_move_param.to_pos);
+
+  queue_move_byitemid(queue, cmd->arg.queue_move_param.item_id, cmd->arg.queue_move_param.to_pos, 0);
 
   cur_plversion++;
 
@@ -4187,8 +4210,28 @@ player_queue_move_bypos(int pos_from, int pos_to)
 
   cmd.func = playerqueue_move_bypos;
   cmd.func_bh = NULL;
-  cmd.arg.ps_pos[0] = pos_from;
-  cmd.arg.ps_pos[1] = pos_to;
+  cmd.arg.queue_move_param.from_pos = pos_from;
+  cmd.arg.queue_move_param.to_pos = pos_to;
+
+  ret = sync_command(&cmd);
+
+  command_deinit(&cmd);
+
+  return ret;
+}
+
+int
+player_queue_move_byitemid(uint32_t item_id, int pos_to)
+{
+  struct player_command cmd;
+  int ret;
+
+  command_init(&cmd);
+
+  cmd.func = playerqueue_move_byitemid;
+  cmd.func_bh = NULL;
+  cmd.arg.queue_move_param.item_id = item_id;
+  cmd.arg.queue_move_param.to_pos = pos_to;
 
   ret = sync_command(&cmd);
 

--- a/src/player.h
+++ b/src/player.h
@@ -170,6 +170,9 @@ int
 player_queue_move_bypos(int ps_pos_from, int ps_pos_to);
 
 int
+player_queue_move_byitemid(uint32_t item_id, int pos_to);
+
+int
 player_queue_remove_bypos(int pos);
 
 int

--- a/src/queue.h
+++ b/src/queue.h
@@ -84,6 +84,9 @@ void
 queue_move_bypos(struct queue *queue, unsigned int item_id, unsigned int from_pos, unsigned int to_offset, char shuffle);
 
 void
+queue_move_byitemid(struct queue *queue, unsigned int item_id, unsigned int to_pos, char shuffle);
+
+void
 queue_remove_byitemid(struct queue *queue, unsigned int item_id);
 
 void


### PR DESCRIPTION
This pr adds the ability to move songs in the playqueue for mpd clients that are using the moveid command (e. g. MPDroid). There is another move command (moving by position) that is still missing (ncmcpp is one client that makes use of it).

The implementation of the close command is merely to suppress the error log message if a client issues this command. 