### PR TITLE
Refactor thread exit handling

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -1658,8 +1658,8 @@ cache_deinit(void)
   if (!g_initialized)
     return;
 
-  commands_cmdloop_exit(cmdbase);
   g_initialized = 0;
+  commands_base_destroy(cmdbase);
 
   ret = pthread_join(tid_cache, NULL);
   if (ret != 0)
@@ -1670,7 +1670,4 @@ cache_deinit(void)
 
   // Free event base (should free events too)
   event_base_free(evbase_cache);
-
-  // Close pipes and free command base
-  commands_base_free(cmdbase);
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -379,8 +379,9 @@ cmdloop_exit(void *arg, int *retval)
 }
 
 void
-commands_cmdloop_exit(struct commands_base *cmdbase)
+commands_base_destroy(struct commands_base *cmdbase)
 {
   commands_exec_sync(cmdbase, cmdloop_exit, NULL, cmdbase);
+  commands_base_free(cmdbase);
 }
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -64,6 +64,6 @@ int
 commands_exec_async(struct commands_base *cmdbase, command_function func, void *arg);
 
 void
-commands_cmdloop_exit(struct commands_base *cmdbase);
+commands_base_destroy(struct commands_base *cmdbase);
 
 #endif /* SRC_COMMANDS_H_ */

--- a/src/commands.h
+++ b/src/commands.h
@@ -39,11 +39,14 @@ enum command_state {
  */
 typedef enum command_state (*command_function)(void *arg, int *ret);
 
+typedef void (*command_exit_cb)(void);
+
+
 struct commands_base;
 
 
 struct commands_base *
-commands_base_new(struct event_base *evbase);
+commands_base_new(struct event_base *evbase, command_exit_cb exit_cb);
 
 int
 commands_base_free(struct commands_base *cmdbase);
@@ -60,5 +63,7 @@ commands_exec_sync(struct commands_base *cmdbase, command_function func, command
 int
 commands_exec_async(struct commands_base *cmdbase, command_function func, void *arg);
 
+void
+commands_cmdloop_exit(struct commands_base *cmdbase);
 
 #endif /* SRC_COMMANDS_H_ */

--- a/src/filescanner.c
+++ b/src/filescanner.c
@@ -104,12 +104,10 @@ struct stacked_dir {
   struct stacked_dir *next;
 };
 
-static int exit_pipe[2];
 static int scan_exit;
 static int inofd;
 static struct event_base *evbase_scan;
 static struct event *inoev;
-static struct event *exitev;
 static pthread_t tid_scan;
 static struct deferred_pl *playlists;
 static struct stacked_dir *dirstack;
@@ -1911,13 +1909,6 @@ inofd_event_unset(void)
 }
 
 /* Thread: scan */
-static void
-exit_cb(int fd, short event, void *arg)
-{
-  event_base_loopbreak(evbase_scan);
-
-  scan_exit = 1;
-}
 
 static enum command_state
 filescanner_initscan(void *arg, int *retval)
@@ -2002,32 +1993,13 @@ filescanner_init(void)
       return -1;
     }
 
-#ifdef HAVE_PIPE2
-  ret = pipe2(exit_pipe, O_CLOEXEC);
-#else
-  ret = pipe(exit_pipe);
-#endif
-  if (ret < 0)
-    {
-      DPRINTF(E_FATAL, L_SCAN, "Could not create pipe: %s\n", strerror(errno));
-
-      goto pipe_fail;
-    }
-
-  exitev = event_new(evbase_scan, exit_pipe[0], EV_READ, exit_cb, NULL);
-  if (!exitev || (event_add(exitev, NULL) < 0))
-    {
-      DPRINTF(E_LOG, L_SCAN, "Could not create/add command event\n");
-      goto exitev_fail;
-    }
-
   ret = inofd_event_set();
   if (ret < 0)
     {
       goto ino_fail;
     }
 
-  cmdbase = commands_base_new(evbase_scan);
+  cmdbase = commands_base_new(evbase_scan, NULL);
 
   ret = pthread_create(&tid_scan, NULL, filescanner, NULL);
   if (ret != 0)
@@ -2048,11 +2020,7 @@ filescanner_init(void)
  thread_fail:
   commands_base_free(cmdbase);
   close(inofd);
- exitev_fail:
  ino_fail:
