### PR TITLE
Refactor scanning of metadata and support for adding internet radio streams

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -4194,6 +4194,13 @@ db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id)
 
   DPRINTF(E_DBG, L_DB, "Player queue query returned %d items\n", qp->results);
 
+  if (qp->results == 0)
+    {
+      db_query_end(qp);
+      db_transaction_end();
+      return 0;
+    }
+
   while (((ret = db_query_fetch_file(qp, &dbmfi)) == 0) && (dbmfi.id))
     {
       ret = queue_add_file(&dbmfi, pos, pos);
@@ -4217,8 +4224,7 @@ db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id)
       return -1;
     }
 
-  if (pos > 0)
-    ret = (int) sqlite3_last_insert_rowid(hdl);
+  ret = (int) sqlite3_last_insert_rowid(hdl);
 
   db_transaction_end();
 

--- a/src/db.h
+++ b/src/db.h
@@ -705,6 +705,9 @@ int
 db_queue_add_by_fileid(int id, char reshuffle, uint32_t item_id);
 
 int
+db_queue_add_item(struct db_queue_item *queue_item, char reshuffle, uint32_t item_id);
+
+int
 db_queue_enum_start(struct query_params *query_params);
 
 void

--- a/src/library.c
+++ b/src/library.c
@@ -511,6 +511,14 @@ library_add_queue_item(struct media_file_info *mfi)
   queue_item.virtual_path = mfi->virtual_path;
   queue_item.data_kind = mfi->data_kind;
   queue_item.media_kind = mfi->media_kind;
+  queue_item.song_length = mfi->song_length;
+  queue_item.seek = mfi->seek;
+  queue_item.songalbumid = mfi->songalbumid;
+  queue_item.time_modified = mfi->time_modified;
+  queue_item.year = mfi->year;
+  queue_item.track = mfi->track;
+  queue_item.disc = mfi->disc;
+  //queue_item.artwork_url
 
   return db_queue_add_item(&queue_item, 0, 0);
 }

--- a/src/library.c
+++ b/src/library.c
@@ -344,7 +344,7 @@ fixup_tags(struct media_file_info *mfi)
 }
 
 void
