### PR TITLE
Fix paringhelper.sh to operate correctly for device names with apostrophe

### DIFF
--- a/scripts/pairinghelper.sh
+++ b/scripts/pairinghelper.sh
@@ -38,8 +38,8 @@ read -p "Press ENTER when ready..." yn
 echo -n "Looking in $logfile for Remote announcement..."
 sleep 5
 
-remote=`grep "Discovered remote" $logfile | tail -1 | grep -Po "'.*?'"`
-remote="${remote%\'}"
+remote=`grep "Discovered remote" $logfile | tail -1 | grep -Po "'.*' \("`
+remote="${remote%\'\ \(}"
 remote="${remote#\'}"
 
 if [ -z "$remote" ]; then


### PR DESCRIPTION
Before the fix, a log entry for ‘Foo’s iPhone’ would be parsed as
originating from the device “Foo”. I have changed the matching to
include the parenthesis opening after the closing single quote.