### PR TITLE
Set thread names

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -30,6 +30,9 @@
 #include <time.h>
 #include <string.h>
 #include <pthread.h>
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+# include <pthread_np.h>
+#endif
 
 #include <event2/event.h>
 
@@ -1847,6 +1850,12 @@ cache_init(void)
 
       goto thread_fail;
     }
+
+#if defined(__linux__)
+  pthread_setname_np(tid_cache, "cache");
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+  pthread_set_name_np(tid_cache, "cache");
+#endif
 
   return 0;
   

--- a/src/filescanner.c
+++ b/src/filescanner.c
@@ -47,6 +47,7 @@
 #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 # include <sys/time.h>
 # include <sys/event.h>
+# include <pthread_np.h>
 #endif
 
 #ifdef HAVE_REGEX_H
@@ -2312,6 +2313,12 @@ filescanner_init(void)
 
       goto thread_fail;
     }
+
+#if defined(__linux__)
+  pthread_setname_np(tid_scan, "filescanner");
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+  pthread_set_name_np(tid_scan, "filescanner");
+#endif
 
   return 0;
 

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -28,6 +28,9 @@
 #include <limits.h>
 #include <errno.h>
 #include <pthread.h>
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+# include <pthread_np.h>
+#endif
 #include <time.h>
 #include <sys/param.h>
 #include <sys/queue.h>
@@ -1393,6 +1396,12 @@ httpd_init(void)
 
       goto thread_fail;
     }
+
+#if defined(__linux__)
+  pthread_setname_np(tid_httpd, "httpd");
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+  pthread_set_name_np(tid_httpd, "httpd");
+#endif
 
   return 0;
 

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -47,6 +47,7 @@
 
 #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 # include <netinet/in.h>
+# include <pthread_np.h>
 #endif
 
 #include "logger.h"
@@ -4908,6 +4909,12 @@ int mpd_init(void)
 
       goto thread_fail;
     }
+
+#if defined(__linux__)
+  pthread_setname_np(tid_mpd, "mpd");
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+  pthread_set_name_np(tid_mpd, "mpd");
+#endif
 
   idle_clients = NULL;
   listener_add(mpd_listener_cb, LISTENER_PLAYER | LISTENER_PLAYLIST | LISTENER_VOLUME | LISTENER_SPEAKER | LISTENER_OPTIONS);

--- a/src/player.c
+++ b/src/player.c
@@ -3386,9 +3386,7 @@ playerqueue_add(struct player_command *cmd)
       queue_shuffle(queue, cur_id);
     }
 
-  //TODO [refactor] Unnecessary if, always set plid to 0 after adding items
-  if (cur_plid != 0)
-    cur_plid = 0;
+  cur_plid = 0;
   cur_plversion++;
 
   listener_notify(LISTENER_PLAYLIST);
@@ -3411,9 +3409,7 @@ playerqueue_add_next(struct player_command *cmd)
   if (shuffle)
     queue_shuffle(queue, cur_id);
 
-  //TODO [refactor] Unnecessary if, always set plid to 0 after adding items
-  if (cur_plid != 0)
-    cur_plid = 0;
+  cur_plid = 0;
   cur_plversion++;
 
   listener_notify(LISTENER_PLAYLIST);

--- a/src/player.c
+++ b/src/player.c
@@ -36,6 +36,7 @@
 # include <sys/timerfd.h>
 #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 # include <signal.h>
+# include <pthread_np.h>
 #endif
 
 #include <event2/event.h>
@@ -4727,6 +4728,12 @@ player_init(void)
       DPRINTF(E_FATAL, L_PLAYER, "Could not spawn player thread: %s\n", strerror(errno));
       goto thread_fail;
     }
+#if defined(__linux__)
+  pthread_setname_np(tid_player, "player");
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+  pthread_set_name_np(tid_player, "player");
+#endif
+
 
   return 0;
 

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -37,6 +37,9 @@
 #include <sys/queue.h>
 #include <time.h>
 #include <pthread.h>
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+# include <pthread_np.h>
+#endif
 
 #include <dlfcn.h>
 #include <libspotify/api.h>
@@ -2273,6 +2276,12 @@ spotify_init(void)
       DPRINTF(E_FATAL, L_SPOTIFY, "Could not spawn Spotify thread: %s\n", strerror(errno));
       goto thread_fail;
     }
+
+#if defined(__linux__)
+  pthread_setname_np(tid_spotify, "spotify");
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+  pthread_set_name_np(tid_spotify, "spotify");
+#endif
 
   DPRINTF(E_DBG, L_SPOTIFY, "Spotify init complete\n");
   return 0;

--- a/src/worker.c
+++ b/src/worker.c
@@ -30,6 +30,9 @@
 #include <string.h>
 #include <errno.h>
 #include <pthread.h>
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+# include <pthread_np.h>
+#endif
 
 #include <event2/event.h>
 
@@ -331,6 +334,12 @@ worker_init(void)
 
       goto thread_fail;
     }
+
+#if defined(__linux__)
+  pthread_setname_np(tid_worker, "worker");
+#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+  pthread_set_name_np(tid_worker, "worker");
+#endif
 
   return 0;
   


### PR DESCRIPTION
This makes identifying the different threads a little bit easier. And fixes two todos in player (unnecessary check removed).
