### PR TITLE
Fix mpd delete (by pos)

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -4929,7 +4929,7 @@ db_queue_delete_bypos(uint32_t pos, int count)
   memset(&query_params, 0, sizeof(struct query_params));
 
   to_pos = pos + count;
-  query_params.filter = sqlite3_mprintf("pos => %d AND pos < %d", pos, to_pos);
+  query_params.filter = sqlite3_mprintf("pos >= %d AND pos < %d", pos, to_pos);
 
   db_transaction_begin();
 


### PR DESCRIPTION
The mpd command "delete" with a given range of queue positions failed (due to an invalid query filter and a wrong assumption on my end, see commit message). 