### PR TITLE
Fixed typos in instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -63,16 +63,19 @@ sudo yum install \
  sqlite-devel libconfuse-devel libunistring-devel mxml-devel libevent-devel \
  avahi-devel libgcrypt-devel zlib-devel alsa-lib-devel ffmpeg-devel
 
+Clone the forked-daapd repo:
+
+ git clone https://github.com/ejurgensen/forked-daapd.git
+ cd forked-daapd
+
 Now you need to install ANTLR3, but you probably can't use the version that
 comes with the package manager (but do try that first). Instead you can install
 it by running this script:
 
-scripts/antlr34_install.sh
+ scripts/antlr35_install.sh
 
 Then run the following:
 
- git clone https://github.com/ejurgensen/forked-daapd.git
- cd forked-daapd
  autoreconf -i
  ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var
  make

--- a/README_SMARTPL.md
+++ b/README_SMARTPL.md
@@ -125,7 +125,7 @@ One example of a valid date is a date in yyyy-mm-dd format:
 There are also some special date keywords:
 * "today", "yesterday", "last week", "last month", "last year"
 
-A valid date can also be made by appling an interval to a date. Intervals can be defined as "days", "weeks", "months", "years".
+A valid date can also be made by applying an interval to a date. Intervals can be defined as "days", "weeks", "months", "years".
 As an example, a valid date might be:
 
 ```3 weeks before today``` or ```3 weeks ago```


### PR DESCRIPTION
INSTALL: You can't run the script before you clone the repo.  Also updated the name of the script.
Fixed typo in README_SMARTPL.md.