### PR TITLE
[filescanner] Fix building directory structure with trailing '/'

### DIFF
--- a/src/filescanner.c
+++ b/src/filescanner.c
@@ -1092,7 +1092,7 @@ process_parent_directories(char *path)
   ptr = path + 1;
   while (ptr && (ptr = strchr(ptr, '/')))
     {
-      if ((ptr - path) > 0)
+      if (strlen(ptr) <= 1)
 	{
 	  // Do not process trailing '/'
 	  break;


### PR DESCRIPTION
@ejurgensen I made a mistake in PR #277. The condition to break out of the loop is wrong and skips to many directories (somehow ympd allows to browse the directories even if the parent directories are missing ...). This pr should fix it. (I tested with ympd and mpc and validated the sqlite3 db.)