### PR TITLE
[travic-ci] Added configuration file for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: c
+sudo: required
+dist: trusty
+env:
+  matrix:
+    - CFG=""
+    - CFG="--enable-lastfm"
+    - CFG="--enable-itunes"
+    - CFG="--enable-spotify"
+
+script:
+  - autoreconf -fi
+  - ./configure $CFG
+  - scan-build --status-bugs -disable-checker deadcode.DeadStores make
+
+before_install:
+  - wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
+  - sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/jessie.list
+  - sudo apt-get -qq update
+  - sudo apt-get install -y build-essential clang git autotools-dev autoconf libtool gettext gawk gperf antlr3 libantlr3c-dev libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libmxml-dev libgcrypt11-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libcurl4-openssl-dev libjson-c-dev libspotify-dev 
+  
+# Disable email notification
+notifications:
+  email: false


### PR DESCRIPTION
It would be nice, if this could be included in master. If you do not register your github repository with travic-ci.org it should do no harm. If registered, a build is triggered and checked with scan-build automatically after each push: https://travis-ci.org/chme/forked-daapd