### PR TITLE
[threads] Added missing initializers, check errors on mutex/cond calls

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -35,8 +35,6 @@
 #include <sys/mman.h>
 #include <limits.h>
 
-#include <pthread.h>
-
 #include <sqlite3.h>
 
 #include "conffile.h"
@@ -532,12 +530,12 @@ unlock_notify_cb(void **args, int nargs)
     {
       u = (struct db_unlock *)args[i];
 
-      pthread_mutex_lock(&u->lck);
+      fork_mutex_lock(&u->lck);
 
       u->proceed = 1;
-      pthread_cond_signal(&u->cond);
+      fork_cond_signal(&u->cond);
 
-      pthread_mutex_unlock(&u->lck);
+      fork_mutex_unlock(&u->lck);
     }
 }
 
@@ -548,25 +546,25 @@ db_wait_unlock(void)
   int ret;
 
   u.proceed = 0;
-  pthread_mutex_init(&u.lck, NULL);
-  pthread_cond_init(&u.cond, NULL);
+  fork_mutex_init(&u.lck);
+  fork_cond_init(&u.cond);
 
   ret = sqlite3_unlock_notify(hdl, unlock_notify_cb, &u);
   if (ret == SQLITE_OK)
     {
-      pthread_mutex_lock(&u.lck);
+      fork_mutex_lock(&u.lck);
 
       if (!u.proceed)
 	{
 	  DPRINTF(E_INFO, L_DB, "Waiting for database unlock\n");
-	  pthread_cond_wait(&u.cond, &u.lck);
+	  fork_cond_wait(&u.cond, &u.lck);
 	}
 
-      pthread_mutex_unlock(&u.lck);
+      fork_mutex_unlock(&u.lck);
     }
 
-  pthread_cond_destroy(&u.cond);
-  pthread_mutex_destroy(&u.lck);
+  fork_cond_destroy(&u.cond);
+  fork_mutex_destroy(&u.lck);
 
   return ret;
 }

--- a/src/logger.c
+++ b/src/logger.c
@@ -37,15 +37,23 @@
 #include "conffile.h"
 #include "misc.h"
 
-static pthread_mutex_t logger_lck = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t logger_lck;
+static int logger_initialized;
 static int logdomains;
 static int threshold;
-static int console;
+static int console = 1;
 static char *logfilename;
 static FILE *logfile;
 static char *labels[] = { "config", "daap", "db", "httpd", "http", "main", "mdns", "misc", "rsp", "scan", "xcode", "event", "remote", "dacp", "ffmpeg", "artwork", "player", "raop", "laudio", "dmap", "dbperf", "spotify", "lastfm", "cache", "mpd", "stream", "cast", "fifo" };
 static char *severities[] = { "FATAL", "LOG", "WARN", "INFO", "DEBUG", "SPAM" };
 
+/* We need our own check to avoid nested locking or recursive calls */
+#define LOGGER_CHECK_ERR(f) \
+  do { int lerr; lerr = f; if (lerr != 0) { \
+      vlogger_fatal("%s failed at line %d, err %d (%s)\n", #f, __LINE__, \
+                    lerr, strerror(lerr)); \
+      abort(); \
+    } } while(0)
 
 static int
 set_logdomains(char *domains)
@@ -80,23 +88,12 @@ set_logdomains(char *domains)
 }
 
 static void
-vlogger(int severity, int domain, const char *fmt, va_list args)
+vlogger_writer(int severity, int domain, const char *fmt, va_list args)
 {
   va_list ap;
   char stamp[32];
   time_t t;
   int ret;
-
-  if (!((1 << domain) & logdomains) || (severity > threshold))
-    return;
-
-  fork_mutex_lock(&logger_lck);
-
-  if (!logfile && !console)
-    {
-      fork_mutex_unlock(&logger_lck);
-      return;
-    }
 
   if (logfile)
     {
@@ -122,8 +119,43 @@ vlogger(int severity, int domain, const char *fmt, va_list args)
       vfprintf(stderr, fmt, ap);
       va_end(ap);
     }
+}
 
-  fork_mutex_unlock(&logger_lck);
+static void
+vlogger_fatal(const char *fmt, ...)
+{
+  va_list ap;
+
+  va_start(ap, fmt);
+  vlogger_writer(E_FATAL, L_MISC, fmt, ap);
+  va_end(ap);
+}
+
+static void
+vlogger(int severity, int domain, const char *fmt, va_list args)
+{
+
+  if(! logger_initialized)
+    {
+      /* lock not initialized, use stderr */
+      vlogger_writer(severity, domain, fmt, args);
+      return;
+    }
+
+  if (!((1 << domain) & logdomains) || (severity > threshold))
+    return;
+
+  LOGGER_CHECK_ERR(pthread_mutex_lock(&logger_lck));
+
+  if (!logfile && !console)
+    {
+      LOGGER_CHECK_ERR(pthread_mutex_unlock(&logger_lck));
+      return;
+    }
+
+  vlogger_writer(severity, domain, fmt, args);
+
+  LOGGER_CHECK_ERR(pthread_mutex_unlock(&logger_lck));
 }
 
 void
@@ -204,7 +236,7 @@ logger_reinit(void)
   if (!logfile)
     return;
 
-  fork_mutex_lock(&logger_lck);
+  LOGGER_CHECK_ERR(pthread_mutex_lock(&logger_lck));
 
   fp = fopen(logfilename, "a");
   if (!fp)
@@ -218,7 +250,7 @@ logger_reinit(void)
   logfile = fp;
 
  out:
-  fork_mutex_unlock(&logger_lck);
+  LOGGER_CHECK_ERR(pthread_mutex_unlock(&logger_lck));
 }
 
 
@@ -287,6 +319,11 @@ logger_init(char *file, char *domains, int severity)
 
   logfilename = file;
 
