### PR TITLE
[spotify] Retrieve playlist tracks based on user country

### DIFF
--- a/src/spotify_webapi.h
+++ b/src/spotify_webapi.h
@@ -68,6 +68,10 @@ struct spotify_track
   const char *name;
   int track_number;
   const char *uri;
+
+  bool is_playable;
+  const char *restrictions;
+  const char *linked_from_uri;
 };
 
 struct spotify_playlist
@@ -106,7 +110,7 @@ spotifywebapi_token_refresh();
 void
 spotifywebapi_request_end(struct spotify_request *request);
 int
-spotifywebapi_request_next(struct spotify_request *request, const char *uri);
+spotifywebapi_request_next(struct spotify_request *request, const char *uri, bool append_market);
 int
 spotifywebapi_saved_albums_fetch(struct spotify_request *request, json_object **jsontracks, int *track_count, struct spotify_album *album);
 int


### PR DESCRIPTION
Reading the user country from the spotify web api requires an additional scope (user-read-private). This means you need to reauthorize forked-daapd through the web interface to make it work. If forked-daapd cannot read the user country the behavior is the same as before.

I am not sure if this is the best approach. This requests the user information on each token-refresh. Another way to do it would be to request the information once and store it in the db. 

The diff is a bit larger than necessary due to moving some functions around.