-  close(exit_pipe[0]);
-  close(exit_pipe[1]);
- pipe_fail:
   event_base_free(evbase_scan);
 
   return -1;
@@ -2063,16 +2031,8 @@ void
 filescanner_deinit(void)
 {
   int ret;
-  int dummy = 42;
 
-  ret = write(exit_pipe[1], &dummy, sizeof(dummy));
-  if (ret != sizeof(dummy))
-    {
-      DPRINTF(E_FATAL, L_SCAN, "Could not write to exit fd: %s\n", strerror(errno));
-
-      return;
-    }
-
+  commands_cmdloop_exit(cmdbase);
   scan_exit = 1;
 
   ret = pthread_join(tid_scan, NULL);
@@ -2087,6 +2047,4 @@ filescanner_deinit(void)
 
   event_base_free(evbase_scan);
   commands_base_free(cmdbase);
-  close(exit_pipe[0]);
-  close(exit_pipe[1]);
 }

--- a/src/filescanner.c
+++ b/src/filescanner.c
@@ -2032,8 +2032,8 @@ filescanner_deinit(void)
 {
   int ret;
 
-  commands_cmdloop_exit(cmdbase);
   scan_exit = 1;
+  commands_base_destroy(cmdbase);
 
   ret = pthread_join(tid_scan, NULL);
   if (ret != 0)
@@ -2046,5 +2046,4 @@ filescanner_deinit(void)
   inofd_event_unset();
 
   event_base_free(evbase_scan);
-  commands_base_free(cmdbase);
 }

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4782,7 +4782,7 @@ void mpd_deinit(void)
       return;
     }
 
-  commands_cmdloop_exit(cmdbase);
+  commands_base_destroy(cmdbase);
 
   ret = pthread_join(tid_mpd, NULL);
   if (ret != 0)
@@ -4808,7 +4808,4 @@ void mpd_deinit(void)
 
   // Free event base (should free events too)
   event_base_free(evbase_mpd);
-
-  // Close pipes and free command base
-  commands_base_free(cmdbase);
 }

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -68,8 +68,6 @@
 static pthread_t tid_mpd;
 
 static struct event_base *evbase_mpd;
-static int g_exit_pipe[2];
-static struct event *g_exitev;
 
 static struct commands_base *cmdbase;
 
@@ -192,17 +190,6 @@ struct idle_client
 struct idle_client *idle_clients;
 
 
-static void
-thread_exit(void)
-{
-  int dummy = 42;
-
-  DPRINTF(E_DBG, L_MPD, "Killing mpd thread\n");
-
-  if (write(g_exit_pipe[1], &dummy, sizeof(dummy)) != sizeof(dummy))
-    DPRINTF(E_LOG, L_MPD, "Could not write to exit fd: %s\n", strerror(errno));
-}
-
 
 /* Thread: mpd */
 static void *
@@ -223,21 +210,6 @@ mpd(void *arg)
   db_perthread_deinit();
 
   pthread_exit(NULL);
-}
-
-static void
-exit_cb(int fd, short what, void *arg)
-{
-  int dummy;
-  int ret;
-
-  ret = read(g_exit_pipe[0], &dummy, sizeof(dummy));
-  if (ret != sizeof(dummy))
-    DPRINTF(E_LOG, L_MPD, "Error reading from exit pipe\n");
-
-  event_base_loopbreak(evbase_mpd);
-
-  event_add(g_exitev, NULL);
 }
 
 static void
@@ -4670,17 +4642,6 @@ int mpd_init(void)
 
   v6enabled = cfg_getbool(cfg_getsec(cfg, "general"), "ipv6");
 
-#ifdef HAVE_PIPE2
-  ret = pipe2(g_exit_pipe, O_CLOEXEC);
-#else
-  ret = pipe(g_exit_pipe);
-#endif
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_MPD, "Could not create pipe: %s\n", strerror(errno));
-      goto exit_fail;
-    }
-
   evbase_mpd = event_base_new();
   if (!evbase_mpd)
     {
@@ -4688,16 +4649,7 @@ int mpd_init(void)
       goto evbase_fail;
     }
 
