### PR TITLE
Reduce dependency to media file in stream setup methods

### DIFF
--- a/src/httpd.c
+++ b/src/httpd.c
@@ -491,7 +491,7 @@ httpd_stream_file(struct evhttp_request *req, int id)
 
       stream_cb = stream_chunk_xcode_cb;
 
-      st->xcode = transcode_setup(mfi, XCODE_PCM16_HEADER, &st->size);
+      st->xcode = transcode_setup(mfi->data_kind, mfi->path, mfi->song_length, XCODE_PCM16_HEADER, &st->size);
       if (!st->xcode)
 	{
 	  DPRINTF(E_WARN, L_HTTPD, "Transcoding setup failed, aborting streaming\n");

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -41,36 +41,36 @@ static int g_fd = -1;
 static uint16_t *g_buf = NULL;
 
 int
-pipe_setup(struct media_file_info *mfi)
+pipe_setup(const char *path)
 {
   struct stat sb;
 
-  if (!mfi->path)
+  if (!path)
     {
       DPRINTF(E_LOG, L_PLAYER, "Path to pipe is NULL\n");
       return -1;
     }
 
-  DPRINTF(E_DBG, L_PLAYER, "Setting up pipe: %s\n", mfi->path);
+  DPRINTF(E_DBG, L_PLAYER, "Setting up pipe: %s\n", path);
 
-  if (lstat(mfi->path, &sb) < 0)
+  if (lstat(path, &sb) < 0)
     {
-      DPRINTF(E_LOG, L_PLAYER, "Could not lstat() '%s': %s\n", mfi->path, strerror(errno));
+      DPRINTF(E_LOG, L_PLAYER, "Could not lstat() '%s': %s\n", path, strerror(errno));
       return -1;
     }
 
   if (!S_ISFIFO(sb.st_mode))
     {
-      DPRINTF(E_LOG, L_PLAYER, "Source type is pipe, but path is not a fifo: %s\n", mfi->path);
+      DPRINTF(E_LOG, L_PLAYER, "Source type is pipe, but path is not a fifo: %s\n", path);
       return -1;
     }
 
   pipe_cleanup();
 
-  g_fd = open(mfi->path, O_RDONLY | O_NONBLOCK);
+  g_fd = open(path, O_RDONLY | O_NONBLOCK);
   if (g_fd < 0)
     {
-      DPRINTF(E_LOG, L_PLAYER, "Could not open pipe for reading '%s': %s\n", mfi->path, strerror(errno));
+      DPRINTF(E_LOG, L_PLAYER, "Could not open pipe for reading '%s': %s\n", path, strerror(errno));
       return -1;
     }
 

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -3,10 +3,9 @@
 #define __PIPE_H__
 
 #include <event2/buffer.h>
-#include "db.h"
 
 int
-pipe_setup(struct media_file_info *mfi);
+pipe_setup(const char *path);
 
 void
 pipe_cleanup(void);

--- a/src/player.c
+++ b/src/player.c
@@ -684,7 +684,7 @@ stream_setup(struct player_source *ps, struct media_file_info *mfi)
 
       case DATA_KIND_SPOTIFY:
 #ifdef HAVE_SPOTIFY_H
-	ret = spotify_playback_setup(mfi);
+	ret = spotify_playback_setup(mfi->path);
 #else
 	DPRINTF(E_LOG, L_PLAYER, "Player source has data kind 'spotify' (%d), but forked-daapd is compiled without spotify support - cannot setup source '%s' (%s)\n",
 		    ps->data_kind, mfi->title, mfi->path);

--- a/src/player.c
+++ b/src/player.c
@@ -693,7 +693,7 @@ stream_setup(struct player_source *ps, struct media_file_info *mfi)
 	break;
 
       case DATA_KIND_PIPE:
-	ret = pipe_setup(mfi);
+	ret = pipe_setup(mfi->path);
 	break;
 
       default:

--- a/src/player.c
+++ b/src/player.c
@@ -666,7 +666,7 @@ stream_setup(struct player_source *ps, struct media_file_info *mfi)
   switch (ps->data_kind)
     {
       case DATA_KIND_FILE:
-	ps->xcode = transcode_setup(mfi, XCODE_PCM16_NOHEADER, NULL);
+	ps->xcode = transcode_setup(mfi->data_kind, mfi->path, mfi->song_length, XCODE_PCM16_NOHEADER, NULL);
 	ret = ps->xcode ? 0 : -1;
 	break;
 
@@ -678,7 +678,7 @@ stream_setup(struct player_source *ps, struct media_file_info *mfi)
 	free(mfi->path);
 	mfi->path = url;
 
-	ps->xcode = transcode_setup(mfi, XCODE_PCM16_NOHEADER, NULL);
+	ps->xcode = transcode_setup(mfi->data_kind, mfi->path, mfi->song_length, XCODE_PCM16_NOHEADER, NULL);
 	ret = ps->xcode ? 0 : -1;
 	break;
 

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -1643,16 +1643,16 @@ notify_cb(int fd, short what, void *arg)
 
 /* Thread: player */
 int
-spotify_playback_setup(struct media_file_info *mfi)
+spotify_playback_setup(const char *path)
 {
   sp_link *link;
 
   DPRINTF(E_DBG, L_SPOTIFY, "Playback setup request\n");
 
-  link = fptr_sp_link_create_from_string(mfi->path);
+  link = fptr_sp_link_create_from_string(path);
   if (!link)
     {
-      DPRINTF(E_LOG, L_SPOTIFY, "Playback setup failed, invalid Spotify link: %s\n", mfi->path);
+      DPRINTF(E_LOG, L_SPOTIFY, "Playback setup failed, invalid Spotify link: %s\n", path);
       return -1;
     }
 

--- a/src/spotify.h
+++ b/src/spotify.h
@@ -2,12 +2,11 @@
 #ifndef __SPOTIFY_H__
 #define __SPOTIFY_H__
 
-#include "db.h"
 #include <event2/event.h>
 #include <event2/buffer.h>
 
 int
-spotify_playback_setup(struct media_file_info *mfi);
+spotify_playback_setup(const char *path);
 
 int
 spotify_playback_play();

--- a/src/transcode.h
+++ b/src/transcode.h
@@ -28,13 +28,13 @@ struct decoded_frame;
 
 // Setting up
 struct decode_ctx *
-transcode_decode_setup(struct media_file_info *mfi, int decode_video);
+transcode_decode_setup(enum data_kind data_kind, const char *path, uint32_t song_length, int decode_video);
 
 struct encode_ctx *
 transcode_encode_setup(struct decode_ctx *src_ctx, enum transcode_profile profile, off_t *est_size);
 
 struct transcode_ctx *
-transcode_setup(struct media_file_info *mfi, enum transcode_profile profile, off_t *est_size);
+transcode_setup(enum data_kind data_kind, const char *path, uint32_t song_length, enum transcode_profile profile, off_t *est_size);
 
 struct decode_ctx *
 transcode_decode_setup_raw(void);


### PR DESCRIPTION
This is preliminary work to allow playing items, that are not persisted in the files table.
The different backends (transcode, spotify, pipe, httpd) don't really need a media file. Mostly the path is enough to start playback.