+  /* logging w/o locks before initialized complete */
+  CHECK_ERR(L_MISC, mutex_init(&logger_lck));
+
+  logger_initialized = 1;
+
   return 0;
 }
 
@@ -294,5 +331,16 @@ void
 logger_deinit(void)
 {
   if (logfile)
-    fclose(logfile);
+    {
+      fclose(logfile);
+      logfile = NULL;
+    }
+
+  if(logger_initialized)
+    {
+      /* logging w/o locks to stderr now */
+      logger_initialized = 0;
+      console = 1;
+      CHECK_ERR(L_MISC, pthread_mutex_destroy(&logger_lck));
+    }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -44,8 +44,6 @@
 # include <sys/event.h>
 #endif
 
-#include <pthread.h>
-
 #include <getopt.h>
 #include <event2/event.h>
 #include <libavutil/log.h>
@@ -422,26 +420,29 @@ signal_kqueue_cb(int fd, short event, void *arg)
 
 
 static int
-ffmpeg_lockmgr(void **mutex, enum AVLockOp op)
+ffmpeg_lockmgr(void **pmutex, enum AVLockOp op)
 {
   switch (op)
     {
       case AV_LOCK_CREATE:
-	*mutex = malloc(sizeof(pthread_mutex_t));
-	if (!*mutex)
+	*pmutex = malloc(sizeof(pthread_mutex_t));
+	if (!*pmutex)
 	  return 1;
-
-	return !!pthread_mutex_init(*mutex, NULL);
+        fork_mutex_init(*pmutex);
+	return 0;
 
       case AV_LOCK_OBTAIN:
-	return !!pthread_mutex_lock(*mutex);
+        fork_mutex_lock(*pmutex);
+	return 0;
 
       case AV_LOCK_RELEASE:
-	return !!pthread_mutex_unlock(*mutex);
+        fork_mutex_unlock(*pmutex);
+	return 0;
 
       case AV_LOCK_DESTROY:
-	pthread_mutex_destroy(*mutex);
-	free(*mutex);
+	fork_mutex_destroy(*pmutex);
+	free(*pmutex);
+        *pmutex = NULL;
 
 	return 0;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -428,19 +428,19 @@ ffmpeg_lockmgr(void **pmutex, enum AVLockOp op)
 	*pmutex = malloc(sizeof(pthread_mutex_t));
 	if (!*pmutex)
 	  return 1;
-        fork_mutex_init(*pmutex);
+        CHECK_ERR(L_MAIN, mutex_init(*pmutex));
 	return 0;
 
       case AV_LOCK_OBTAIN:
-        fork_mutex_lock(*pmutex);
+        CHECK_ERR(L_MAIN, pthread_mutex_lock(*pmutex));
 	return 0;
 
       case AV_LOCK_RELEASE:
-        fork_mutex_unlock(*pmutex);
+        CHECK_ERR(L_MAIN, pthread_mutex_unlock(*pmutex));
 	return 0;
 
       case AV_LOCK_DESTROY:
-	fork_mutex_destroy(*pmutex);
+	CHECK_ERR(L_MAIN, pthread_mutex_destroy(*pmutex));
 	free(*pmutex);
         *pmutex = NULL;
 
@@ -449,7 +449,6 @@ ffmpeg_lockmgr(void **pmutex, enum AVLockOp op)
 
   return 1;
 }
-
 
 int
 main(int argc, char **argv)

--- a/src/misc.c
+++ b/src/misc.c
@@ -920,87 +920,34 @@ timespec_cmp(struct timespec time1, struct timespec time2)
     return 0;
 }
 
-void
-fork_mutex_init(pthread_mutex_t *mutex)
+int
+mutex_init(pthread_mutex_t *mutex)
 {
   pthread_mutexattr_t mattr;
   int err;
 
-  err = pthread_mutexattr_init(&mattr);
-  assert(err == 0);
-  err = pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_ERRORCHECK);
-  assert(err == 0);
+  CHECK_ERR(L_MISC, pthread_mutexattr_init(&mattr));
+  CHECK_ERR(L_MISC, pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_ERRORCHECK));
   err = pthread_mutex_init(mutex, &mattr);
-  assert(err == 0);
-  err = pthread_mutexattr_destroy(&mattr);
-  assert(err == 0);
-}
+  CHECK_ERR(L_MISC, pthread_mutexattr_destroy(&mattr));
 
-void
-fork_mutex_lock(pthread_mutex_t *mutex)
-{
-  int err;
-  err = pthread_mutex_lock(mutex);
-  assert(err == 0);
-}
-
-void
-fork_mutex_unlock(pthread_mutex_t *mutex)
-{
-  int err;
-  err = pthread_mutex_unlock(mutex);
-  assert(err == 0);
-}
-
-void
-fork_mutex_destroy(pthread_mutex_t *mutex)
-{
-  int err;
-  err = pthread_mutex_destroy(mutex);
-  assert(err == 0);
-}
-
-/* condition wrappers with checks */
-void
-fork_cond_init(pthread_cond_t *cond)
-{
-  int err;
-  err = pthread_cond_init(cond, NULL);
-  assert(err == 0);
-}
-
-void
-fork_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
-{
-  int err;
-  err = pthread_cond_wait(cond, mutex);
-  assert(err == 0);
-}
-
-int
-fork_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex,
-                    const struct timespec *ts)
-{
-  int err;
-  err = pthread_cond_timedwait(cond, mutex, ts);
-  if(err == ETIMEDOUT)
-    return err;
-  assert(err == 0);
   return err;
 }
 
