### PR TITLE
[spotify] Purge spotify songs from db before scanning after oauth

### DIFF
--- a/src/spotify.c
+++ b/src/spotify.c
@@ -2386,6 +2386,8 @@ fullrescan()
 static enum command_state
 webapi_scan(void *arg, int *ret)
 {
+  db_spotify_purge();
+
   *ret = rescan();
   return COMMAND_END;
 }


### PR DESCRIPTION
After (re) authenticating forked-daapd to access the spotify web api it makes sense to first purge existing spotify songs from the db before scanning them through the web api. 