-library_process_media(struct media_file_info *mfi)
+library_add_media(struct media_file_info *mfi)
 {
   if (!mfi->path || !mfi->fname || !mfi->data_kind)
     {

--- a/src/library.c
+++ b/src/library.c
@@ -383,8 +383,8 @@ library_scan_media(const char *path, struct media_file_info *mfi)
 
   DPRINTF(E_DBG, L_LIB, "Scan metadata for path '%s'\n", path);
 
-  ret = METADATA_PATH_INVALID;
-  for (i = 0; sources[i] && ret == METADATA_PATH_INVALID; i++)
+  ret = LIBRARY_PATH_INVALID;
+  for (i = 0; sources[i] && ret == LIBRARY_PATH_INVALID; i++)
     {
       if (sources[i]->disabled || !sources[i]->scan_metadata)
         {
@@ -394,11 +394,11 @@ library_scan_media(const char *path, struct media_file_info *mfi)
 
       ret = sources[i]->scan_metadata(path, mfi);
 
-      if (ret == METADATA_OK)
+      if (ret == LIBRARY_OK)
 	DPRINTF(E_DBG, L_LIB, "Got metadata for path '%s' from library source '%s'\n", path, sources[i]->name);
     }
 
-  if (ret == METADATA_OK)
+  if (ret == LIBRARY_OK)
     {
       if (!mfi->virtual_path)
 	mfi->virtual_path = strdup(mfi->path);

--- a/src/library.h
+++ b/src/library.h
@@ -66,7 +66,7 @@ struct library_source
 
 
 void
-library_process_media(const char *path, time_t mtime, off_t size, enum data_kind data_kind, enum media_kind force_media_kind, bool force_compilation, struct media_file_info *external_mfi, int dir_id);
+library_process_media(struct media_file_info *mfi);
 
 int
 library_add_playlist_info(const char *path, const char *title, const char *virtual_path, enum pl_type type, int parent_pl_id, int dir_id);

--- a/src/library.h
+++ b/src/library.h
@@ -66,7 +66,7 @@ struct library_source
 
 
 void
-library_process_media(struct media_file_info *mfi);
+library_add_media(struct media_file_info *mfi);
 
 int
 library_add_playlist_info(const char *path, const char *title, const char *virtual_path, enum pl_type type, int parent_pl_id, int dir_id);

--- a/src/library.h
+++ b/src/library.h
@@ -83,7 +83,7 @@ int
 library_scan_media(const char *path, struct media_file_info *mfi);
 
 int
-library_add_queue_item(struct media_file_info* mfi);
+library_add_queue_item(struct media_file_info *mfi);
 
 void
 library_rescan();

--- a/src/library.h
+++ b/src/library.h
@@ -26,9 +26,9 @@
 #include "commands.h"
 #include "db.h"
 
-#define METADATA_OK 0
-#define METADATA_ERROR -1
-#define METADATA_PATH_INVALID -2
+#define LIBRARY_OK 0
+#define LIBRARY_ERROR -1
+#define LIBRARY_PATH_INVALID -2
 
 /*
  * Definition of a library source

--- a/src/library.h
+++ b/src/library.h
@@ -26,6 +26,10 @@
 #include "commands.h"
 #include "db.h"
 
+#define METADATA_OK 0
+#define METADATA_ERROR -1
+#define METADATA_PATH_INVALID -2
+
 /*
  * Definition of a library source
  *
@@ -62,6 +66,10 @@ struct library_source
    */
   int (*fullrescan)(void);
 
+  /*
+   * Scans metadata for the media file with the given path into the given mfi
+   */
+  int (*scan_metadata)(const char *path, struct media_file_info *mfi);
 };
 
 
@@ -70,6 +78,12 @@ library_add_media(struct media_file_info *mfi);
 
 int
 library_add_playlist_info(const char *path, const char *title, const char *virtual_path, enum pl_type type, int parent_pl_id, int dir_id);
+
+int
+library_scan_media(const char *path, struct media_file_info *mfi);
+
+int
+library_add_queue_item(struct media_file_info* mfi);
 
 void
 library_rescan();

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -162,6 +162,20 @@ static int
 filescanner_fullrescan();
 
 
+const char *
+filename_from_path(const char *path)
+{
+  const char *filename;
+
+  filename = strrchr(path, '/');
+  if ((!filename) || (strlen(filename) == 1))
+    filename = path;
+  else
+    filename++;
+
+  return filename;
+}
+
 static int
 push_dir(struct stacked_dir **s, char *path, int parent_id)
 {
@@ -417,7 +431,7 @@ process_regular_file(char *file, struct stat *sb, int type, int flags, int dir_i
   memset(&mfi, 0, sizeof(struct media_file_info));
 
   mfi.id = id;
-  mfi.fname = strdup(basename(file));
+  mfi.fname = strdup(filename_from_path(file));
   mfi.path = strdup(file);
 
   mfi.time_modified = sb->st_mtime;
@@ -1538,7 +1552,7 @@ scan_metadata(const char *path, struct media_file_info *mfi)
     {
       memset(mfi, 0, sizeof(struct media_file_info));
       mfi->path = strdup(path);
-      mfi->fname = strdup(basename(mfi->path));
+      mfi->fname = strdup(filename_from_path(mfi->path));
       mfi->data_kind = DATA_KIND_HTTP;
       mfi->directory_id = DIR_HTTP;
 

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -456,7 +456,7 @@ process_regular_file(char *file, struct stat *sb, int type, int flags, int dir_i
 	}
     }
 
-  library_process_media(&mfi);
+  library_add_media(&mfi);
 
   cache_artwork_ping(file, sb->st_mtime, !is_bulkscan);
   // TODO [artworkcache] If entry in artwork cache exists for no artwork available, delete the entry if media file has embedded artwork

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -1565,10 +1565,10 @@ scan_metadata(const char *path, struct media_file_info *mfi)
 	  mfi->description = strdup("MPEG audio file");
 	}
 
-      return METADATA_OK;
+      return LIBRARY_OK;
     }
 
-  return METADATA_PATH_INVALID;
+  return LIBRARY_PATH_INVALID;
 }
 
 /* Thread: main */

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -613,10 +613,10 @@ create_virtual_path(char *path, char *virtual_path, int virtual_path_len)
  * and resolved_path contains the resolved path (resolved_path must be of length PATH_MAX).
  * If path is not a symbolic link, resolved_path holds the same value as path.
  *
- * The return value is 0 if the operation is successful, or -1 on failure. In addition
+ * The return value is 0 if the operation is successful, or -1 on failure
  */
 static int
-read_attributes(const char *path, struct stat *sb, char *resolved_path)
+read_attributes(char *resolved_path, const char *path, struct stat *sb)
 {
   int ret;
 
@@ -723,7 +723,7 @@ process_directory(char *path, int parent_id, int flags)
 	  continue;
 	}
 
-      ret = read_attributes(entry, &sb, resolved_path);
+      ret = read_attributes(resolved_path, entry, &sb);
       if (ret < 0)
 	{
 	  DPRINTF(E_LOG, L_SCAN, "Skipping %s, read_attributes() failed\n", entry);
@@ -1254,7 +1254,7 @@ process_inotify_file(struct watch_info *wi, char *path, struct inotify_event *ie
 	    incomingfiles_buffer[i] = 0;
 	  }
 
-      ret = read_attributes(path, &sb, resolved_path);
+      ret = read_attributes(resolved_path, path, &sb);
       if (ret < 0)
         {
 	  DPRINTF(E_LOG, L_SCAN, "Skipping %s, read_attributes() failed\n", path);

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -4,14 +4,6 @@
 
 #include "db.h"
 
-#define F_SCAN_TYPE_FILE         (1 << 0)
-#define F_SCAN_TYPE_PODCAST      (1 << 1)
-#define F_SCAN_TYPE_AUDIOBOOK    (1 << 2)
-#define F_SCAN_TYPE_COMPILATION  (1 << 3)
-#define F_SCAN_TYPE_URL          (1 << 4)
-#define F_SCAN_TYPE_SPOTIFY      (1 << 5)
-#define F_SCAN_TYPE_PIPE         (1 << 6)
-
 
 /* Actual scanners */
 int

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -20,4 +20,7 @@ void
 scan_itunes_itml(char *file);
 #endif
 
+const char *
+filename_from_path(const char *path);
+
 #endif /* !__FILESCANNER_H__ */

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -75,6 +75,112 @@ extinf_get(char *string, struct media_file_info *mfi, int *extinf)
   return 1;
 }
 
+static int
+process_url(const char *path, time_t mtime, int extinf, struct media_file_info *mfi, char **filename)
+{
+  char virtual_path[PATH_MAX];
+  time_t stamp;
+  int id;
+  int ret;
+
+  *filename = strdup(path);
+
+  db_file_stamp_bypath(path, &stamp, &id);
+  if (stamp && (stamp >= mtime))
+    {
+      db_file_ping(id);
+      return 0;
+    }
+
+  if (extinf)
+    DPRINTF(E_INFO, L_SCAN, "Playlist has EXTINF metadata, artist is '%s', title is '%s'\n", mfi->artist, mfi->title);
+
+  mfi->id = id;
+  mfi->path = strdup(path);
+  mfi->fname = strdup(filename_from_path(path));
+  mfi->data_kind = DATA_KIND_HTTP;
+  mfi->time_modified = mtime;
+  mfi->directory_id = DIR_HTTP;
+
+  ret = scan_metadata_ffmpeg(path, mfi);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_SCAN, "Playlist URL '%s' is unavailable for probe/metadata, assuming MP3 encoding\n", path);
+      mfi->type = strdup("mp3");
+      mfi->codectype = strdup("mpeg");
+      mfi->description = strdup("MPEG audio file");
+    }
+
+  if (!mfi->title)
+    mfi->title = strdup(mfi->fname);
+
+  snprintf(virtual_path, PATH_MAX, "/http:/%s", mfi->title);
+  mfi->virtual_path = strdup(virtual_path);
+
+  library_add_media(mfi);
+
+  return 0;
+}
+
+int
+process_regular_file(char *path, char **filename)
+{
+  int i;
+  int mfi_id;
+  char *ptr;
+  char *entry;
+  int ret;
+
+  /* Playlist might be from Windows so we change backslash to forward slash */
+  for (i = 0; i < strlen(path); i++)
+    {
+      if (path[i] == '\\')
+	path[i] = '/';
+    }
+
+  /* Now search for the library item where the path has closest match to playlist item */
+  /* Succes is when we find an unambiguous match, or when we no longer can expand the  */
+  /* the path to refine our search.                                                    */
+  entry = NULL;
+  do
+    {
+      ptr = strrchr(path, '/');
+      if (entry)
+	*(entry - 1) = '/';
+
+      if (ptr)
+	{
+	  *ptr = '\0';
+	  entry = ptr + 1;
+	}
+      else
+	entry = path;
+
+      DPRINTF(E_SPAM, L_SCAN, "Playlist entry is now %s\n", entry);
+      ret = db_files_get_count_bymatch(entry);
+    }
+  while (ptr && (ret > 1));
+
+  if (ret > 0)
+    {
+      mfi_id = db_file_id_bymatch(entry);
+      DPRINTF(E_DBG, L_SCAN, "Found playlist entry match, id is %d, entry is %s\n", mfi_id, entry);
+      *filename = db_file_path_byid(mfi_id);
+      if (!(*filename))
+	{
+	  DPRINTF(E_LOG, L_SCAN, "Playlist entry %s matches file id %d, but file path is missing.\n", entry, mfi_id);
+	  return -1;
+	}
+    }
+  else
+    {
+      DPRINTF(E_DBG, L_SCAN, "No match for playlist entry %s\n", entry);
+      return -1;
+    }
+
+  return 0;
+}
+
 void
 scan_playlist(char *file, time_t mtime, int dir_id)
 {
@@ -84,19 +190,15 @@ scan_playlist(char *file, time_t mtime, int dir_id)
   struct stat sb;
   char buf[PATH_MAX];
   char *path;
-  char *entry;
-  char *filename;
+  const char *filename;
   char *ptr;
   size_t len;
   int extinf;
   int pl_id;
   int pl_format;
-  int mfi_id;
   int ret;
   char virtual_path[PATH_MAX];
-  int i;
-  time_t stamp;
-  int id;
+  char *plitem_path;
 
   DPRINTF(E_LOG, L_SCAN, "Processing static playlist: %s\n", file);
 
@@ -111,11 +213,7 @@ scan_playlist(char *file, time_t mtime, int dir_id)
   else
     return;
 
-  filename = strrchr(file, '/');
-  if (!filename)
-    filename = file;
-  else
-    filename++;
+  filename = filename_from_path(file);
 
   ret = stat(file, &sb);
   if (ret < 0)
@@ -231,105 +329,25 @@ scan_playlist(char *file, time_t mtime, int dir_id)
 	{
 	  DPRINTF(E_DBG, L_SCAN, "Playlist contains URL entry: '%s'\n", path);
 
-	  db_file_stamp_bypath(path, &stamp, &id);
-	  if (stamp && (stamp >= sb.st_mtime))
-	    {
-	      db_file_ping(id);
-	      continue;
-	    }
-
-	  filename = strdup(path);
-	  if (!filename)
-	    {
-	      DPRINTF(E_LOG, L_SCAN, "Out of memory for playlist filename\n");
-
-	      continue;
-	    }
-
-	  if (extinf)
-	    DPRINTF(E_INFO, L_SCAN, "Playlist has EXTINF metadata, artist is '%s', title is '%s'\n", mfi.artist, mfi.title);
-
-	  mfi.id = id;
-	  mfi.fname = strdup(basename(filename));
-	  mfi.path = strdup(filename);
-	  mfi.data_kind = DATA_KIND_HTTP;
-	  mfi.time_modified = mtime;
-	  mfi.directory_id = DIR_HTTP;
-
-	  ret = scan_metadata_ffmpeg(path, &mfi);
-	  if (ret < 0)
-	    {
-	      DPRINTF(E_LOG, L_SCAN, "Playlist URL '%s' is unavailable for probe/metadata, assuming MP3 encoding\n", path);
-	      mfi.type = strdup("mp3");
-	      mfi.codectype = strdup("mpeg");
-	      mfi.description = strdup("MPEG audio file");
-	    }
-
-	  snprintf(virtual_path, PATH_MAX, "/http:/%s", mfi.title); //TODO can title be null at this point?
-	  mfi.virtual_path = strdup(virtual_path);
-	  library_add_media(&mfi);
+	  ret = process_url(path, sb.st_mtime, extinf, &mfi, &plitem_path);
 	}
       /* Regular file, should already be in library */
       else
 	{
-	  /* Playlist might be from Windows so we change backslash to forward slash */
-	  for (i = 0; i < strlen(path); i++)
-	    {
-	      if (path[i] == '\\')
-	        path[i] = '/';
-	    }
-
-          /* Now search for the library item where the path has closest match to playlist item */
-          /* Succes is when we find an unambiguous match, or when we no longer can expand the  */
-          /* the path to refine our search.                                                    */
-	  entry = NULL;
-	  do
-	    {
-	      ptr = strrchr(path, '/');
-	      if (entry)
-		*(entry - 1) = '/';
-	      if (ptr)
-		{
-		  *ptr = '\0';
-		  entry = ptr + 1;
-		}
-	      else
-		entry = path;
-
-	      DPRINTF(E_SPAM, L_SCAN, "Playlist entry is now %s\n", entry);
-	      ret = db_files_get_count_bymatch(entry);
-
-	    } while (ptr && (ret > 1));
-
-	  if (ret > 0)
-	    {
-	      mfi_id = db_file_id_bymatch(entry);
-	      DPRINTF(E_DBG, L_SCAN, "Found playlist entry match, id is %d, entry is %s\n", mfi_id, entry);
-
-	      filename = db_file_path_byid(mfi_id);
-	      if (!filename)
-		{
-		  DPRINTF(E_LOG, L_SCAN, "Playlist entry %s matches file id %d, but file path is missing.\n", entry, mfi_id);
-
-		  continue;
-		}
-	    }
-	  else
-	    {
-	      DPRINTF(E_DBG, L_SCAN, "No match for playlist entry %s\n", entry);
-
-	      continue;
-	    }
+	  ret = process_regular_file(path, &plitem_path);
 	}
 
-      ret = db_pl_add_item_bypath(pl_id, filename);
-      if (ret < 0)
-	DPRINTF(E_WARN, L_SCAN, "Could not add %s to playlist\n", filename);
+      if (ret == 0)
+	{
+	  ret = db_pl_add_item_bypath(pl_id, plitem_path);
+	  if (ret < 0)
+	    DPRINTF(E_WARN, L_SCAN, "Could not add %s to playlist\n", plitem_path);
 
-      /* Clean up in preparation for next item */
-      extinf = 0;
-      free_mfi(&mfi, 1);
-      free(filename);
+	  /* Clean up in preparation for next item */
+	  extinf = 0;
+	  free_mfi(&mfi, 1);
+	  free(plitem_path);
+	}
     }
 
   /* We had some extinf that we never got to use, free it now */

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -267,7 +267,7 @@ scan_playlist(char *file, time_t mtime, int dir_id)
 
 	  snprintf(virtual_path, PATH_MAX, "/http:/%s", mfi.title); //TODO can title be null at this point?
 	  mfi.virtual_path = strdup(virtual_path);
-	  library_process_media(&mfi);
+	  library_add_media(&mfi);
 	}
       /* Regular file, should already be in library */
       else

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -122,7 +122,7 @@ process_url(const char *path, time_t mtime, int extinf, struct media_file_info *
 }
 
 static int
