### PR TITLE
[spotify] Remove options to exclude starred songs from artist/album override

### DIFF
--- a/forked-daapd.conf
+++ b/forked-daapd.conf
@@ -198,11 +198,6 @@ spotify {
 	# album artist for spotify items that are not in the starred playlist.
 #	artist_override = false
 
-	# Like artist_override, the starred_artist_override flag can be set to true,
-	# in order to use the compilation_artist for items in the spotify starred
-	# playlist.
-#	starred_artist_override = false
-
 	# Similar to the different artists in spotify playlists, the playlist items
 	# belong to different albums, and if you do not want every album to be listed
 	# when browsing in Remote, you can set the album_override flag to true. This
@@ -210,10 +205,6 @@ spotify {
 	# the starred playlist. Notice that if an item is in more than one playlist,
 	# it will only appear in one album when browsing (in which album is random).
 #	album_override = false
-
-	# Like album_override, the starred_album_override flag can be set to true,
-	# in order to use the playlist name as album name.
-#	starred_album_override = false
 }
 
 # MPD configuration (only have effect if MPD enabled - see README/INSTALL)

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -119,9 +119,7 @@ static cfg_opt_t sec_spotify[] =
     CFG_INT("bitrate", 0, CFGF_NONE),
     CFG_BOOL("base_playlist_disable", cfg_false, CFGF_NONE),
     CFG_BOOL("artist_override", cfg_false, CFGF_NONE),
-    CFG_BOOL("starred_artist_override", cfg_false, CFGF_NONE),
     CFG_BOOL("album_override", cfg_false, CFGF_NONE),
-    CFG_BOOL("starred_album_override", cfg_false, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -489,9 +489,7 @@ spotify_metadata_get(sp_track *track, struct media_file_info *mfi, const char *p
 {
   cfg_t *spotify_cfg;
   bool artist_override;
-  bool starred_artist_override;
   bool album_override;
-  bool starred_album_override;
   sp_album *album;
   sp_artist *artist;
   sp_albumtype albumtype;
@@ -501,9 +499,7 @@ spotify_metadata_get(sp_track *track, struct media_file_info *mfi, const char *p
 
   spotify_cfg = cfg_getsec(cfg, "spotify");
   artist_override = cfg_getbool(spotify_cfg, "artist_override");
-  starred_artist_override = cfg_getbool(spotify_cfg, "starred_artist_override");
   album_override = cfg_getbool(spotify_cfg, "album_override");
-  starred_album_override = cfg_getbool(spotify_cfg, "starred_album_override");
 
   album = fptr_sp_track_album(track);
   if (!album)
@@ -523,11 +519,9 @@ spotify_metadata_get(sp_track *track, struct media_file_info *mfi, const char *p
    * - starred_artist_override in config is set to true and track is part of the starred playlist
    */
   compilation = ((albumtype == SP_ALBUMTYPE_COMPILATION)
-		  || (starred && starred_artist_override)
-		  || (!starred && artist_override));
+		  || artist_override);
 
-  if ((starred && starred_album_override)
-      || (!starred && album_override))
+  if (album_override)
     albumname = strdup(pltitle);
   else
     albumname = strdup(fptr_sp_album_name(album));


### PR DESCRIPTION
Spotify removed the "starred" playlist and it is not possible anymore to add new songs to it.
The config options to exclude the starred songs form the artist/album override are useless now and this pr removes them.

I am not using the "artist_override" and "album_override" option anymore as it only made sense for me as long as there was a possibility to exclude songs from it. I am not sure if it would be best to completely remove them?