### PR TITLE
some fixes

### DIFF
--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1517,7 +1517,7 @@ mpd_queueitem_make(char *path, int recursive)
 
   qp.type = Q_ITEMS;
   qp.idx_type = I_NONE;
-  qp.sort = S_ALBUM;
+  qp.sort = S_ARTIST;
 
   if (recursive)
     {
@@ -2499,7 +2499,7 @@ mpd_command_findadd(struct evbuffer *evbuf, int argc, char **argv, char **errmsg
   memset(&qp, 0, sizeof(struct query_params));
 
   qp.type = Q_ITEMS;
-  qp.sort = S_NAME;
+  qp.sort = S_ARTIST;
   qp.idx_type = I_NONE;
 
   mpd_get_query_params_find(argc - 1, argv + 1, &qp);
@@ -2973,7 +2973,7 @@ mpd_command_searchadd(struct evbuffer *evbuf, int argc, char **argv, char **errm
   memset(&qp, 0, sizeof(struct query_params));
 
   qp.type = Q_ITEMS;
-  qp.sort = S_NAME;
+  qp.sort = S_ARTIST;
   qp.idx_type = I_NONE;
 
   mpd_get_query_params_search(argc - 1, argv + 1, &qp);

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1407,7 +1407,7 @@ mpd_command_seekid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 
   //TODO Allow seeking in songs not currently playing
   player_get_status(&status);
-  if (status.id != id)
+  if (status.item_id != id)
     {
       ret = asprintf(errmsg, "Given song is not the current playing one, seeking is not supported");
       if (ret < 0)

--- a/src/queue.c
+++ b/src/queue.c
@@ -460,8 +460,8 @@ queue_next(struct queue *queue, unsigned int item_id, char shuffle, enum repeat_
   item = queueitem_get_byitemid(queue, item_id);
 
   if (!item)
-    // Item not found
-    return NULL;
+    // Item not found, start playing from the start of the queue
+    item = queue->head;
 
   if (r_mode == REPEAT_SONG && item != queue->head)
     return item;


### PR DESCRIPTION
First commit fixes the order in which songs are added to the queue with the mpd commands findadd and searchadd.
Second commit fixes that playback stops if the now playing item is not in the queue anymore (happens after clearing the queue).
Third commit fixes the mpd command seekid which is used by MPDroid to seek in the now playing item.