### PR TITLE
Fix return values in command functions

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -2346,7 +2346,8 @@ playback_start_item(union player_arg *cmdarg, int *retval, struct queue_item *qi
       if (ret < 0)
 	{
 	  playback_abort();
-	  return -1;
+	  *retval = -1;
+	  return COMMAND_END;
 	}
     }
 

--- a/src/player.c
+++ b/src/player.c
@@ -2938,7 +2938,10 @@ volume_setrel_speaker(void *arg, int *retval)
 	continue;
 
       if (!device->selected)
-	return 0;
+	{
+	  *retval = 0;
+	  return COMMAND_END;
+	}
 
       device->relvol = relvol;
       device->volume = rel_to_vol(relvol);

--- a/src/player.c
+++ b/src/player.c
@@ -3020,7 +3020,10 @@ repeat_set(void *arg, int *retval)
   union player_arg *cmdarg = arg;
 
   if (cmdarg->mode == repeat)
-    return 0;
+    {
+      *retval = 0;
+      return COMMAND_END;
+    }
 
   switch (cmdarg->mode)
     {

--- a/src/player.c
+++ b/src/player.c
@@ -2530,7 +2530,8 @@ playback_prev_bh(void *arg, int *retval)
 	{
 	  playback_abort();
 
-	  return -1;
+          *retval = -1;
+          return COMMAND_END;
 	}
     }
   else

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -1068,7 +1068,8 @@ playback_eot(void *arg, int *retval)
   if (SP_ERROR_OK != err)
     {
       DPRINTF(E_LOG, L_SPOTIFY, "Playback end of track failed: %s\n", fptr_sp_error_message(err));
-      return -1;
+      *retval = -1;
+      return COMMAND_END;
     }
 
   g_state = SPOTIFY_STATE_STOPPING;


### PR DESCRIPTION
I hope, i found all command functions not returning COMMAND_END or COMMAND_PENDING. I also changed the behavior, if a command function does not return a valid value (see last commit).