-void
-fork_cond_signal(pthread_cond_t *cond)
-{
-  int err;
-  err = pthread_cond_signal(cond);
-  assert(err == 0);
+void log_fatal_err(int domain, const char *func, int line, int err) {
+  DPRINTF(E_FATAL, domain, "%s failed at line %d, error %d (%s)\n", func,
+          line, err, strerror(err));
+  abort();
 }
 
-void
-fork_cond_destroy(pthread_cond_t *cond)
-{
-  int err;
-  err = pthread_cond_destroy(cond);
-  assert(err == 0);
+void log_fatal_errno(int domain, const char *func, int line) {
+  DPRINTF(E_FATAL, domain, "%s failed at line %d, error %d (%s)\n", func,
+          line, errno, strerror(errno));
+  abort();
 }
+
+void log_fatal_null(int domain, const char *func, int line) {
+  DPRINTF(E_FATAL, domain, "%s returned NULL at line %d\n", func, line);
+  abort();
+}
+

--- a/src/misc.c
+++ b/src/misc.c
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <limits.h>
 #include <sys/param.h>
+#include <assert.h>
 
 #include <unistr.h>
 #include <uniconv.h>
@@ -917,4 +918,89 @@ timespec_cmp(struct timespec time1, struct timespec time2)
   /* Equal. */
   else
     return 0;
+}
+
+void
+fork_mutex_init(pthread_mutex_t *mutex)
+{
+  pthread_mutexattr_t mattr;
+  int err;
+
+  err = pthread_mutexattr_init(&mattr);
+  assert(err == 0);
+  err = pthread_mutexattr_settype(&mattr, PTHREAD_MUTEX_ERRORCHECK);
+  assert(err == 0);
+  err = pthread_mutex_init(mutex, &mattr);
+  assert(err == 0);
+  err = pthread_mutexattr_destroy(&mattr);
+  assert(err == 0);
+}
+
+void
+fork_mutex_lock(pthread_mutex_t *mutex)
+{
+  int err;
+  err = pthread_mutex_lock(mutex);
+  assert(err == 0);
+}
+
+void
+fork_mutex_unlock(pthread_mutex_t *mutex)
+{
+  int err;
+  err = pthread_mutex_unlock(mutex);
+  assert(err == 0);
+}
+
+void
+fork_mutex_destroy(pthread_mutex_t *mutex)
+{
+  int err;
+  err = pthread_mutex_destroy(mutex);
+  assert(err == 0);
+}
+
+/* condition wrappers with checks */
+void
+fork_cond_init(pthread_cond_t *cond)
+{
+  int err;
+  err = pthread_cond_init(cond, NULL);
+  assert(err == 0);
+}
+
+void
+fork_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
+{
+  int err;
+  err = pthread_cond_wait(cond, mutex);
+  assert(err == 0);
+}
+
+int
+fork_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex,
+                    const struct timespec *ts)
+{
+  int err;
+  err = pthread_cond_timedwait(cond, mutex, ts);
+  if(err == ETIMEDOUT)
+    return err;
+  assert(err == 0);
+  return err;
+}
+
+void
+fork_cond_signal(pthread_cond_t *cond)
+{
+  int err;
+  err = pthread_cond_signal(cond);
+  assert(err == 0);
+}
+
+void
+fork_cond_destroy(pthread_cond_t *cond)
+{
+  int err;
+  err = pthread_cond_destroy(cond);
+  assert(err == 0);
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -33,7 +33,6 @@
 #include <stdint.h>
 #include <limits.h>
 #include <sys/param.h>
-#include <assert.h>
 
 #include <unistr.h>
 #include <uniconv.h>

--- a/src/misc.h
+++ b/src/misc.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <time.h>
+#include <pthread.h>
 
 struct onekeyval {
   char *name;
@@ -95,5 +96,28 @@ timespec_add(struct timespec time1, struct timespec time2);
 
 int
 timespec_cmp(struct timespec time1, struct timespec time2);
+
+/* mutex wrappers with checks */
+void
+fork_mutex_init(pthread_mutex_t *mutex);
+void
+fork_mutex_lock(pthread_mutex_t *mutex);
+void
+fork_mutex_unlock(pthread_mutex_t *mutex);
+void
+fork_mutex_destroy(pthread_mutex_t *mutex);
+
+/* condition wrappers with checks */
+void
+fork_cond_init(pthread_cond_t *cond);
+void
+fork_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
+int
+fork_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex,
+                    const struct timespec *ts);
+void
+fork_cond_signal(pthread_cond_t *cond);
+void
+fork_cond_destroy(pthread_cond_t *cond);
 
 #endif /* !__MISC_H__ */

--- a/src/misc.h
+++ b/src/misc.h
@@ -97,27 +97,49 @@ timespec_add(struct timespec time1, struct timespec time2);
 int
 timespec_cmp(struct timespec time1, struct timespec time2);
 
-/* mutex wrappers with checks */
-void
-fork_mutex_init(pthread_mutex_t *mutex);
-void
-fork_mutex_lock(pthread_mutex_t *mutex);
-void
-fork_mutex_unlock(pthread_mutex_t *mutex);
-void
-fork_mutex_destroy(pthread_mutex_t *mutex);
-
-/* condition wrappers with checks */
-void
-fork_cond_init(pthread_cond_t *cond);
-void
-fork_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
+/* initialize mutex with error checking (not default on all platforms) */
 int
-fork_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex,
-                    const struct timespec *ts);
-void
-fork_cond_signal(pthread_cond_t *cond);
-void
-fork_cond_destroy(pthread_cond_t *cond);
+mutex_init(pthread_mutex_t *mutex);
+
+/* Check that the function returns 0, logging a fatal error referencing
+   returned error (type errno) if it fails, and aborts the process.
+   Example: CHECK_ERR(L_MAIN, my_function()); */
+#define CHECK_ERR(d, f) \
+  do { int chk_err; \
+    if ( (chk_err = (f)) != 0) \
+      log_fatal_err(d, #f, __LINE__, chk_err); \
+  } while(0)
+
+/* Check that the function returns 0 or okval, logging a fatal
+   error referencing returned erro (type errno) if not, and aborts the process.
+   Example: int err; CHECK_ERR_EXCEPT(L_MAIN, my_wait(), err, ETIMEDOUT); */
+#define CHECK_ERR_EXCEPT(d, f, var, okval) \
+  do { (var) = (f);                             \
+    if (! (((var) == (okval)) || ((var) == 0))) \
+      log_fatal_err(d, #f, __LINE__, (var)); \
+  } while(0)
+
+/* Check that the function returns value >= 0, logging a fatal error
+   referencing errno if it not, and aborts the process.
+   Example: int ret; CHECK_ERRNO(L_MAIN, ret = my_function()); */
+#define CHECK_ERRNO(d, f) \
+  do { \
+    if ( (f) < 0 ) \
+      log_fatal_errno(d, #f, __LINE__); \
+  } while(0)
+
+/* Check that the function returns non-NULL, logging a fatal error if not,
+   and aborts the process.
+   Example: void *ptr; CHECK_NULL(L_MAIN, ptr = my_create()); */
+#define CHECK_NULL(d, f) \
+  do { \
+    if ( (f) == NULL ) \
+      log_fatal_null(d, #f, __LINE__); \
+  } while(0)
+
+/* Used by CHECK_*() macros */
+void log_fatal_err(int domain, const char *func, int line, int err);
+void log_fatal_errno(int domain, const char *func, int line);
+void log_fatal_null(int domain, const char *func, int line);
 
 #endif /* !__MISC_H__ */

--- a/src/remote_pairing.c
+++ b/src/remote_pairing.c
@@ -84,7 +84,7 @@ static int pairing_efd;
 static int pairing_pipe[2];
 #endif
 static struct event *pairingev;
-static pthread_mutex_t remote_lck = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t remote_lck;
 static struct remote_info *remote_list;
 
 
@@ -660,7 +660,7 @@ pairing_cb(int fd, short event, void *arg)
 
   for (;;)
     {
-      fork_mutex_lock(&remote_lck);
+      CHECK_ERR(L_REMOTE, pthread_mutex_lock(&remote_lck));
 
       for (ri = remote_list; ri; ri = ri->next)
 	{
@@ -672,7 +672,7 @@ pairing_cb(int fd, short event, void *arg)
 	    }
 	}
 
-      fork_mutex_unlock(&remote_lck);
+      CHECK_ERR(L_REMOTE, pthread_mutex_unlock(&remote_lck));
 
       if (!ri)
 	break;
@@ -699,11 +699,11 @@ touch_remote_cb(const char *name, const char *type, const char *domain, const ch
        * failed; any subsequent attempt will need a new pairing pin, so
        * we can just forget everything we know about the remote.
        */
-      fork_mutex_lock(&remote_lck);
+      CHECK_ERR(L_REMOTE, pthread_mutex_lock(&remote_lck));
 
       remove_remote_address_byid(name, family);
 
-      fork_mutex_unlock(&remote_lck);
+      CHECK_ERR(L_REMOTE, pthread_mutex_unlock(&remote_lck));
     }
   else
     {
@@ -761,7 +761,7 @@ touch_remote_cb(const char *name, const char *type, const char *domain, const ch
       DPRINTF(E_LOG, L_REMOTE, "Discovered remote '%s' (id %s) at %s:%d, paircode %s\n", devname, name, address, port, paircode);
 
       /* Add the data to the list, adding the remote to the list if needed */
-      fork_mutex_lock(&remote_lck);
+      CHECK_ERR(L_REMOTE, pthread_mutex_lock(&remote_lck));
 
       ret = add_remote_mdns_data(name, family, address, port, devname, paircode);
 
@@ -775,7 +775,7 @@ touch_remote_cb(const char *name, const char *type, const char *domain, const ch
       else if (ret == 1)
 	kickoff_pairing();
 
-      fork_mutex_unlock(&remote_lck);
+      CHECK_ERR(L_REMOTE, pthread_mutex_unlock(&remote_lck));
     }
 }
 
@@ -885,7 +885,7 @@ remote_pairing_read_pin(char *path)
 
   DPRINTF(E_LOG, L_REMOTE, "Read Remote pairing data (name '%s', pin '%s') from %s\n", devname, pin, path);
 
-  fork_mutex_lock(&remote_lck);
+  CHECK_ERR(L_REMOTE, pthread_mutex_lock(&remote_lck));
 
   ret = add_remote_pin_data(devname, pin);
   free(devname);
@@ -894,7 +894,7 @@ remote_pairing_read_pin(char *path)
   else
     kickoff_pairing();
 
-  fork_mutex_unlock(&remote_lck);
+  CHECK_ERR(L_REMOTE, pthread_mutex_unlock(&remote_lck));
 }
 
 
@@ -905,6 +905,8 @@ remote_pairing_init(void)
   int ret;
 
   remote_list = NULL;
+
+  CHECK_ERR(L_REMOTE, mutex_init(&remote_lck));
 
 #ifdef HAVE_EVENTFD
   pairing_efd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
@@ -989,4 +991,6 @@ remote_pairing_deinit(void)
   close(pairing_pipe[0]);
   close(pairing_pipe[1]);
 #endif
+
+  CHECK_ERR(L_REMOTE, pthread_mutex_destroy(&remote_lck));
 }

--- a/src/remote_pairing.c
+++ b/src/remote_pairing.c
@@ -39,7 +39,6 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <errno.h>
-#include <pthread.h>
 
 #ifdef HAVE_EVENTFD
 # include <sys/eventfd.h>
@@ -661,7 +660,7 @@ pairing_cb(int fd, short event, void *arg)
 
   for (;;)
     {
-      pthread_mutex_lock(&remote_lck);
+      fork_mutex_lock(&remote_lck);
 
       for (ri = remote_list; ri; ri = ri->next)
 	{
@@ -673,7 +672,7 @@ pairing_cb(int fd, short event, void *arg)
 	    }
 	}
 
-      pthread_mutex_unlock(&remote_lck);
+      fork_mutex_unlock(&remote_lck);
 
       if (!ri)
 	break;
@@ -700,11 +699,11 @@ touch_remote_cb(const char *name, const char *type, const char *domain, const ch
        * failed; any subsequent attempt will need a new pairing pin, so
        * we can just forget everything we know about the remote.
        */
-      pthread_mutex_lock(&remote_lck);
+      fork_mutex_lock(&remote_lck);
 
       remove_remote_address_byid(name, family);
 
-      pthread_mutex_unlock(&remote_lck);
+      fork_mutex_unlock(&remote_lck);
     }
   else
     {
@@ -762,7 +761,7 @@ touch_remote_cb(const char *name, const char *type, const char *domain, const ch
       DPRINTF(E_LOG, L_REMOTE, "Discovered remote '%s' (id %s) at %s:%d, paircode %s\n", devname, name, address, port, paircode);
 
       /* Add the data to the list, adding the remote to the list if needed */
-      pthread_mutex_lock(&remote_lck);
+      fork_mutex_lock(&remote_lck);
 
       ret = add_remote_mdns_data(name, family, address, port, devname, paircode);
 
@@ -776,7 +775,7 @@ touch_remote_cb(const char *name, const char *type, const char *domain, const ch
       else if (ret == 1)
 	kickoff_pairing();
 
-      pthread_mutex_unlock(&remote_lck);
+      fork_mutex_unlock(&remote_lck);
     }
 }
 
@@ -886,7 +885,7 @@ remote_pairing_read_pin(char *path)
 
   DPRINTF(E_LOG, L_REMOTE, "Read Remote pairing data (name '%s', pin '%s') from %s\n", devname, pin, path);
 
-  pthread_mutex_lock(&remote_lck);
+  fork_mutex_lock(&remote_lck);
 
   ret = add_remote_pin_data(devname, pin);
   free(devname);
@@ -895,7 +894,7 @@ remote_pairing_read_pin(char *path)
   else
     kickoff_pairing();
 
-  pthread_mutex_unlock(&remote_lck);
+  fork_mutex_unlock(&remote_lck);
 }
 
 

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -1489,7 +1489,7 @@ audio_fifo_flush(void)
 
     DPRINTF(E_DBG, L_SPOTIFY, "Flushing audio fifo\n");
 
-    fork_mutex_lock(&g_audio_fifo->mutex);
+    CHECK_ERR(L_SPOTIFY, pthread_mutex_lock(&g_audio_fifo->mutex));
 
     while((afd = TAILQ_FIRST(&g_audio_fifo->q))) {
 	TAILQ_REMOVE(&g_audio_fifo->q, afd, link);
@@ -1498,7 +1498,7 @@ audio_fifo_flush(void)
 
     g_audio_fifo->qlen = 0;
     g_audio_fifo->fullcount = 0;
-    fork_mutex_unlock(&g_audio_fifo->mutex);
+    CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&g_audio_fifo->mutex));
 }
 
 static enum command_state
@@ -1668,6 +1668,7 @@ audio_get(void *arg, int *retval)
   int processed;
   int timeout;
   int ret;
+  int err;
   int s;
 
   audio = (struct audio_get_param *) arg;
@@ -1678,7 +1679,7 @@ audio_get(void *arg, int *retval)
   if (g_state == SPOTIFY_STATE_PAUSED)
     playback_play(NULL, retval);
 
-  fork_mutex_lock(&g_audio_fifo->mutex);
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_lock(&g_audio_fifo->mutex));
 
   while ((processed < audio->wanted) && (g_state != SPOTIFY_STATE_STOPPED))
     {
@@ -1701,7 +1702,7 @@ audio_get(void *arg, int *retval)
 	  DPRINTF(E_DBG, L_SPOTIFY, "Waiting for audio\n");
 	  timeout += 5;
 	  mk_reltime(&ts, 5);
-	  fork_cond_timedwait(&g_audio_fifo->cond, &g_audio_fifo->mutex, &ts);
+	  CHECK_ERR_EXCEPT(L_SPOTIFY, pthread_cond_timedwait(&g_audio_fifo->cond, &g_audio_fifo->mutex, &ts), err, ETIMEDOUT);
 	}
 
       if ((!afd) && (timeout >= SPOTIFY_TIMEOUT))
