### PR TITLE
Do not start playback after adding songs to the queue using mpd clients

### DIFF
--- a/forked-daapd.conf
+++ b/forked-daapd.conf
@@ -217,6 +217,11 @@ mpd {
 	# and will need additional configuration in the MPD client to work).
 	# Set to 0 to disable serving artwork over http.
 #	http_port = 0
+
+	# By default forked-daapd will - like iTunes - clear the playqueue if playback stops. 
+	# Setting clear_queue_on_stop_disable to true will keep the playlist like MPD does.
+	# Note that some dacp clients do not show the playqueue if playback is stopped.
+#	clear_queue_on_stop_disable = false
 }
 
 # SQLite configuration (allows to modify the operation of the SQLite databases)

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -139,6 +139,7 @@ static cfg_opt_t sec_mpd[] =
   {
     CFG_INT("port", 6600, CFGF_NONE),
     CFG_INT("http_port", 0, CFGF_NONE),
+    CFG_BOOL("clear_queue_on_stop_disable", cfg_false, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1068,6 +1068,9 @@ dacp_reply_cue_play(struct evhttp_request *req, struct evbuffer *evbuf, char **u
 	{
 	  /* Play from Up Next queue */
 	  pos += status.pos_pl;
+
+	  if (status.status == PLAY_STOPPED && pos > 0)
+	    pos--;
 	}
     }
 

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1015,7 +1015,7 @@ dacp_reply_cue_play(struct evhttp_request *req, struct evbuffer *evbuf, char **u
 	  return;
 	}
 
-      player_queue_add(items);
+      player_queue_add(items, NULL);
     }
   else
     {
@@ -1253,7 +1253,7 @@ dacp_reply_playspec(struct evhttp_request *req, struct evbuffer *evbuf, char **u
     player_playback_stop();
 
   player_queue_clear();
-  player_queue_add(items);
+  player_queue_add(items, NULL);
   player_queue_plid(plid);
 
   if (shuffle)
@@ -1787,7 +1787,7 @@ dacp_reply_playqueueedit_add(struct evhttp_request *req, struct evbuffer *evbuf,
       }
       else
       {
-        player_queue_add(items);
+        player_queue_add(items, NULL);
       }
     }
   else

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1564,28 +1564,24 @@ dacp_reply_playqueuecontents(struct evhttp_request *req, struct evbuffer *evbuf,
     {
       player_get_status(&status);
 
-      /* Get queue and make songlist only if playing or paused */
-      if (status.status != PLAY_STOPPED)
+      queue = player_queue_get_bypos(abs(span));
+      if (queue)
 	{
-	  queue = player_queue_get_bypos(abs(span));
-	  if (queue)
+	  i = 0;
+	  count = queue_count(queue);
+	  for (n = 0; (n < count) && (n < abs(span)); n++)
 	    {
-	      i = 0;
-	      count = queue_count(queue);
-	      for (n = 0; (n < count) && (n < abs(span)); n++)
+	      item = queue_get_byindex(queue, n, 0);
+	      ret = playqueuecontents_add_source(songlist, queueitem_id(item), (n + i + 1), status.plid);
+	      if (ret < 0)
 		{
-		  item = queue_get_byindex(queue, n, 0);
-		  ret = playqueuecontents_add_source(songlist, queueitem_id(item), (n + i + 1), status.plid);
-		  if (ret < 0)
-		    {
-		      DPRINTF(E_LOG, L_DACP, "Could not add song to songlist for playqueue-contents\n");
+		  DPRINTF(E_LOG, L_DACP, "Could not add song to songlist for playqueue-contents\n");
 
-		      dmap_send_error(req, "ceQR", "Out of memory");
-		      return;
-		    }
+		  dmap_send_error(req, "ceQR", "Out of memory");
+		  return;
 		}
-	      queue_free(queue);
 	    }
+	  queue_free(queue);
 	}
     }
 

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1604,7 +1604,7 @@ mpd_command_add(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       return ACK_ERROR_UNKNOWN;
     }
 
-  player_queue_add(items);
+  player_queue_add(items, NULL);
 
   ret = player_playback_start(NULL);
   if (ret < 0)
@@ -1625,6 +1625,7 @@ static int
 mpd_command_addid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 {
   struct queue_item *items;
+  uint32_t item_id;
   int ret;
 
   if (argc < 2)
@@ -1652,14 +1653,11 @@ mpd_command_addid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
     }
 
 
-  player_queue_add(items);
+  player_queue_add(items, &item_id);
 
-  //TODO [queue] Get queue-item-id for mpd-command addid
   evbuffer_add_printf(evbuf,
-      "addid: %s\n"
       "Id: %d\n",
-      argv[1],
-      0); //ps->id);
+      item_id);
 
   ret = player_playback_start(NULL);
   if (ret < 0)
@@ -2362,7 +2360,7 @@ mpd_command_load(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       return ACK_ERROR_UNKNOWN;
     }
 
-  player_queue_add(items);
+  player_queue_add(items, NULL);
 
   ret = player_playback_start(NULL);
   if (ret < 0)
@@ -2628,7 +2626,7 @@ mpd_command_findadd(struct evbuffer *evbuf, int argc, char **argv, char **errmsg
       return ACK_ERROR_UNKNOWN;
     }
 
-  player_queue_add(items);
+  player_queue_add(items, NULL);
 
   ret = player_playback_start(NULL);
   if (ret < 0)
@@ -3263,7 +3261,7 @@ mpd_command_searchadd(struct evbuffer *evbuf, int argc, char **argv, char **errm
       return ACK_ERROR_UNKNOWN;
     }
 
-  player_queue_add(items);
+  player_queue_add(items, NULL);
 
   ret = player_playback_start(NULL);
   if (ret < 0)

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1606,12 +1606,6 @@ mpd_command_add(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 
   player_queue_add(items, NULL);
 
-  ret = player_playback_start(NULL);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_MPD, "Could not start playback\n");
-    }
-
   return 0;
 }
 
