### PR TITLE
[mpd] Allow adding non-library items to the queue

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -4233,6 +4233,11 @@ db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id)
     }
 
   DPRINTF(E_DBG, L_DB, "Player queue query returned %d items\n", qp->results);
+  if (qp->results == 0)
+    {
+      db_transaction_end();
+      return 0;
+    }
 
   while (((ret = db_query_fetch_file(qp, &dbmfi)) == 0) && (dbmfi.id))
     {
@@ -4322,6 +4327,68 @@ db_queue_add_by_fileid(int id, char reshuffle, uint32_t item_id)
   ret = db_queue_add_by_query(&qp, reshuffle, item_id);
 
   return ret;
+}
+
+int
+db_queue_add_item(struct db_queue_item *queue_item, char reshuffle, uint32_t item_id)
+{
+#define Q_TMPL "INSERT INTO queue "							\
+		    "(id, file_id, song_length, data_kind, media_kind, "		\
+		    "pos, shuffle_pos, path, virtual_path, title, "			\
+		    "artist, album_artist, album, genre, songalbumid, "			\
+		    "time_modified, artist_sort, album_sort, album_artist_sort, year, "	\
+		    "track, disc)" 							\
+		"VALUES"                                           			\
+		    "(NULL, %d, %d, %d, %d, "						\
+		    "%d, %d, %Q, %Q, %Q, "						\
+		    "%Q, %Q, %Q, %Q, %d, "						\
+		    "%d, %Q, %Q, %Q, %d, "						\
+		    "%d, %d);"
+
+  char *query;
+  int pos;
+  int ret;
+
+  db_transaction_begin();
+
+  pos = db_queue_get_count();
+  if (pos < 0)
+    {
+      DPRINTF(E_LOG, L_DB, "Could not get count from queue\n");
+      db_transaction_rollback();
+      return -1;
+    }
+
+  query = sqlite3_mprintf(Q_TMPL,
+			  queue_item->file_id, queue_item->song_length, queue_item->data_kind, queue_item->media_kind,
+			  pos, pos, queue_item->path, queue_item->virtual_path, queue_item->title,
+			  queue_item->artist, queue_item->album_artist, queue_item->album, queue_item->genre, queue_item->songalbumid,
+			  queue_item->time_modified, queue_item->artist_sort, queue_item->album_sort, queue_item->album_artist_sort, queue_item->year,
+			  queue_item->track, queue_item->disc);
+  ret = db_query_run(query, 1, 0);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_DB, "Error adding queue item\n");
+      db_transaction_rollback();
+      return -1;
+    }
+
+  ret = (int) sqlite3_last_insert_rowid(hdl);
+
+  db_transaction_end();
+
+  // Reshuffle after adding new items
+  if (reshuffle)
+    {
+      db_queue_reshuffle(item_id);
+    }
+  else
+    {
+      queue_inc_version_and_notify();
+    }
+  return ret;
+
+#undef Q_TMPL
 }
 
 static int

--- a/src/db.h
+++ b/src/db.h
@@ -703,6 +703,9 @@ int
 db_queue_add_by_fileid(int id, char reshuffle, uint32_t item_id);
 
 int
+db_queue_add_item(struct db_queue_item *queue_item, char reshuffle, uint32_t item_id);
+
+int
 db_queue_enum_start(struct query_params *query_params);
 
 void

--- a/src/library.c
+++ b/src/library.c
@@ -462,7 +462,7 @@ scan_media(const char *path, time_t mtime, off_t size, enum data_kind data_kind,
 }
 
 void
-library_process_media(const char *path, time_t mtime, off_t size, enum data_kind data_kind, enum media_kind force_media_kind, bool force_compilation, struct media_file_info *external_mfi, int dir_id)
+library_add_media(const char *path, time_t mtime, off_t size, enum data_kind data_kind, enum media_kind force_media_kind, bool force_compilation, struct media_file_info *external_mfi, int dir_id)
 {
   struct media_file_info *mfi;
   time_t stamp;

--- a/src/library.c
+++ b/src/library.c
@@ -46,6 +46,9 @@
 #include "logger.h"
 #include "misc.h"
 #include "player.h"
+#ifdef HAVE_SPOTIFY_H
+# include "spotify.h"
+#endif
 
 
 static struct commands_base *cmdbase;
@@ -337,46 +340,31 @@ fixup_tags(struct media_file_info *mfi)
     sort_tag_create(&mfi->composer_sort, mfi->composer);
 }
 
