### PR TITLE
[db] Make loading of playlistitem count optional

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -417,7 +417,7 @@ int
 db_query_fetch_file(struct query_params *qp, struct db_media_file_info *dbmfi);
 
 int
-db_query_fetch_pl(struct query_params *qp, struct db_playlist_info *dbpli);
+db_query_fetch_pl(struct query_params *qp, struct db_playlist_info *dbpli, int with_itemcount);
 
 int
 db_query_fetch_group(struct query_params *qp, struct db_group_info *dbgri);

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -1670,7 +1670,7 @@ daap_reply_playlists(struct evhttp_request *req, struct evbuffer *evbuf, char **
     }
 
   npls = 0;
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&qp, &dbpli, 1)) == 0) && (dbpli.id))
     {
       plid = 1;
       if (safe_atoi32(dbpli.id, &plid) != 0)

--- a/src/httpd_rsp.c
+++ b/src/httpd_rsp.c
@@ -394,7 +394,7 @@ rsp_reply_db(struct evhttp_request *req, char **uri, struct evkeyvalq *query)
   mxmlNewTextf(node, 0, "%d", qp.results);
 
   /* Playlists block (all playlists) */
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&qp, &dbpli, 1)) == 0) && (dbpli.id))
     {
       /* Playlist block (one playlist) */
       pl = mxmlNewElement(pls, "playlist");

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2237,7 +2237,7 @@ mpd_command_listplaylists(struct evbuffer *evbuf, int argc, char **argv, char **
       return ACK_ERROR_UNKNOWN;
     }
 
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&qp, &dbpli, 0)) == 0) && (dbpli.id))
     {
       if (safe_atou32(dbpli.db_timestamp, &time_modified) != 0)
         {
@@ -2752,7 +2752,7 @@ mpd_add_directory(struct evbuffer *evbuf, int directory_id, int listall, int lis
 	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
       return ACK_ERROR_UNKNOWN;
     }
-  while (((ret = db_query_fetch_pl(&qp, &dbpli)) == 0) && (dbpli.id))
+  while (((ret = db_query_fetch_pl(&qp, &dbpli, 0)) == 0) && (dbpli.id))
     {
       if (safe_atou32(dbpli.db_timestamp, &time_modified) != 0)
 	{


### PR DESCRIPTION
Hi @ejurgensen,

currently loading the playlists from the db always additionally fetches the item count for each playlist. The count query on a rpi can take quite long, especially if you have smart playlists where the count query cannot use an existing index.

The mpd commands for playlists do not use the item count information, so this pr improves performance for these queries, by skipping the item count queries.  