### PR TITLE
Allow anonymous access to /content-codes url

### DIFF
--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -2776,6 +2776,7 @@ daap_request(struct evhttp_request *req)
   /* No authentication for these URIs */
   if ((strcmp(uri, "/server-info") == 0)
       || (strcmp(uri, "/logout") == 0)
+      || (strcmp(uri, "/content-codes") == 0)
       || (strncmp(uri, "/databases/1/items/", strlen("/databases/1/items/")) == 0))
     passwd = NULL;
 


### PR DESCRIPTION
The content-codes url provides a mapping of dmap content codes to names, it's
types and sizes. It doesn't contain any private information and therefore should
be available to anonymous users too.