-  g_exitev = event_new(evbase_mpd, g_exit_pipe[0], EV_READ, exit_cb, NULL);
-  if (!g_exitev)
-    {
-      DPRINTF(E_LOG, L_MPD, "Could not create exit event\n");
-      goto evnew_fail;
-    }
-
-  event_add(g_exitev, NULL);
-
-  cmdbase = commands_base_new(evbase_mpd);
+  cmdbase = commands_base_new(evbase_mpd, NULL);
 
   if (v6enabled)
     {
@@ -4808,15 +4760,10 @@ int mpd_init(void)
   evconnlistener_free(listener);
  connew_fail:
   commands_base_free(cmdbase);
- evnew_fail:
   event_base_free(evbase_mpd);
   evbase_mpd = NULL;
 
  evbase_fail:
-  close(g_exit_pipe[0]);
-  close(g_exit_pipe[1]);
-
- exit_fail:
   return -1;
 }
 
@@ -4835,7 +4782,7 @@ void mpd_deinit(void)
       return;
     }
 
-  thread_exit();
+  commands_cmdloop_exit(cmdbase);
 
   ret = pthread_join(tid_mpd, NULL);
   if (ret != 0)
@@ -4864,6 +4811,4 @@ void mpd_deinit(void)
 
   // Close pipes and free command base
   commands_base_free(cmdbase);
-  close(g_exit_pipe[0]);
-  close(g_exit_pipe[1]);
 }

--- a/src/player.c
+++ b/src/player.c
@@ -4123,8 +4123,8 @@ player_deinit(void)
 {
   int ret;
 
-  commands_cmdloop_exit(cmdbase);
   player_exit = 1;
+  commands_base_destroy(cmdbase);
 
   ret = pthread_join(tid_player, NULL);
   if (ret != 0)
@@ -4149,6 +4149,4 @@ player_deinit(void)
   outputs_deinit();
 
   event_base_free(evbase_player);
-
-  commands_base_free(cmdbase);
 }

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -1606,6 +1606,7 @@ exit_cb()
 {
   fptr_sp_session_player_unload(g_sess);
   fptr_sp_session_logout(g_sess);
+  g_state = SPOTIFY_STATE_INACTIVE;
 }
 
 /* Process events when timeout expires or triggered by libspotify's notify_main_thread */
@@ -2086,7 +2087,7 @@ spotify_deinit(void)
   /* Send exit signal to thread (if active) */
   if (g_state != SPOTIFY_STATE_INACTIVE)
     {
-      commands_cmdloop_exit(cmdbase);
+      commands_base_destroy(cmdbase);
       g_state = SPOTIFY_STATE_INACTIVE;
 
       ret = pthread_join(tid_spotify, NULL);
@@ -2103,8 +2104,7 @@ spotify_deinit(void)
   /* Free event base (should free events too) */
   event_base_free(evbase_spotify);
 
-  /* Close pipes and free command base */
-  commands_base_free(cmdbase);
+  /* Close pipes */
   close(g_notify_pipe[0]);
   close(g_notify_pipe[1]);
 

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -114,9 +114,7 @@ static pthread_cond_t login_cond;
 
 // Event base, pipes and events
 struct event_base *evbase_spotify;
-static int g_exit_pipe[2];
 static int g_notify_pipe[2];
-static struct event *g_exitev;
 static struct event *g_notifyev;
 
 static struct commands_base *cmdbase;
@@ -382,21 +380,6 @@ fptr_assign_all()
   return -1;
 }
 // End of ugly part
-
-
-/* ---------------------------- COMMAND EXECUTION -------------------------- */
-
-/* Thread: main and filescanner */
-static void
-thread_exit(void)
-{
-  int dummy = 42;
-
-  DPRINTF(E_DBG, L_SPOTIFY, "Killing Spotify thread\n");
-
-  if (write(g_exit_pipe[1], &dummy, sizeof(dummy)) != sizeof(dummy))
-    DPRINTF(E_LOG, L_SPOTIFY, "Could not write to exit fd: %s\n", strerror(errno));
-}
 
 
 /* --------------------------  PLAYLIST HELPERS    ------------------------- */
@@ -1619,23 +1602,10 @@ spotify(void *arg)
 }
 
 static void