-process_regular_file(char *path, char **filename)
+process_regular_file(char **filename, char *path)
 {
   int i;
   int mfi_id;
@@ -333,7 +333,7 @@ scan_playlist(char *file, time_t mtime, int dir_id)
       /* Regular file, should already be in library */
       else
 	{
-	  ret = process_regular_file(path, &plitem_path);
+	  ret = process_regular_file(&plitem_path, path);
 	}
 
       if (ret == 0)

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -33,7 +33,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include <libgen.h>
 
 #include "logger.h"
 #include "db.h"
@@ -122,7 +121,7 @@ process_url(const char *path, time_t mtime, int extinf, struct media_file_info *
   return 0;
 }
 
-int
+static int
 process_regular_file(char *path, char **filename)
 {
   int i;

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1578,7 +1578,7 @@ mpd_command_add(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
     {
       // Given path is not in the library, check if it is possible to add as a non-library queue item
       ret = library_scan_media(argv[1], &mfi);
-      if (ret != METADATA_OK)
+      if (ret != LIBRARY_OK)
 	{
 	  ret = asprintf(errmsg, "Failed to add song '%s' to playlist (unkown path)", argv[1]);
 	  if (ret < 0)
@@ -1625,7 +1625,7 @@ mpd_command_addid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
     {
       // Given path is not in the library, directly add it as a new queue item
       ret = library_scan_media(argv[1], &mfi);
-      if (ret != METADATA_OK)
+      if (ret != LIBRARY_OK)
 	{
 	  ret = asprintf(errmsg, "Failed to add song '%s' to playlist (unkown path)", argv[1]);
 	  if (ret < 0)

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1504,6 +1504,13 @@ mpd_command_stop(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
   return 0;
 }
 
+/*
+ * Add media file item with given virtual path to the queue
+ *
+ * @param path The virtual path
+ * @param recursive If 0 add only item with exact match, otherwise add all items virtual path start with the given path
+ * @return The queue item id of the last inserted item or -1 on failure
+ */
 static int
 mpd_queue_add(char *path, int recursive)
 {
@@ -1546,6 +1553,7 @@ mpd_queue_add(char *path, int recursive)
 static int
 mpd_command_add(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 {
+  struct media_file_info mfi;
   int ret;
 
   if (argc < 2)
@@ -1566,6 +1574,22 @@ mpd_command_add(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       return ACK_ERROR_UNKNOWN;
     }
 
+  if (ret == 0)
+    {
+      // Given path is not in the library, check if it is possible to add as a non-library queue item
+      ret = library_scan_media(argv[1], &mfi);
+      if (ret != METADATA_OK)
+	{
+	  ret = asprintf(errmsg, "Failed to add song '%s' to playlist (unkown path)", argv[1]);
+	  if (ret < 0)
+	    DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+	  return ACK_ERROR_UNKNOWN;
+	}
+
+      library_add_queue_item(&mfi);
+      free_mfi(&mfi, 1);
+    }
+
   return 0;
 }
 
@@ -1578,6 +1602,7 @@ mpd_command_add(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 static int
 mpd_command_addid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 {
+  struct media_file_info mfi;
   int ret;
 
   if (argc < 2)
@@ -1595,6 +1620,22 @@ mpd_command_addid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
     }
 
   ret = mpd_queue_add(argv[1], 0);
+
+  if (ret == 0)
+    {
+      // Given path is not in the library, directly add it as a new queue item
+      ret = library_scan_media(argv[1], &mfi);
+      if (ret != METADATA_OK)
+	{
+	  ret = asprintf(errmsg, "Failed to add song '%s' to playlist (unkown path)", argv[1]);
+	  if (ret < 0)
+	    DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+	  return ACK_ERROR_UNKNOWN;
+	}
+
+      ret = library_add_queue_item(&mfi);
+      free_mfi(&mfi, 1);
+    }
 
   if (ret < 0)
     {

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -711,7 +711,7 @@ spotify_track_save(int plid, sp_track *track, const char *pltitle, int time_adde
   mfi.virtual_path = strdup(virtual_path);
   mfi.directory_id = dir_id;
 
-  library_process_media(&mfi);
+  library_add_media(&mfi);
 
   free_mfi(&mfi, 1);
 
@@ -2094,7 +2094,7 @@ scan_saved_albums()
 		      mfi.virtual_path = strdup(virtual_path);
 		      mfi.directory_id = dir_id;
 
-		      library_process_media(&mfi);
+		      library_add_media(&mfi);
 
 		      free_mfi(&mfi, 1);
 		    }
@@ -2190,7 +2190,7 @@ scan_playlisttracks(struct spotify_playlist *playlist, int plid)
 	      mfi.virtual_path = strdup(virtual_path);
 	      mfi.directory_id = dir_id;
 
-	      library_process_media(&mfi);
+	      library_add_media(&mfi);
 
 	      spotify_uri_register(track.uri);
 


### PR DESCRIPTION
There are two parts in this pr. The first refactors the scanning of metadata. In the current code the library knows how to scan metadata and has an ugly dependency to the filescanner. With these changes the library source is the only one who knows how to read metadata for a supported path. The library only does the general source agnostic metadata fixup.

The second part introduces a new scan_media function to the library, that takes a path that does not need to be in the library. For now only http-urls are supported. Together with the changes in mpd.c, forked-daapd is now able to add arbitrary http-streams to the queue.

For example the following mpc command now works:

```
mpc add http://path-to-radiostream
```