@@ -1725,7 +1726,7 @@ audio_get(void *arg, int *retval)
       if (ret < 0)
 	{
 	  DPRINTF(E_LOG, L_SPOTIFY, "Out of memory for evbuffer (tried to add %d bytes)\n", s);
-	  fork_mutex_unlock(&g_audio_fifo->mutex);
+	  CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&g_audio_fifo->mutex));
 	  *retval = -1;
 	  return COMMAND_END;
 	}
@@ -1733,7 +1734,7 @@ audio_get(void *arg, int *retval)
       processed += s;
     }
 
-  fork_mutex_unlock(&g_audio_fifo->mutex);
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&g_audio_fifo->mutex));
 
 
   *retval = processed;
@@ -1747,12 +1748,12 @@ artwork_loaded_cb(sp_image *image, void *userdata)
 
   artwork = userdata;
 
-  fork_mutex_lock(&artwork->mutex);
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_lock(&artwork->mutex));
 
   artwork->is_loaded = 1;
 
-  fork_cond_signal(&artwork->cond);
-  fork_mutex_unlock(&artwork->mutex);
+  CHECK_ERR(L_SPOTIFY, pthread_cond_signal(&artwork->cond));
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&artwork->mutex));
 }
 
 static enum command_state
@@ -1989,10 +1990,10 @@ logged_out(sp_session *sess)
 {
   DPRINTF(E_INFO, L_SPOTIFY, "Logout complete\n");
 
-  fork_mutex_lock(&login_lck);
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_lock(&login_lck));
 