-void
-library_process_media(const char *path, time_t mtime, off_t size, enum data_kind data_kind, enum media_kind force_media_kind, bool force_compilation, struct media_file_info *external_mfi, int dir_id)
+static struct media_file_info *
+scan_media(const char *path, time_t mtime, off_t size, enum data_kind data_kind, enum media_kind force_media_kind, bool force_compilation, struct media_file_info *external_mfi)
 {
   struct media_file_info *mfi;
   const char *filename;
-  time_t stamp;
-  int id;
-  char virtual_path[PATH_MAX];
   int ret;
+
+  if (!external_mfi)
+    {
+      mfi = calloc(1, sizeof(struct media_file_info));
+      if (!mfi)
+	{
+	  DPRINTF(E_LOG, L_LIB, "Out of memory for mfi\n");
+	  return NULL;
+	}
+    }
+  else
+    mfi = external_mfi;
+
 
   filename = strrchr(path, '/');
   if ((!filename) || (strlen(filename) == 1))
     filename = path;
   else
     filename++;
-
-  db_file_stamp_bypath(path, &stamp, &id);
-
-  if (stamp && (stamp >= mtime))
-    {
-      db_file_ping(id);
-      return;
-    }
-
-  if (!external_mfi)
-    {
-      mfi = (struct media_file_info*)malloc(sizeof(struct media_file_info));
-      if (!mfi)
-	{
-	  DPRINTF(E_LOG, L_LIB, "Out of memory for mfi\n");
-	  return;
-	}
-
-      memset(mfi, 0, sizeof(struct media_file_info));
-    }
-  else
-    mfi = external_mfi;
-
-  if (stamp)
-    mfi->id = id;
 
   mfi->fname = strdup(filename);
   if (!mfi->fname)
@@ -421,7 +409,20 @@ library_process_media(const char *path, time_t mtime, off_t size, enum data_kind
   else if (data_kind == DATA_KIND_SPOTIFY)
     {
       mfi->data_kind = DATA_KIND_SPOTIFY;
-      ret = mfi->artist && mfi->album && mfi->title;
+      if (!external_mfi)
+	{
+	  // Only retrieve metadata if external_mfi is NULL
+#ifdef HAVE_SPOTIFY_H
+	  ret = scan_metadata_spotify(path, mfi);
+#else
+	  ret = -1;
+#endif
+	}
+      else
+	{
+	  // If an external_mfi is given, we assume that metadata has already been fully loaded
+	  ret = mfi->artist && mfi->album && mfi->title;
+	}
     }
   else if (data_kind == DATA_KIND_PIPE)
     {
@@ -452,6 +453,40 @@ library_process_media(const char *path, time_t mtime, off_t size, enum data_kind
 
   fixup_tags(mfi);
 
+  return mfi;
+
+ out:
+  if (!external_mfi)
+    free_mfi(mfi, 0);
+  return NULL;
+}
+
+void
+library_process_media(const char *path, time_t mtime, off_t size, enum data_kind data_kind, enum media_kind force_media_kind, bool force_compilation, struct media_file_info *external_mfi, int dir_id)
+{
+  struct media_file_info *mfi;
+  time_t stamp;
+  int id;
+  char virtual_path[PATH_MAX];
+
+  db_file_stamp_bypath(path, &stamp, &id);
+
+  if (stamp && (stamp >= mtime))
+    {
+      db_file_ping(id);
+      return;
+    }
+
+  mfi = scan_media(path, mtime, size, data_kind, force_media_kind, force_compilation, external_mfi);
+  if (!mfi)
+    {
+      DPRINTF(E_LOG, L_LIB, "Error scanning metadata for '%s'\n", path);
+      return;
+    }
+
+  if (stamp)
+    mfi->id = id;
+
   if (data_kind == DATA_KIND_HTTP)
     {
       snprintf(virtual_path, PATH_MAX, "/http:/%s", mfi->title);
@@ -474,10 +509,50 @@ library_process_media(const char *path, time_t mtime, off_t size, enum data_kind
     db_file_add(mfi);
   else
     db_file_update(mfi);
+}
 
- out:
-  if (!external_mfi)
-    free_mfi(mfi, 0);
+static enum data_kind
+parse_data_kind(const char *path)
+{
+  if (strncmp(path, "http:", strlen("http:")) == 0)
+    {
+      return DATA_KIND_HTTP;
+    }
+  else if (strncmp(path, "spotify:", strlen("spotify:")) == 0)
+    {
+      return DATA_KIND_SPOTIFY;
+    }
+  else if (strncmp(path, "/", strlen("/")) == 0)
+    {
+      return DATA_KIND_FILE;
+    }
+
+  return 0;
+}
+
+struct media_file_info *
+library_scan_media(const char *path)
+{
+  struct media_file_info *mfi;
+  enum data_kind data_kind;
+
+  data_kind = parse_data_kind(path);
+  if (!data_kind)
+    {
+      DPRINTF(E_LOG, L_LIB, "Could not determine data kind for path '%s'\n", path);
+      return NULL;
+    }
+
+  mfi = scan_media(path, 0, 0, data_kind, 0, false, NULL);
+  if (!mfi)
+    {
+      DPRINTF(E_LOG, L_LIB, "Unable to scan metadata for path '%s'\n", path);
+      return NULL;
+    }
+
+  mfi->virtual_path = strdup(path);
+
+  return mfi;
 }
 
 int
@@ -546,6 +621,38 @@ library_add_playlist_info(const char *path, const char *title, const char *virtu
 
   free_pli(pli, 0);
   return plid;
+}
+
+int
+library_add_queue_item(struct media_file_info* mfi)
+{
+  struct db_queue_item queue_item;
+
+  memset(&queue_item, 0, sizeof(struct db_queue_item));
+
+  if (mfi->id)
+    queue_item.file_id = mfi->id;
+  else
+    queue_item.file_id = 9999999;
+
+  queue_item.title = mfi->title;
+  queue_item.artist = mfi->artist;
+  queue_item.album_artist = mfi->album_artist;
+  queue_item.album = mfi->album;
+  queue_item.genre = mfi->genre;
+  queue_item.artist_sort = mfi->artist_sort;
+  queue_item.album_artist_sort = mfi->album_artist_sort;
+  queue_item.album_sort = mfi->album_sort;
+  queue_item.path = mfi->path;
+  queue_item.virtual_path = mfi->virtual_path;
+  queue_item.data_kind = mfi->data_kind;
+  queue_item.media_kind = mfi->media_kind;
+
+#ifdef HAVE_SPOTIFY_H
+  if (mfi->data_kind == DATA_KIND_SPOTIFY && !mfi->id)
+    spotify_uri_register(mfi->path);
+#endif
+  return db_queue_add_item(&queue_item, 0, 0);
 }
 
 static void

--- a/src/library.h
+++ b/src/library.h
@@ -65,7 +65,7 @@ struct library_source
 
 
 void
-library_process_media(const char *path, time_t mtime, off_t size, enum data_kind data_kind, enum media_kind force_media_kind, bool force_compilation, struct media_file_info *external_mfi, int dir_id);
+library_add_media(const char *path, time_t mtime, off_t size, enum data_kind data_kind, enum media_kind force_media_kind, bool force_compilation, struct media_file_info *external_mfi, int dir_id);
 
 int
 library_add_playlist_info(const char *path, const char *title, const char *virtual_path, enum pl_type type, int parent_pl_id, int dir_id);

--- a/src/library.h
+++ b/src/library.h
@@ -61,7 +61,6 @@ struct library_source
    * Run a full rescan (purge library entries and rescan) (called from the library thread)
    */
   int (*fullrescan)(void);
-
 };
 
 
@@ -70,6 +69,12 @@ library_process_media(const char *path, time_t mtime, off_t size, enum data_kind
 
 int
 library_add_playlist_info(const char *path, const char *title, const char *virtual_path, enum pl_type type, int parent_pl_id, int dir_id);
+
+struct media_file_info *
+library_scan_media(const char *path);
+
+int
+library_add_queue_item(struct media_file_info* mfi);
 
 void
 library_rescan();

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -417,7 +417,7 @@ process_file(char *file, time_t mtime, off_t size, int type, int flags, int dir_
 	else
 	  data_kind = DATA_KIND_FILE;
 
-	library_process_media(file, mtime, size, data_kind, media_kind, is_type_compilation, NULL, dir_id);
+	library_add_media(file, mtime, size, data_kind, media_kind, is_type_compilation, NULL, dir_id);
 
 	cache_artwork_ping(file, mtime, !is_bulkscan);
 	// TODO [artworkcache] If entry in artwork cache exists for no artwork available, delete the entry if media file has embedded artwork

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -239,7 +239,7 @@ scan_playlist(char *file, time_t mtime, int dir_id)
 	  if (extinf)
 	    DPRINTF(E_INFO, L_SCAN, "Playlist has EXTINF metadata, artist is '%s', title is '%s'\n", mfi.artist, mfi.title);
 
-	  library_process_media(filename, mtime, 0, DATA_KIND_HTTP, 0, false, &mfi, DIR_HTTP);
+	  library_add_media(filename, mtime, 0, DATA_KIND_HTTP, 0, false, &mfi, DIR_HTTP);
 	}
       /* Regular file, should already be in library */
       else

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -719,7 +719,7 @@ spotify_track_save(int plid, sp_track *track, const char *pltitle, int time_adde
 
 //  DPRINTF(E_DBG, L_SPOTIFY, "Saving track '%s': '%s' by %s (%s)\n", url, mfi.title, mfi.artist, mfi.album);
 
-  library_process_media(url, time(NULL), 0, DATA_KIND_SPOTIFY, 0, false, &mfi, dir_id);
+  library_add_media(url, time(NULL), 0, DATA_KIND_SPOTIFY, 0, false, &mfi, dir_id);
 
   free_mfi(&mfi, 1);
 
@@ -2212,7 +2212,7 @@ scan_saved_albums()
 		  map_track_to_mfi(&track, &mfi);
 		  map_album_to_mfi(&album, &mfi);
 
-		  library_process_media(track.uri, album.mtime, 0, DATA_KIND_SPOTIFY, 0, album.is_compilation, &mfi, dir_id);
+		  library_add_media(track.uri, album.mtime, 0, DATA_KIND_SPOTIFY, 0, album.is_compilation, &mfi, dir_id);
 		  spotify_uri_register(track.uri);
 
 		  cache_artwork_ping(track.uri, album.mtime, 0);
@@ -2278,7 +2278,7 @@ scan_playlisttracks(struct spotify_playlist *playlist, int plid)
 		  mfi.album = strdup(playlist->name);
 		}
 
-	      library_process_media(track.uri, 1 /* TODO passing one prevents overwriting existing entries */, 0, DATA_KIND_SPOTIFY, 0, track.is_compilation, &mfi, dir_id);
+	      library_add_media(track.uri, 1 /* TODO passing one prevents overwriting existing entries */, 0, DATA_KIND_SPOTIFY, 0, track.is_compilation, &mfi, dir_id);
 	      spotify_uri_register(track.uri);
 
 	      cache_artwork_ping(track.uri, 1, 0);

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -2074,7 +2074,7 @@ spotify_oauth_callback(struct evbuffer *evbuf, struct evkeyvalq *param, const ch
   return;
 }
 
-static void
+void
 spotify_uri_register(const char *uri)
 {
   char *tmp;
@@ -2397,6 +2397,30 @@ scan_playlist(const char *uri)
   spotifywebapi_request_end(&request);
 
   return 0;
+}
+
+int
+scan_metadata_spotify(const char *uri, struct media_file_info *mfi)
+{
+  struct spotify_request request;
+  struct spotify_track track;
+  int ret;
+
+  memset(&request, 0, sizeof(struct spotify_request));
+
+  ret = spotifywebapi_track_start(&request, uri, &track);
+  if (ret == 0)
+    {
+      DPRINTF(E_DBG, L_SPOTIFY, "Got track: '%s' (%s) \n", track.name, track.uri);
+
+      map_track_to_mfi(&track, mfi);
+
+      spotify_uri_register(uri);
+    }
+
+  spotifywebapi_request_end(&request);
+
+  return ret;
 }
 
 static void

--- a/src/spotify.h
+++ b/src/spotify.h
@@ -6,6 +6,8 @@
 #include <event2/buffer.h>
 #include <event2/http.h>
 
+#include "db.h"
+
 int
 spotify_playback_setup(const char *path);
 
@@ -38,6 +40,12 @@ spotify_oauth_interface(struct evbuffer *evbuf, const char *redirect_uri);
 
 void
 spotify_oauth_callback(struct evbuffer *evbuf, struct evkeyvalq *param, const char *redirect_uri);
+
+int
+scan_metadata_spotify(const char *uri, struct media_file_info *mfi);
+
+void
+spotify_uri_register(const char *uri);
 
 void
 spotify_login(char *path);

--- a/src/spotify_webapi.h
+++ b/src/spotify_webapi.h
@@ -117,5 +117,7 @@ int
 spotifywebapi_playlisttracks_fetch(struct spotify_request *request, struct spotify_track *track);
 int
 spotifywebapi_playlist_start(struct spotify_request *request, const char *path, struct spotify_playlist *playlist);
+int
+spotifywebapi_track_start(struct spotify_request *request, const char *path, struct spotify_track *track);
 
 #endif /* SRC_SPOTIFY_WEBAPI_H_ */


### PR DESCRIPTION
This pr allows mpd clients to add items to the queue that are not in the library. Similar to mpd, passing a internetradio-stream-url to the 'add' or 'addid' command will append the stream to the queue, even if it is not part of a local playlist.