### PR TITLE
[mpd] Implement parts of stats command

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1474,7 +1474,7 @@ db_build_query_count_items(struct query_params *qp, char **q)
   if (qp->filter)
     query = sqlite3_mprintf("SELECT COUNT(*), SUM(song_length) FROM files f WHERE f.disabled = 0 AND %s;", qp->filter);
   else
-    return -1;
+    query = sqlite3_mprintf("SELECT COUNT(*), SUM(song_length) FROM files f WHERE f.disabled = 0;");
 
   if (!query)
     {
@@ -2034,6 +2034,18 @@ int
 db_files_get_count(void)
 {
   return db_get_count("SELECT COUNT(*) FROM files f WHERE f.disabled = 0;");
+}
+
+int
+db_files_get_artist_count(void)
+{
+  return db_get_count("SELECT COUNT(DISTINCT songartistid) FROM files f WHERE f.disabled = 0;");
+}
+
+int
+db_files_get_album_count(void)
+{
+  return db_get_count("SELECT COUNT(DISTINCT songalbumid) FROM files f WHERE f.disabled = 0;");
 }
 
 int

--- a/src/db.h
+++ b/src/db.h
@@ -417,6 +417,12 @@ int
 db_files_get_count(void);
 
 int
+db_files_get_artist_count(void);
+
+int
+db_files_get_album_count(void);
+
+int
 db_files_get_count_bymatch(char *path);
 
 void


### PR DESCRIPTION
Currently the stats command only returns dummy values. Besides giving information about the size of the library (number of artists, albums, songs), I noticed that mPoD seems to use the stats command for calculating the progress of the library import (probably by using the number of songs).

Still missing is the uptime, last library update time and the time played.