-  fork_cond_signal(&login_cond);
-  fork_mutex_unlock(&login_lck);
+  CHECK_ERR(L_SPOTIFY, pthread_cond_signal(&login_cond));
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&login_lck));
 }
 
 /**
@@ -2017,7 +2018,7 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
   if (num_frames == 0)
     return 0; // Audio discontinuity, do nothing
 
-  fork_mutex_lock(&g_audio_fifo->mutex);
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_lock(&g_audio_fifo->mutex));
 
   /* Buffer three seconds of audio */
   if (g_audio_fifo->qlen > (3 * format->sample_rate))
@@ -2033,7 +2034,7 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
 	  g_audio_fifo->fullcount = 0;
 	}
 
-      fork_mutex_unlock(&g_audio_fifo->mutex);
+      CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&g_audio_fifo->mutex));
 
       return 0;
     }
@@ -2050,8 +2051,8 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
   TAILQ_INSERT_TAIL(&g_audio_fifo->q, afd, link);
   g_audio_fifo->qlen += num_frames;
 
-  fork_cond_signal(&g_audio_fifo->cond);
-  fork_mutex_unlock(&g_audio_fifo->mutex);
+  CHECK_ERR(L_SPOTIFY, pthread_cond_signal(&g_audio_fifo->cond));
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&g_audio_fifo->mutex));
 
   return num_frames;
 }
