### PR TITLE
Keep the now playing item in the queue when calling playqueueedit_clear

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -735,7 +735,7 @@ int
 db_queue_cleanup();
 
 int
-db_queue_clear();
+db_queue_clear(uint32_t keep_item_id);
 
 int
 db_queue_delete_byitemid(uint32_t item_id);

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1013,7 +1013,7 @@ dacp_reply_cue_play(struct evhttp_request *req, struct evbuffer *evbuf, char **u
 	{
 	  player_playback_stop();
 
-	  db_queue_clear();
+	  db_queue_clear(0);
 	}
     }
 
@@ -1137,7 +1137,7 @@ dacp_reply_cue_clear(struct evhttp_request *req, struct evbuffer *evbuf, char **
 
   player_playback_stop();
 
-  db_queue_clear();
+  db_queue_clear(0);
 
   dmap_add_container(evbuf, "cacr", 24); /* 8 + len */
   dmap_add_int(evbuf, "mstt", 200);      /* 12 */
@@ -1268,7 +1268,7 @@ dacp_reply_playspec(struct evhttp_request *req, struct evbuffer *evbuf, char **u
   if (status.status != PLAY_STOPPED)
     player_playback_stop();
 
-  db_queue_clear();
+  db_queue_clear(0);
 
   if (plid > 0)
     ret = db_queue_add_by_playlistid(plid, status.shuffle, status.item_id);
@@ -1747,6 +1747,7 @@ static void
 dacp_reply_playqueueedit_clear(struct evhttp_request *req, struct evbuffer *evbuf, char **uri, struct evkeyvalq *query)
 {
   const char *param;
+  struct player_status status;
 
   param = evhttp_find_header(query, "mode");
 
@@ -1758,7 +1759,10 @@ dacp_reply_playqueueedit_clear(struct evhttp_request *req, struct evbuffer *evbu
   if (strcmp(param,"0x68697374") == 0)
     player_queue_clear_history();
   else
-    db_queue_clear();
+    {
+      player_get_status(&status);
+      db_queue_clear(status.item_id);
+    }
 
   dmap_add_container(evbuf, "cacr", 24); /* 8 + len */
   dmap_add_int(evbuf, "mstt", 200);      /* 12 */
@@ -1810,7 +1814,7 @@ dacp_reply_playqueueedit_add(struct evhttp_request *req, struct evbuffer *evbuf,
   if ((mode == 1) || (mode == 2))
     {
       player_playback_stop();
-      db_queue_clear();
+      db_queue_clear(0);
     }
 
   editquery = evhttp_find_header(query, "query");

--- a/src/library.c
+++ b/src/library.c
@@ -613,7 +613,7 @@ fullrescan(void *arg, int *ret)
   starttime = time(NULL);
 
   player_playback_stop();
-  db_queue_clear();
+  db_queue_clear(0);
   db_purge_all(); // Clears files, playlists, playlistitems, inotify and groups
 
   for (i = 0; sources[i]; i++)
@@ -696,7 +696,7 @@ initscan()
   clear_queue_disabled = cfg_getbool(cfg_getsec(cfg, "mpd"), "clear_queue_on_stop_disable");
   if (!clear_queue_disabled)
     {
-      db_queue_clear();
+      db_queue_clear(0);
     }
 
   for (i = 0; sources[i]; i++)

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1626,7 +1626,7 @@ mpd_command_clear(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       DPRINTF(E_DBG, L_MPD, "Failed to stop playback\n");
     }
 
-  db_queue_clear();
+  db_queue_clear(0);
 
   return 0;
 }
@@ -1648,7 +1648,7 @@ mpd_command_delete(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
   // If argv[1] is ommited clear the whole queue
   if (argc < 2)
     {
-      db_queue_clear();
+      db_queue_clear(0);
       return 0;
     }
 

--- a/src/player.c
+++ b/src/player.c
@@ -1696,7 +1696,7 @@ playback_abort(void)
   source_stop();
 
   if (!clear_queue_on_stop_disabled)
-    db_queue_clear();
+    db_queue_clear(0);
 
   status_update(PLAY_STOPPED);
 
@@ -2052,7 +2052,7 @@ playback_start_id(void *arg, int *retval)
 
   if (player_state == PLAY_STOPPED)
     {
-      db_queue_clear();
+      db_queue_clear(0);
 
       ret = db_queue_add_by_fileid(cmdarg->id, 0, 0);
       if (ret < 0)


### PR DESCRIPTION
Hi @ejurgensen, this should address the issue with remote when clearing the up-next queue. It should only affect dacp clients (at all the other places queue-clear is called, playback has already stopped).