### PR TITLE
Fix for dacp-cue-play request

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1099,6 +1099,17 @@ dacp_reply_cue_play(struct evhttp_request *req, struct evbuffer *evbuf, char **u
 	    }
 	}
     }
+  else
+    {
+      queue_item = db_queue_fetch_bypos(pos, status.shuffle);
+      if (!queue_item)
+	{
+	  DPRINTF(E_LOG, L_DACP, "Could not fetch item from queue: pos=%d\n", pos);
+
+	  dmap_send_error(req, "cacr", "Playback failed to start");
+	  return;
+	}
+    }
 
   ret = player_playback_start_byitem(queue_item);
   free_queue_item(queue_item, 0);

--- a/src/player.c
+++ b/src/player.c
@@ -1929,6 +1929,8 @@ playback_start_item(void *arg, int *retval)
 
   if (player_state == PLAY_PLAYING)
     {
+      DPRINTF(E_DBG, L_PLAYER, "Player is already playing, ignoring call to playback start\n");
+
       status_update(player_state);
 
       *retval = 1; // Value greater 0 will prevent execution of the bottom half function
@@ -1940,6 +1942,8 @@ playback_start_item(void *arg, int *retval)
 
   if (player_state == PLAY_STOPPED && !queue_item)
     {
+      DPRINTF(E_LOG, L_PLAYER, "Failed to start/resume playback, no queue item given\n");
+
       *retval = -1;
       return COMMAND_END;
     }


### PR DESCRIPTION
This should restore the old behavior (before the persistent queue change) in "dacp_reply_cue_play" if "command" parameter is not "playnow" (plus some additional log message in player.c).