### PR TITLE
[spotify] Add missing virtual path to "Saved Tracks" playlist

### DIFF
--- a/src/spotify.c
+++ b/src/spotify.c
@@ -943,6 +943,7 @@ spotify_uri_register(void *arg, int *retval)
       pli.title = "Spotify Saved";
       pli.type = PL_PLAIN;
       pli.path = "spotify:savedtracks";
+      pli.virtual_path = "/spotify:/Spotify Saved";
 
       ret = db_pl_add(&pli, &spotify_saved_plid);
       if (ret < 0)


### PR DESCRIPTION
Without setting a virtual path the "spotify:savedtracks" playlist shows in mpd clients as "NULL)"