### PR TITLE
Remove rebuilding the persistent-ids on startup

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3385,6 +3385,44 @@ db_groups_clear(void)
   return db_query_run("DELETE FROM groups;", 0, 1);
 }
 
+/*
+ * Remove album and artist entries in the groups table that are not longer referenced from the files table
+ */
+int
+db_groups_cleanup()
+{
+#define Q_TMPL_ALBUM "DELETE FROM groups WHERE type = 1 AND NOT persistentid IN (SELECT songalbumid from files WHERE disabled = 0);"
+#define Q_TMPL_ARTIST "DELETE FROM groups WHERE type = 2 AND NOT persistentid IN (SELECT songartistid from files WHERE disabled = 0);"
+
+  int ret;
+
+  db_transaction_begin();
+
+  ret = db_query_run(Q_TMPL_ALBUM, 0, 0);
+  if (ret < 0)
+    {
+      db_transaction_rollback();
+      return -1;
+    }
+
+  DPRINTF(E_DBG, L_DB, "Removed album group-entries: %d\n", sqlite3_changes(hdl));
+
+  ret = db_query_run(Q_TMPL_ARTIST, 0, 0);
+  if (ret < 0)
+    {
+      db_transaction_rollback();
+      return -1;
+    }
+
+  DPRINTF(E_DBG, L_DB, "Removed artist group-entries: %d\n", sqlite3_changes(hdl));
+  db_transaction_end();
+
+  return 0;
+
+#undef Q_TMPL_ALBUM
+#undef Q_TMPL_ARTIST
+}
+
 static enum group_type
 db_group_type_bypersistentid(int64_t persistentid)
 {

--- a/src/db.c
+++ b/src/db.c
@@ -2025,18 +2025,6 @@ db_files_get_count_bymatch(char *path)
 }
 
 void
-db_files_update_songartistid(void)
-{
-  db_query_run("UPDATE files SET songartistid = daap_songalbumid(LOWER(album_artist), '');", 0, 1);
-}
-
-void
-db_files_update_songalbumid(void)
-{
-  db_query_run("UPDATE files SET songalbumid = daap_songalbumid(LOWER(album_artist), LOWER(album));", 0, 1);
-}
-
-void
 db_file_inc_playcount(int id)
 {
 #define Q_TMPL "UPDATE files SET play_count = play_count + 1, time_played = %" PRIi64 ", seek = 0 WHERE id = %d;"

--- a/src/db.h
+++ b/src/db.h
@@ -618,6 +618,9 @@ int
 db_groups_clear(void);
 
 int
+db_groups_cleanup();
+
+int
 db_group_persistentid_byid(int id, int64_t *persistentid);
 
 

--- a/src/db.h
+++ b/src/db.h
@@ -499,12 +499,6 @@ int
 db_files_get_count_bymatch(char *path);
 
 void
-db_files_update_songartistid(void);
-
-void
-db_files_update_songalbumid(void);
-
-void
 db_file_inc_playcount(int id);
 
 void


### PR DESCRIPTION
Rebuilding the persistent ids for songalbum and songartist takes a noticeable amount of time (on my rpi2 it can take up to 10 seconds). The rebuild is only necessary, if the db was created on a different machine. This is - as far as i know - an undocumented feature (not sure if it actually works), that probably was a workaround for the extremely long scanning times on older versions of forked-daapd.

In favor of faster startup times, i would like to remove this feature.

If you want to keep it, it would make sense to only rebuild, if it is actually necessary. The only difference i spotted, that varies between different machines, is that there is a hash function for 32 bit and 64 bit systems. This information could be stored in the db to only rebuild if it actually changed.