### PR TITLE
Fixed warnings in logger.c

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdarg.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <errno.h>


### PR DESCRIPTION
Looks like abort is defined in stdlib.h, but was indirectly pulled in on all my test systems, so I missed that include :)  Here's a patch.
