### PR TITLE
[filescanner] Fix building directory structure with trailing '/'

### DIFF
--- a/src/filescanner.c
+++ b/src/filescanner.c
@@ -1092,6 +1092,12 @@ process_parent_directories(char *path)
   ptr = path + 1;
   while (ptr && (ptr = strchr(ptr, '/')))
     {
+      if ((ptr - path) > 0)
+	{
+	  // Do not process trailing '/'
+	  break;
+	}
+
       strncpy(buf, path, (ptr - path));
       buf[(ptr - path)] = '\0';
 


### PR DESCRIPTION
Library directories with a trailing '/'  in the config file (like '/srv/music/' instead of '/srv/musc') lead to an unbrowsable directory structure. The trailing '/' resulted in an update to the library directory in the directories table with a parent_id pointing to itself.