### PR TITLE
Fix adding items while playing through dacp clients

### DIFF
--- a/src/commands.h
+++ b/src/commands.h
@@ -15,6 +15,10 @@ enum command_state {
  * If the function has pending events to complete, it needs to return 
  * COMMAND_PENDING with 'ret' set to the number of pending events to wait for.
  *
+ * If the function returns with  COMMAND_END, command execution will proceed
+ * with the "bottem half" function (if passed to the command_exec function) only
+ * if 'ret' is 0.
+ *
  * @param arg Opaque pointer passed by command_exec_sync or command_exec_async
  * @param ret Pointer to the return value for the caller of the command
  * @return    COMMAND_END if there are no pending events (function execution is 

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1122,7 +1122,7 @@ mpd_command_pause(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
   else
     ret = player_playback_start(NULL);
 
-  if (ret != 0)
+  if (ret < 0)
     {
       ret = asprintf(errmsg, "Failed to pause playback");
       if (ret < 0)
@@ -1177,7 +1177,7 @@ mpd_command_play(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
   else
     ret = player_playback_start(NULL);
 
-  if (ret != 0)
+  if (ret < 0)
     {
       ret = asprintf(errmsg, "Failed to start playback");
       if (ret < 0)
@@ -1227,7 +1227,7 @@ mpd_command_playid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
   else
     ret = player_playback_start(NULL);
 
-  if (ret != 0)
+  if (ret < 0)
     {
       ret = asprintf(errmsg, "Failed to start playback");
       if (ret < 0)

--- a/src/player.c
+++ b/src/player.c
@@ -2316,7 +2316,7 @@ playback_start_item(union player_arg *cmdarg, int *retval, struct queue_item *qi
 
       status_update(player_state);
 
-      *retval = 0;
+      *retval = 1; // Value greater 0 will prevent execution of the bottom half function
       return COMMAND_END;
     }
 
@@ -2673,7 +2673,8 @@ playback_pause(void *arg, int *retval)
       DPRINTF(E_LOG, L_PLAYER, "Could not retrieve current position for pause\n");
 
       playback_abort();
-      return -1;
+      *retval = -1;
+      return COMMAND_END;
     }
 
   /* Make sure playback is still running after source_check() */


### PR DESCRIPTION
This is a nasty one ... found it because it resulted in segfaults in my persistentqueue branch. Not sure if it could result in a segfault on current master, but it is the reason why playback shortly stops while adding new songs.

The cause is, that calling playback_start can return early if player is already playing. After this early return the bottom half function should not be executed.  