-exit_cb(int fd, short what, void *arg)
+exit_cb()
 {
-  int dummy;
-  int ret;
-
-  ret = read(g_exit_pipe[0], &dummy, sizeof(dummy));
-  if (ret != sizeof(dummy))
-    DPRINTF(E_LOG, L_SPOTIFY, "Error reading from exit pipe\n");
-
   fptr_sp_session_player_unload(g_sess);
   fptr_sp_session_logout(g_sess);
-
-  event_base_loopbreak(evbase_spotify);
-
-  g_state = SPOTIFY_STATE_INACTIVE;
-
-  event_add(g_exitev, NULL);
 }
 
 /* Process events when timeout expires or triggered by libspotify's notify_main_thread */
@@ -1977,17 +1947,6 @@ spotify_init(void)
     goto assign_fail;
 
 #ifdef HAVE_PIPE2
-  ret = pipe2(g_exit_pipe, O_CLOEXEC);
-#else
-  ret = pipe(g_exit_pipe);
-#endif
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_SPOTIFY, "Could not create pipe: %s\n", strerror(errno));
-      goto exit_fail;
-    }
-
-#ifdef HAVE_PIPE2
   ret = pipe2(g_notify_pipe, O_CLOEXEC);
 #else
   ret = pipe(g_notify_pipe);
@@ -2005,13 +1964,6 @@ spotify_init(void)
       goto evbase_fail;
     }
 
-  g_exitev = event_new(evbase_spotify, g_exit_pipe[0], EV_READ, exit_cb, NULL);
-  if (!g_exitev)
-    {
-      DPRINTF(E_LOG, L_SPOTIFY, "Could not create exit event\n");
-      goto evnew_fail;
-    }
-
   g_notifyev = event_new(evbase_spotify, g_notify_pipe[0], EV_READ | EV_TIMEOUT, notify_cb, NULL);
   if (!g_notifyev)
     {
@@ -2019,11 +1971,10 @@ spotify_init(void)
       goto evnew_fail;
     }
 
-  event_add(g_exitev, NULL);
   event_add(g_notifyev, NULL);
 
 
-  cmdbase = commands_base_new(evbase_spotify);
+  cmdbase = commands_base_new(evbase_spotify, exit_cb);
   if (!cmdbase)
     {
       DPRINTF(E_LOG, L_SPOTIFY, "Could not create command base\n");
@@ -2116,10 +2067,6 @@ spotify_init(void)
   close(g_notify_pipe[1]);
 
  notify_fail:
-  close(g_exit_pipe[0]);
-  close(g_exit_pipe[1]);
-
- exit_fail:
  assign_fail:
   dlclose(g_libhandle);
   g_libhandle = NULL;
@@ -2139,7 +2086,8 @@ spotify_deinit(void)
   /* Send exit signal to thread (if active) */
   if (g_state != SPOTIFY_STATE_INACTIVE)
     {
-      thread_exit();
+      commands_cmdloop_exit(cmdbase);
+      g_state = SPOTIFY_STATE_INACTIVE;
 
       ret = pthread_join(tid_spotify, NULL);
       if (ret != 0)
@@ -2159,8 +2107,6 @@ spotify_deinit(void)
   commands_base_free(cmdbase);
   close(g_notify_pipe[0]);
   close(g_notify_pipe[1]);
-  close(g_exit_pipe[0]);
-  close(g_exit_pipe[1]);
 
   /* Destroy locks */
   pthread_cond_destroy(&login_cond);

--- a/src/worker.c
+++ b/src/worker.c
@@ -199,7 +199,6 @@ worker_init(void)
   
  thread_fail:
   commands_base_free(cmdbase);
- evnew_fail:
   event_base_free(evbase_worker);
   evbase_worker = NULL;
 
@@ -212,8 +211,8 @@ worker_deinit(void)
 {
   int ret;
 
-  commands_cmdloop_exit(cmdbase);
   g_initialized = 0;
+  commands_base_destroy(cmdbase);
 
   ret = pthread_join(tid_worker, NULL);
   if (ret != 0)
@@ -224,7 +223,4 @@ worker_deinit(void)
 
   // Free event base (should free events too)
   event_base_free(evbase_worker);
-
-  // Close pipes and free command base
-  commands_base_free(cmdbase);
 }


### PR DESCRIPTION
This removes the exit pipes from the various places (e. g. player, filescanner, ...) and moves the thread exit logic to the commands util. 

@ejurgensen I hope, understood your comment regarding the naming correctly.