### PR TITLE
[ALSA] Add mixer_device configuration file option for ALSA

### DIFF
--- a/forked-daapd.conf
+++ b/forked-daapd.conf
@@ -163,12 +163,16 @@ audio {
 	# Type of the output (alsa, pulseaudio or dummy)
 #	type = "alsa"
 
-	# Audio device name for local audio output - ALSA only
+	# Audio PCM device name for local audio output - ALSA only
 #	card = "default"
 
 	# Mixer channel to use for volume control - ALSA only
 	# If not set, PCM will be used if available, otherwise Master.
 #	mixer = ""
+
+	# Mixer device to use for volume control - ALSA only
+	# If not set, the value for "card" will be used.
+#	mixer_device = ""
 
 	# Syncronization - ALSA only
 	# If your local audio is out of sync with AirPlay, you can adjust this

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -99,6 +99,7 @@ static cfg_opt_t sec_audio[] =
     CFG_STR("type", NULL, CFGF_NONE),
     CFG_STR("card", "default", CFGF_NONE),
     CFG_STR("mixer", NULL, CFGF_NONE),
+    CFG_STR("mixer_device", NULL, CFGF_NONE),
     CFG_INT("offset", 0, CFGF_NONE),
     CFG_END()
   };

--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -49,6 +49,7 @@
 // TODO Unglobalise these and add support for multiple sound cards
 static char *card_name;
 static char *mixer_name;
+static char *mixer_device_name;
 static snd_pcm_t *hdl;
 static snd_mixer_t *mixer_hdl;
 static snd_mixer_elem_t *vol_elem;
@@ -316,7 +317,7 @@ mixer_open(void)
       return -1;
     }
 
-  ret = snd_mixer_attach(mixer_hdl, card_name);
+  ret = snd_mixer_attach(mixer_hdl, mixer_device_name);
   if (ret < 0)
     {
       DPRINTF(E_LOG, L_LAUDIO, "Failed to attach mixer: %s\n", snd_strerror(ret));
@@ -989,6 +990,9 @@ alsa_init(void)
 
   card_name = cfg_getstr(cfg_audio, "card");
   mixer_name = cfg_getstr(cfg_audio, "mixer");
+  mixer_device_name = cfg_getstr(cfg_audio, "mixer_device");
+  if (mixer_device_name == NULL || strlen(mixer_device_name) == 0)
+    mixer_device_name = card_name;
   nickname = cfg_getstr(cfg_audio, "nickname");
   offset = cfg_getint(cfg_audio, "offset");
   if (abs(offset) > 44100)


### PR DESCRIPTION
Support a separate mixer_device configuration file option for
advanced ALSA configurations. Previously, ALSA local output
happened to work becasue "default" is valid as both a PCM and a
mixer. Now you can separately specify the device name for PCM
output and mixer operations.

In my setup, I am using the following:
card = "default:CARD=NVidia"
mixer = "Front"
mixer_device = "hw:CARD=NVidia"