@@ -2365,25 +2366,26 @@ spotify_artwork_get(struct evbuffer *evbuf, char *path, int max_w, int max_h)
   struct artwork_get_param artwork;
   struct timespec ts;
   int ret;
+  int err;
 
   artwork.evbuf  = evbuf;
   artwork.path = path;
   artwork.max_w = max_w;
   artwork.max_h = max_h;
 
-  fork_mutex_init(&artwork.mutex);
-  fork_cond_init(&artwork.cond);
+  CHECK_ERR(L_SPOTIFY, mutex_init(&artwork.mutex));
+  CHECK_ERR(L_SPOTIFY, pthread_cond_init(&artwork.cond, NULL));
 
   ret = commands_exec_sync(cmdbase, artwork_get, NULL, &artwork);
 
   // Artwork was not ready, wait for callback from libspotify
   if (ret == 0)
     {
-      fork_mutex_lock(&artwork.mutex);
+      CHECK_ERR(L_SPOTIFY, pthread_mutex_lock(&artwork.mutex));
       mk_reltime(&ts, SPOTIFY_ARTWORK_TIMEOUT);
       if (!artwork.is_loaded)
-	fork_cond_timedwait(&artwork.cond, &artwork.mutex, &ts);
-      fork_mutex_unlock(&artwork.mutex);
+	CHECK_ERR_EXCEPT(L_SPOTIFY, pthread_cond_timedwait(&artwork.cond, &artwork.mutex, &ts), err, ETIMEDOUT);
+      CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&artwork.mutex));
 
       ret = commands_exec_sync(cmdbase, artwork_get_bh, NULL, &artwork);
     }
@@ -2431,7 +2433,7 @@ void
 spotify_oauth_callback(struct evbuffer *evbuf, struct evkeyvalq *param, const char *redirect_uri)
 {
   const char *code;
-  const char *err;
+  const char *err = "";
   int total;
   int ret;
 
@@ -2499,7 +2501,7 @@ spotify_login(char *path)
 
   if (SP_CONNECTION_STATE_LOGGED_IN == fptr_sp_session_connectionstate(g_sess))
     {
-      fork_mutex_lock(&login_lck);
+      CHECK_ERR(L_SPOTIFY, pthread_mutex_lock(&login_lck));
 
       DPRINTF(E_LOG, L_SPOTIFY, "Logging out of Spotify (current state is %d)\n", g_state);
 
@@ -2509,12 +2511,12 @@ spotify_login(char *path)
       if (SP_ERROR_OK != err)
 	{
 	  DPRINTF(E_LOG, L_SPOTIFY, "Could not logout of Spotify: %s\n", fptr_sp_error_message(err));
-	  fork_mutex_unlock(&login_lck);
+	  CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&login_lck));
 	  return;
 	}
 
-      fork_cond_wait(&login_cond, &login_lck);
-      fork_mutex_unlock(&login_lck);
+      CHECK_ERR(L_SPOTIFY, pthread_cond_wait(&login_cond, &login_lck));
+      CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&login_lck));
     }
 
   DPRINTF(E_INFO, L_SPOTIFY, "Logging into Spotify\n");
@@ -2649,11 +2651,11 @@ spotify_init(void)
     }
   TAILQ_INIT(&g_audio_fifo->q);
   g_audio_fifo->qlen = 0;
-  fork_mutex_init(&g_audio_fifo->mutex);
-  fork_cond_init(&g_audio_fifo->cond);
+  CHECK_ERR(L_SPOTIFY, mutex_init(&g_audio_fifo->mutex));
+  CHECK_ERR(L_SPOTIFY, pthread_cond_init(&g_audio_fifo->cond, NULL));
 
-  fork_mutex_init(&login_lck);
-  fork_cond_init(&login_cond);
+  CHECK_ERR(L_SPOTIFY, mutex_init(&login_lck));
+  CHECK_ERR(L_SPOTIFY, pthread_cond_init(&login_cond, NULL));
 
   /* Spawn thread */
   ret = pthread_create(&tid_spotify, NULL, spotify, NULL);
@@ -2673,11 +2675,11 @@ spotify_init(void)
   return 0;
 
  thread_fail:
-  fork_cond_destroy(&login_cond);
-  fork_mutex_destroy(&login_lck);
+  CHECK_ERR(L_SPOTIFY, pthread_cond_destroy(&login_cond));
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_destroy(&login_lck));
 
-  fork_cond_destroy(&g_audio_fifo->cond);
-  fork_mutex_destroy(&g_audio_fifo->mutex);
+  CHECK_ERR(L_SPOTIFY, pthread_cond_destroy(&g_audio_fifo->cond));
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_destroy(&g_audio_fifo->mutex));
   free(g_audio_fifo);  
 
  audio_fifo_fail:
@@ -2737,12 +2739,12 @@ spotify_deinit(void)
   close(g_notify_pipe[1]);
 
   /* Destroy locks */
-  fork_cond_destroy(&login_cond);
-  fork_mutex_destroy(&login_lck);
+  CHECK_ERR(L_SPOTIFY, pthread_cond_destroy(&login_cond));
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_destroy(&login_lck));
 
   /* Clear audio fifo */
-  fork_cond_destroy(&g_audio_fifo->cond);
-  fork_mutex_destroy(&g_audio_fifo->mutex);
+  CHECK_ERR(L_SPOTIFY, pthread_cond_destroy(&g_audio_fifo->cond));
+  CHECK_ERR(L_SPOTIFY, pthread_mutex_destroy(&g_audio_fifo->mutex));
   free(g_audio_fifo);
 
   /* Release libspotify handle */

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -1489,7 +1489,7 @@ audio_fifo_flush(void)
 
     DPRINTF(E_DBG, L_SPOTIFY, "Flushing audio fifo\n");
 
-    pthread_mutex_lock(&g_audio_fifo->mutex);
+    fork_mutex_lock(&g_audio_fifo->mutex);
 
     while((afd = TAILQ_FIRST(&g_audio_fifo->q))) {
 	TAILQ_REMOVE(&g_audio_fifo->q, afd, link);
@@ -1498,7 +1498,7 @@ audio_fifo_flush(void)
 
     g_audio_fifo->qlen = 0;
     g_audio_fifo->fullcount = 0;
-    pthread_mutex_unlock(&g_audio_fifo->mutex);
+    fork_mutex_unlock(&g_audio_fifo->mutex);
 }
 
 static enum command_state
@@ -1678,7 +1678,7 @@ audio_get(void *arg, int *retval)
   if (g_state == SPOTIFY_STATE_PAUSED)
     playback_play(NULL, retval);
 
-  pthread_mutex_lock(&g_audio_fifo->mutex);
+  fork_mutex_lock(&g_audio_fifo->mutex);
 
   while ((processed < audio->wanted) && (g_state != SPOTIFY_STATE_STOPPED))
     {
@@ -1701,7 +1701,7 @@ audio_get(void *arg, int *retval)
 	  DPRINTF(E_DBG, L_SPOTIFY, "Waiting for audio\n");
 	  timeout += 5;
 	  mk_reltime(&ts, 5);
-	  pthread_cond_timedwait(&g_audio_fifo->cond, &g_audio_fifo->mutex, &ts);
+	  fork_cond_timedwait(&g_audio_fifo->cond, &g_audio_fifo->mutex, &ts);
 	}
 
       if ((!afd) && (timeout >= SPOTIFY_TIMEOUT))
@@ -1725,7 +1725,7 @@ audio_get(void *arg, int *retval)
       if (ret < 0)
 	{
 	  DPRINTF(E_LOG, L_SPOTIFY, "Out of memory for evbuffer (tried to add %d bytes)\n", s);
-	  pthread_mutex_unlock(&g_audio_fifo->mutex);
+	  fork_mutex_unlock(&g_audio_fifo->mutex);
 	  *retval = -1;
 	  return COMMAND_END;
 	}
@@ -1733,7 +1733,7 @@ audio_get(void *arg, int *retval)
       processed += s;
     }
 
-  pthread_mutex_unlock(&g_audio_fifo->mutex);
+  fork_mutex_unlock(&g_audio_fifo->mutex);
 
 
   *retval = processed;
@@ -1744,15 +1744,15 @@ static void
 artwork_loaded_cb(sp_image *image, void *userdata)
 {
   struct artwork_get_param *artwork;
-  
+
   artwork = userdata;
-  
-  pthread_mutex_lock(&artwork->mutex);
+
+  fork_mutex_lock(&artwork->mutex);
 
   artwork->is_loaded = 1;
 
-  pthread_cond_signal(&artwork->cond);
-  pthread_mutex_unlock(&artwork->mutex);
+  fork_cond_signal(&artwork->cond);
+  fork_mutex_unlock(&artwork->mutex);
 }
 
 static enum command_state
@@ -1989,10 +1989,10 @@ logged_out(sp_session *sess)
 {
   DPRINTF(E_INFO, L_SPOTIFY, "Logout complete\n");
 
-  pthread_mutex_lock(&login_lck);
+  fork_mutex_lock(&login_lck);
 
-  pthread_cond_signal(&login_cond);
-  pthread_mutex_unlock(&login_lck);
+  fork_cond_signal(&login_cond);
+  fork_mutex_unlock(&login_lck);
 }
 
 /**
@@ -2017,7 +2017,7 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
   if (num_frames == 0)
     return 0; // Audio discontinuity, do nothing
 
-  pthread_mutex_lock(&g_audio_fifo->mutex);
+  fork_mutex_lock(&g_audio_fifo->mutex);
 
   /* Buffer three seconds of audio */
   if (g_audio_fifo->qlen > (3 * format->sample_rate))
@@ -2033,7 +2033,7 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
 	  g_audio_fifo->fullcount = 0;
 	}
 
-      pthread_mutex_unlock(&g_audio_fifo->mutex);
+      fork_mutex_unlock(&g_audio_fifo->mutex);
 
       return 0;
     }
@@ -2050,8 +2050,8 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
   TAILQ_INSERT_TAIL(&g_audio_fifo->q, afd, link);
   g_audio_fifo->qlen += num_frames;
 
-  pthread_cond_signal(&g_audio_fifo->cond);
-  pthread_mutex_unlock(&g_audio_fifo->mutex);
+  fork_cond_signal(&g_audio_fifo->cond);
+  fork_mutex_unlock(&g_audio_fifo->mutex);
 
   return num_frames;
 }
