### PR TITLE
[mpd] Implement mpd command 'move'

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -3449,6 +3449,21 @@ playerqueue_move_bypos(struct player_command *cmd)
 }
 
 static int
+playerqueue_move_byindex(struct player_command *cmd)
+{
+  DPRINTF(E_DBG, L_PLAYER, "Moving song from index %d to be the next song after %d\n",
+      cmd->arg.queue_move_param.from_pos, cmd->arg.queue_move_param.to_pos);
+
+  queue_move_byindex(queue, cmd->arg.queue_move_param.from_pos, cmd->arg.queue_move_param.to_pos, 0);
+
+  cur_plversion++;
+
+  listener_notify(LISTENER_PLAYLIST);
+
+  return 0;
+}
+
+static int
 playerqueue_move_byitemid(struct player_command *cmd)
 {
   DPRINTF(E_DBG, L_PLAYER, "Moving song with item-id %d to be the next song after index %d\n",
@@ -4254,6 +4269,26 @@ player_queue_move_bypos(int pos_from, int pos_to)
   command_init(&cmd);
 
   cmd.func = playerqueue_move_bypos;
+  cmd.func_bh = NULL;
+  cmd.arg.queue_move_param.from_pos = pos_from;
+  cmd.arg.queue_move_param.to_pos = pos_to;
+
+  ret = sync_command(&cmd);
+
+  command_deinit(&cmd);
+
+  return ret;
+}
+
+int
+player_queue_move_byindex(int pos_from, int pos_to)
+{
+  struct player_command cmd;
+  int ret;
+
+  command_init(&cmd);
+
+  cmd.func = playerqueue_move_byindex;
   cmd.func_bh = NULL;
   cmd.arg.queue_move_param.from_pos = pos_from;
   cmd.arg.queue_move_param.to_pos = pos_to;

--- a/src/player.h
+++ b/src/player.h
@@ -170,6 +170,9 @@ int
 player_queue_move_bypos(int ps_pos_from, int ps_pos_to);
 
 int
+player_queue_move_byindex(int pos_from, int pos_to);
+
+int
 player_queue_move_byitemid(uint32_t item_id, int pos_to);
 
 int

--- a/src/queue.c
+++ b/src/queue.c
@@ -763,6 +763,65 @@ queue_move_bypos(struct queue *queue, unsigned int item_id, unsigned int from_po
     }
 }
 
+void
+queue_move_byindex(struct queue *queue, unsigned int from_pos, unsigned int to_pos, char shuffle)
+{
+  struct queue_item *item;
+  struct queue_item *itemnext;
+
+  if (from_pos == to_pos)
+    return;
+
+  // Get the item to be moved
+  item = queueitem_get_byindex(queue, from_pos, shuffle);
+  if (!item)
+    {
+      DPRINTF(E_LOG, L_PLAYER, "Invalid position given to move items\n");
+      return;
+    }
+
+  // Get the item at the target position
+  itemnext = queueitem_get_byindex(queue, to_pos, shuffle);
+  if (!itemnext)
+    {
+      DPRINTF(E_LOG, L_PLAYER, "Invalid position given to move items\n");
+      return;
+    }
+
+  if (to_pos > from_pos)
+    itemnext = item_next(itemnext, shuffle);
+
+  // Remove item from the queue
+  if (shuffle)
+    {
+      item->shuffle_prev->shuffle_next = item->shuffle_next;
+      item->shuffle_next->shuffle_prev = item->shuffle_prev;
+    }
+  else
+    {
+      item->prev->next = item->next;
+      item->next->prev = item->prev;
+    }
+
+  // Insert item into the queue before the item at the target postion
+  if (shuffle)
+    {
+      itemnext->shuffle_prev->shuffle_next = item;
+      item->shuffle_prev = itemnext->shuffle_prev;
+
+      itemnext->shuffle_prev = item;
+      item->shuffle_next = itemnext;
+    }
+  else
+    {
+      itemnext->prev->next = item;
+      item->prev = itemnext->prev;
+
+      itemnext->prev = item;
+      item->next = itemnext;
+    }
+}
+
 /*
  * Moves the item with the given item-id to the index to_pos in the play-queue (shuffle = 0)
  * or shuffle-queue (shuffle = 1)

--- a/src/queue.h
+++ b/src/queue.h
@@ -84,6 +84,9 @@ void
 queue_move_bypos(struct queue *queue, unsigned int item_id, unsigned int from_pos, unsigned int to_offset, char shuffle);
 
 void
+queue_move_byindex(struct queue *queue, unsigned int from_pos, unsigned int to_pos, char shuffle);
+
+void
 queue_move_byitemid(struct queue *queue, unsigned int item_id, unsigned int to_pos, char shuffle);
 
 void


### PR DESCRIPTION
This pr implements the "move" command (moving items in the queue) used by MPoD. Only moving a single item is supported, if a range of items is given only the first item will be moved to the new position.