### PR TITLE
Sync output to fifo

### DIFF
--- a/src/outputs/fifo.c
+++ b/src/outputs/fifo.c
@@ -400,7 +400,7 @@ fifo_flush(output_status_cb cb, uint64_t rtptime)
   fifo_session->status_cb = cb;
   fifo_session->state = OUTPUT_STATE_CONNECTED;
   fifo_status(fifo_session);
-  return 0;
+  return 1;
 }
 
 static void


### PR DESCRIPTION
This is an attempt at keeping the output to the fifo in sync with the other outputs. I do not really like the introduction of yet another buffer ... but all other solutions i could come up with, would result in major changes. 

@ejurgensen if you have a better solution let me know.