@@ -2371,23 +2371,23 @@ spotify_artwork_get(struct evbuffer *evbuf, char *path, int max_w, int max_h)
   artwork.max_w = max_w;
   artwork.max_h = max_h;
 
-  pthread_mutex_init(&artwork.mutex, NULL);
-  pthread_cond_init(&artwork.cond, NULL);
+  fork_mutex_init(&artwork.mutex);
+  fork_cond_init(&artwork.cond);
 
   ret = commands_exec_sync(cmdbase, artwork_get, NULL, &artwork);
-  
+
   // Artwork was not ready, wait for callback from libspotify
   if (ret == 0)
     {
-      pthread_mutex_lock(&artwork.mutex);
+      fork_mutex_lock(&artwork.mutex);
       mk_reltime(&ts, SPOTIFY_ARTWORK_TIMEOUT);
       if (!artwork.is_loaded)
-	pthread_cond_timedwait(&artwork.cond, &artwork.mutex, &ts);
-      pthread_mutex_unlock(&artwork.mutex);
+	fork_cond_timedwait(&artwork.cond, &artwork.mutex, &ts);
+      fork_mutex_unlock(&artwork.mutex);
 
       ret = commands_exec_sync(cmdbase, artwork_get_bh, NULL, &artwork);
     }
-    
+
   return ret;
 }
 
@@ -2499,7 +2499,7 @@ spotify_login(char *path)
 
   if (SP_CONNECTION_STATE_LOGGED_IN == fptr_sp_session_connectionstate(g_sess))
     {
-      pthread_mutex_lock(&login_lck);
+      fork_mutex_lock(&login_lck);
 
       DPRINTF(E_LOG, L_SPOTIFY, "Logging out of Spotify (current state is %d)\n", g_state);
 
@@ -2509,12 +2509,12 @@ spotify_login(char *path)
       if (SP_ERROR_OK != err)
 	{
 	  DPRINTF(E_LOG, L_SPOTIFY, "Could not logout of Spotify: %s\n", fptr_sp_error_message(err));
-	  pthread_mutex_unlock(&login_lck);
+	  fork_mutex_unlock(&login_lck);
 	  return;
 	}
 
-      pthread_cond_wait(&login_cond, &login_lck);
-      pthread_mutex_unlock(&login_lck);
+      fork_cond_wait(&login_cond, &login_lck);
+      fork_mutex_unlock(&login_lck);
     }
 
   DPRINTF(E_INFO, L_SPOTIFY, "Logging into Spotify\n");
@@ -2649,11 +2649,11 @@ spotify_init(void)
     }
   TAILQ_INIT(&g_audio_fifo->q);
   g_audio_fifo->qlen = 0;
-  pthread_mutex_init(&g_audio_fifo->mutex, NULL);
-  pthread_cond_init(&g_audio_fifo->cond, NULL);
+  fork_mutex_init(&g_audio_fifo->mutex);
+  fork_cond_init(&g_audio_fifo->cond);
 
-  pthread_mutex_init(&login_lck, NULL);
-  pthread_cond_init(&login_cond, NULL);
+  fork_mutex_init(&login_lck);
+  fork_cond_init(&login_cond);
 
   /* Spawn thread */
   ret = pthread_create(&tid_spotify, NULL, spotify, NULL);
@@ -2673,11 +2673,11 @@ spotify_init(void)
   return 0;
 
  thread_fail:
-  pthread_cond_destroy(&login_cond);
-  pthread_mutex_destroy(&login_lck);
+  fork_cond_destroy(&login_cond);
+  fork_mutex_destroy(&login_lck);
 
-  pthread_cond_destroy(&g_audio_fifo->cond);
-  pthread_mutex_destroy(&g_audio_fifo->mutex);
+  fork_cond_destroy(&g_audio_fifo->cond);
+  fork_mutex_destroy(&g_audio_fifo->mutex);
   free(g_audio_fifo);  
 
  audio_fifo_fail:
@@ -2737,12 +2737,12 @@ spotify_deinit(void)
   close(g_notify_pipe[1]);
 
   /* Destroy locks */
-  pthread_cond_destroy(&login_cond);
-  pthread_mutex_destroy(&login_lck);
+  fork_cond_destroy(&login_cond);
+  fork_mutex_destroy(&login_lck);
 
   /* Clear audio fifo */
-  pthread_cond_destroy(&g_audio_fifo->cond);
-  pthread_mutex_destroy(&g_audio_fifo->mutex);
+  fork_cond_destroy(&g_audio_fifo->cond);
+  fork_mutex_destroy(&g_audio_fifo->mutex);
   free(g_audio_fifo);
 
   /* Release libspotify handle */

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -2044,7 +2044,7 @@ void
 spotify_oauth_callback(struct evbuffer *evbuf, struct evkeyvalq *param, const char *redirect_uri)
 {
   const char *code;
-  const char *err = "";
+  const char *err;
   int ret;
 
   code = evhttp_find_header(param, "code");

--- a/src/spotify_webapi.c
+++ b/src/spotify_webapi.c
@@ -294,6 +294,7 @@ spotifywebapi_token_get(const char *code, const char *redirect_uri, const char *
   struct keyval kv;
   int ret;
 
+  *err = "";
   memset(&kv, 0, sizeof(struct keyval));
   ret = ( (keyval_add(&kv, "grant_type", "authorization_code") == 0) &&
           (keyval_add(&kv, "code", code) == 0) &&


### PR DESCRIPTION
I struggled with memory corruption problems on OSX for a few hours before finally tracking down some uninitialized thread structures (leading to stack corruption).  In the process of tracking this down, I added checks on all the mutex/condition calls so that the next time this happens, it'll be easier to track down!  This may also catch thread problems in code i haven't tested yet (for example, I don't have a spotify account to run checks on the library, but then they're removing support for it soon, and that's another issue :)