### PR TITLE
[mpd] Announce mpd support with avahi/zeroconf

### DIFF
--- a/src/mdns_avahi.c
+++ b/src/mdns_avahi.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2009-2011 Julien BLACHE <jb@jblache.org>
  *
  * Pieces coming from mt-daapd:
- * Copyright (C) 2005 Sebastian Dröge <slomo@ubuntu.com>
+ * Copyright (C) 2005 Sebastian DrÃ¶ge <slomo@ubuntu.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1032,11 +1032,14 @@ mdns_register(char *name, char *type, int port, char **txt)
   ge->port = port;
 
   txt_sl = NULL;
-  for (i = 0; txt[i]; i++)
+  if (txt)
     {
-      txt_sl = avahi_string_list_add(txt_sl, txt[i]);
+      for (i = 0; txt[i]; i++)
+	{
+	  txt_sl = avahi_string_list_add(txt_sl, txt[i]);
 
-      DPRINTF(E_DBG, L_MDNS, "Added key %s\n", txt[i]);
+	  DPRINTF(E_DBG, L_MDNS, "Added key %s\n", txt[i]);
+	}
     }
 
   ge->txt = txt_sl;


### PR DESCRIPTION
This adds mdns announcement for the for "_mpd._tcp" to forked-daapd and makes the first connection to forked-daapd easier for mpd clients that support it (the only client i know that uses the announcement is mPod).

In the following output from avahi-browse the announcement as "Music Player" is from a running mpd server, the announcement for "music 23.3" is from forked-daapd running on my rpi:

```
$ avahi-browse -r -k _mpd._tcp
+  wlan2 IPv6 Music Player                                  _mpd._tcp            local
+  wlan2 IPv4 Music Player                                  _mpd._tcp            local
=  wlan2 IPv6 Music Player                                  _mpd._tcp            local
   hostname = [studio-1749.local]
   address = [fe80::fa16:54ff:fef8:9c6]
   port = [6600]
   txt = []
=  wlan2 IPv4 Music Player                                  _mpd._tcp            local
   hostname = [studio-1749.local]
   address = [192.168.178.36]
   port = [6600]
   txt = []
+  wlan2 IPv4 music 23.3                                    _mpd._tcp            local
=  wlan2 IPv4 music 23.3                                    _mpd._tcp            local
   hostname = [music.local]
   address = [192.168.178.31]
   port = [6600]
   txt = []
```
