### PR TITLE
Cleanup and minor fixes for spotify integration

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -4165,7 +4165,7 @@ db_queue_add_by_queryafteritemid(struct query_params *qp, uint32_t item_id)
  * @param qp Query parameters for the files table
  * @param reshuffle If 1 queue will be reshuffled after adding new items
  * @param item_id The base item id, all items after this will be reshuffled
- * @return 0 on success, -1 on failure
+ * @return Item id of the last inserted item on success, -1 on failure
  */
 int
 db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id)
@@ -4217,7 +4217,8 @@ db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id)
       return -1;
     }
 
-  ret = (int) sqlite3_last_insert_rowid(hdl);
+  if (pos > 0)
+    ret = (int) sqlite3_last_insert_rowid(hdl);
 
   db_transaction_end();
 

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1664,10 +1664,14 @@ db_upgrade(sqlite3 *hdl, int db_ver)
       if (ret < 0)
 	return -1;
 
+      /* FALLTHROUGH */
+
     case 1901:
       ret = db_generic_upgrade(hdl, db_upgrade_v1902_queries, sizeof(db_upgrade_v1902_queries) / sizeof(db_upgrade_v1902_queries[0]));
       if (ret < 0)
 	return -1;
+
+      /* FALLTHROUGH */
 
     case 1902:
       ret = db_generic_upgrade(hdl, db_upgrade_v1903_queries, sizeof(db_upgrade_v1903_queries) / sizeof(db_upgrade_v1903_queries[0]));

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -17,9 +17,6 @@
 int
 scan_metadata_ffmpeg(const char *file, struct media_file_info *mfi);
 
-int
-scan_metadata_icy(char *url, struct media_file_info *mfi);
-
 void
 scan_playlist(char *file, time_t mtime, int dir_id);
 

--- a/src/library/filescanner_ffmpeg.c
+++ b/src/library/filescanner_ffmpeg.c
@@ -378,17 +378,14 @@ scan_metadata_ffmpeg(const char *file, struct media_file_info *mfi)
   path = strdup(file);
 
 #if LIBAVFORMAT_VERSION_MAJOR >= 54 || (LIBAVFORMAT_VERSION_MAJOR == 53 && LIBAVFORMAT_VERSION_MINOR >= 3)
-# ifndef HAVE_FFMPEG
-  // Without this, libav is slow to probe some internet streams
   if (mfi->data_kind == DATA_KIND_HTTP)
     {
+# ifndef HAVE_FFMPEG
+      // Without this, libav is slow to probe some internet streams
       ctx = avformat_alloc_context();
       ctx->probesize = 64000;
-    }
 # endif
 
-  if (mfi->data_kind == DATA_KIND_HTTP)
-    {
       free(path);
       ret = http_stream_setup(&path, file);
       if (ret < 0)

--- a/src/library/filescanner_ffmpeg.c
+++ b/src/library/filescanner_ffmpeg.c
@@ -350,6 +350,16 @@ extract_metadata(struct media_file_info *mfi, AVFormatContext *ctx, AVStream *au
   return mdcount;
 }
 
+/*
+ * Fills metadata read with ffmpeg/libav from the given path into the given mfi
+ *
+ * Following attributes from the given mfi are read to control how to read metadata:
+ * - data_kind: if data_kind is http, icy metadata is used, if the path points to a playlist the first stream-uri in that playlist is used
+ * - media_kind: if media_kind is podcast or audiobook, video streams in the file are ignored
+ * - compilation: like podcast/audiobook video streams are ignored for compilations
+ * - file_size: if bitrate could not be read through ffmpeg/libav, file_size is used to estimate the bitrate
+ * - fname: (filename) used as fallback for artist
+ */
 int
 scan_metadata_ffmpeg(const char *file, struct media_file_info *mfi)
 {

--- a/src/misc.c
+++ b/src/misc.c
@@ -808,17 +808,17 @@ murmur_hash64(const void *key, int len, uint32_t seed)
   switch (len & 7)
     {
       case 7:
-	h ^= (uint64_t)(data_tail[6]) << 48;
+	h ^= (uint64_t)(data_tail[6]) << 48; /* FALLTHROUGH */
       case 6:
-	h ^= (uint64_t)(data_tail[5]) << 40;
+	h ^= (uint64_t)(data_tail[5]) << 40; /* FALLTHROUGH */
       case 5:
-	h ^= (uint64_t)(data_tail[4]) << 32;
+	h ^= (uint64_t)(data_tail[4]) << 32; /* FALLTHROUGH */
       case 4:
-	h ^= (uint64_t)(data_tail[3]) << 24;
+	h ^= (uint64_t)(data_tail[3]) << 24; /* FALLTHROUGH */
       case 3:
-	h ^= (uint64_t)(data_tail[2]) << 16;
+	h ^= (uint64_t)(data_tail[2]) << 16; /* FALLTHROUGH */
       case 2:
-	h ^= (uint64_t)(data_tail[1]) << 8;
+	h ^= (uint64_t)(data_tail[1]) << 8; /* FALLTHROUGH */
       case 1:
 	h ^= (uint64_t)(data_tail[0]);
 	h *= m;

--- a/src/outputs/cast.c
+++ b/src/outputs/cast.c
@@ -1471,6 +1471,8 @@ cast_session_shutdown(struct cast_session *cs, enum cast_state wanted_state)
 	if ((ret < 0) || (wanted_state >= CAST_STATE_MEDIA_LAUNCHED))
 	  break;
 
+	/* FALLTHROUGH */
+
       case CAST_STATE_MEDIA_LAUNCHED:
 	ret = cast_msg_send(cs, STOP, cast_cb_stop);
 	pending = 1;

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -2121,7 +2121,7 @@ scan_playlisttracks(struct spotify_playlist *playlist, int plid)
 	      memset(&mfi, 0, sizeof(struct media_file_info));
 	      map_track_to_mfi(&track, &mfi);
 
-	      track.is_compilation = (track.is_compilation || artist_override);
+	      mfi.compilation = (track.is_compilation || artist_override);
 	      if (album_override)
 		{
 		  free(mfi.album);


### PR DESCRIPTION
The first four commits are cleanups (there should be no functional changes) i found while working on support for non-library-items. The last three commits fix some (minor) problems i encountered:
- "artist_override" for spotify playlist tracks did not work
- In rare cases playing a spotify track did not succeed due to the track still being loaded (especially shortly after a restart of forked-daapd). Instead of registering all spotify tracks read from the web api with libspotify, a track is now only registered/loaded during playback setup. 