@@ -1658,12 +1652,6 @@ mpd_command_addid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
   evbuffer_add_printf(evbuf,
       "Id: %d\n",
       item_id);
-
-  ret = player_playback_start(NULL);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_MPD, "Could not start playback\n");
-    }
 
   return 0;
 }
@@ -2362,12 +2350,6 @@ mpd_command_load(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 
   player_queue_add(items, NULL);
 
-  ret = player_playback_start(NULL);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_MPD, "Could not start playback\n");
-    }
-
   return 0;
 }
 
@@ -2627,12 +2609,6 @@ mpd_command_findadd(struct evbuffer *evbuf, int argc, char **argv, char **errmsg
     }
 
   player_queue_add(items, NULL);
-
-  ret = player_playback_start(NULL);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_MPD, "Could not start playback\n");
-    }
 
   return 0;
 }
@@ -3262,12 +3238,6 @@ mpd_command_searchadd(struct evbuffer *evbuf, int argc, char **argv, char **errm
     }
 
   player_queue_add(items, NULL);
-
-  ret = player_playback_start(NULL);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_MPD, "Could not start playback\n");
-    }
 
   return 0;
 }

--- a/src/player.c
+++ b/src/player.c
@@ -3488,6 +3488,7 @@ playerqueue_remove_bypos(struct player_command *cmd)
 {
   int pos;
   struct player_source *ps_playing;
+  uint32_t item_id;
 
   pos = cmd->arg.intval;
   if (pos < 1)
@@ -3500,12 +3501,14 @@ playerqueue_remove_bypos(struct player_command *cmd)
 
   if (!ps_playing)
     {
-      DPRINTF(E_LOG, L_PLAYER, "Can't remove item at pos %d, no playing item found\n", pos);
-      return -1;
+      DPRINTF(E_DBG, L_PLAYER, "No playing item for remove by pos\n");
+      item_id = 0;
     }
+  else
+    item_id = ps_playing->item_id;
 
   DPRINTF(E_DBG, L_PLAYER, "Removing item from position %d\n", pos);
-  queue_remove_bypos(queue, ps_playing->item_id, pos, shuffle);
+  queue_remove_bypos(queue, item_id, pos, shuffle);
 
   cur_plversion++;
 

--- a/src/player.c
+++ b/src/player.c
@@ -3429,6 +3429,7 @@ static int
 playerqueue_move_bypos(struct player_command *cmd)
 {
   struct player_source *ps_playing;
+  uint32_t item_id;
 
   DPRINTF(E_DBG, L_PLAYER, "Moving song from position %d to be the next song after %d\n",
       cmd->arg.queue_move_param.from_pos, cmd->arg.queue_move_param.to_pos);
@@ -3437,11 +3438,13 @@ playerqueue_move_bypos(struct player_command *cmd)
 
   if (!ps_playing)
     {
-      DPRINTF(E_LOG, L_PLAYER, "Can't move item, no playing item found\n");
-      return -1;
+      DPRINTF(E_DBG, L_PLAYER, "No playing item found for move by pos\n");
+      item_id = 0;
     }
+  else
+    item_id = ps_playing->item_id;
 
-  queue_move_bypos(queue, ps_playing->item_id, cmd->arg.queue_move_param.from_pos, cmd->arg.queue_move_param.to_pos, shuffle);
+  queue_move_bypos(queue, item_id, cmd->arg.queue_move_param.from_pos, cmd->arg.queue_move_param.to_pos, shuffle);
 
   cur_plversion++;
 

--- a/src/player.c
+++ b/src/player.c
@@ -244,6 +244,9 @@ static struct event *exitev;
 static struct event *cmdev;
 static pthread_t tid_player;
 
+/* Config values */
+static int clear_queue_on_stop_disabled;
+
 /* Player status */
 static enum play_status player_state;
 static enum repeat_mode repeat;
@@ -2167,9 +2170,10 @@ playback_abort(void)
 
   source_stop();
 
-  playerqueue_clear(NULL);
-
   evbuffer_drain(audio_buf, evbuffer_get_length(audio_buf));
+
+  if (!clear_queue_on_stop_disabled)
+    playerqueue_clear(NULL);
 
   status_update(PLAY_STOPPED);
 
@@ -4589,6 +4593,8 @@ player_init(void)
   int ret;
 
   player_exit = 0;
+
+  clear_queue_on_stop_disabled = cfg_getbool(cfg_getsec(cfg, "mpd"), "clear_queue_on_stop_disable");
 
   dev_autoselect = 1;
   dev_list = NULL;

--- a/src/player.h
+++ b/src/player.h
@@ -161,7 +161,7 @@ struct queue *
 player_queue_get_byindex(int pos, int count);
 
 int
-player_queue_add(struct queue_item *items);
+player_queue_add(struct queue_item *items, uint32_t *item_id);
 
 int
 player_queue_add_next(struct queue_item *items);

--- a/src/queue.c
+++ b/src/queue.c
@@ -336,7 +336,7 @@ queueitem_get_bypos(struct queue *queue, unsigned int item_id, unsigned int pos,
     return NULL;
 
   i = 0;
-  for (item = item_base; item != queue->head && i < pos; item = item_next(item, shuffle))
+  for (item = item_base; i < pos; item = item_next(item, shuffle))
     {
       i++;
     }


### PR DESCRIPTION
This addresses #224 (commit 963f837 is not  related to this and contains two fixes for the mpd commands addid and status)

The changes allow adding songs through mpd clients without automatically starting playback, if player was stopped (commit fe9ed57). 
Having a non empty playqueue is something iTunes does not have. Therefor the support in dacp clients varies. Remote seems to work fine with this change (at least my somewhat outdated version). With commit 21b9b0d Remote shows the queue and with commits 014824f, 7160366, fc674a1, it also allows editing the queue. Retune on the other hand does not always show the queue if the player is stopped (UpNext stays empty).

The last commit 8ccac55 needs some discussion. It removes the clearing of the queue after aborting playback (e. g. after the last song in the queue has been played). This is how mpd handles it. What i like about it is, that it is easy to restart a queue instead of navigating once again to the album/playlist/... and refill the queue with the same items. The problem i see with this are the dacp clients. As some of them rely on an empty queue if player is stopped this leads to unexpected behavior. To solve this conflict i was thinking of a config option in the mpd section of forked-daapd. The default would be the iTunes behavior but could be changed the mpd behavior.

@ejurgensen what do you think about this? Should the last commit be dropped or should i add a config option?