### PR TITLE
Allow to add Access-Control-Allow-Origin header to responses

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -55,6 +55,7 @@ static cfg_opt_t sec_general[] =
     CFG_BOOL("ipv6", cfg_true, CFGF_NONE),
     CFG_STR("cache_path", STATEDIR "/cache/" PACKAGE "/cache.db", CFGF_NONE),
     CFG_INT("cache_daap_threshold", 1000, CFGF_NONE),
+    CFG_STR("allow_origin", NULL, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -678,6 +678,7 @@ httpd_send_reply(struct evhttp_request *req, int code, const char *reason, struc
   int flush;
   int zret;
   int ret;
+  char *origin;
 
   if (!req)
     return;
@@ -773,6 +774,10 @@ httpd_send_reply(struct evhttp_request *req, int code, const char *reason, struc
   deflateEnd(&strm);
 
   headers = evhttp_request_get_output_headers(req);
+
+  origin = cfg_getstr(cfg_getsec(cfg, "general"), "allow_origin");
+  if (origin && strlen(origin))
+      evhttp_add_header(headers, "Access-Control-Allow-Origin", origin);
 
   evhttp_add_header(headers, "Content-Encoding", "gzip");
   evhttp_send_reply(req, code, reason, gzbuf);


### PR DESCRIPTION
Add a new general config setting allow_origin that is included as
Access-Control-Allow-Origin header in http responses. This allows to make http
request against forked-daapd from browsers with enabled CORS
(https://www.w3.org/TR/cors/) via JavaScript XMLHttpRequest.

Per default the setting is not defined and no Access-Control-Allow-Origin header
is included in the response.