### PR TITLE
Support remote pairing over mpd protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ The Quick Way:
 
  1. Download and run the helper script from [here](https://raw.githubusercontent.com/ejurgensen/forked-daapd/master/scripts/pairinghelper.sh)
 
+Another option is to use mpc (MPD command line client):
+
+ 1. `mpc sendmessage pairing 5387` (where 5387 is the 4-digit pairing code displayed by Remote)
+
 Or, if that doesn't work:
 
  1. Start forked-daapd

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -457,7 +457,7 @@ process_file(char *file, time_t mtime, off_t size, int type, int flags, int dir_
 	if (flags & F_SCAN_BULK)
 	  DPRINTF(E_LOG, L_SCAN, "Bulk scan will ignore '%s' (to process, add it after startup)\n", file);
 	else
-	  remote_pairing_read_pin(file);
+	  remote_pairing_kickoff_byfile(file);
 	break;
 
       case FILE_CTRL_LASTFM:

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3598,25 +3598,7 @@ mpd_command_outputs(struct evbuffer *evbuf, int argc, char **argv, char **errmsg
 static void
 channel_pairing(const char *message)
 {
-  char *device;
-  char *pin;
-  char *ptr;
-
-  ptr = strrchr(message, ':');
-  if (!ptr)
-    {
-      DPRINTF(E_LOG, L_MPD, "Failed to parse devicename and pin from message '%s' (expected format: \"devicename:pin\"\n", message);
-      return;
-    }
-
-  pin = ptr + 1;
-
-  device = strdup(message);
-  ptr = strrchr(device, ':');
-  *ptr = '\0';
-
-  remote_pairing_kickoff_bydevicepin(device, pin);
-  free(device);
+  remote_pairing_kickoff_bypin(message);
 }
 
 struct mpd_channel

--- a/src/remote_pairing.c
+++ b/src/remote_pairing.c
@@ -781,7 +781,7 @@ touch_remote_cb(const char *name, const char *type, const char *domain, const ch
 
 /* Thread: filescanner */
 void
-remote_pairing_read_pin(char *path)
+remote_pairing_kickoff_byfile(char *path)
 {
   char buf[256];
   FILE *fp;

--- a/src/remote_pairing.h
+++ b/src/remote_pairing.h
@@ -3,7 +3,7 @@
 #define __REMOTE_PAIRING_H__
 
 void
-remote_pairing_read_pin(char *path);
+remote_pairing_kickoff_byfile(char *path);
 
 int
 remote_pairing_init(void);

--- a/src/remote_pairing.h
+++ b/src/remote_pairing.h
@@ -3,6 +3,9 @@
 #define __REMOTE_PAIRING_H__
 
 void
+remote_pairing_kickoff_bydevicepin(const char *devname, const char *pin);
+
+void
 remote_pairing_kickoff_byfile(char *path);
 
 int

--- a/src/remote_pairing.h
+++ b/src/remote_pairing.h
@@ -3,7 +3,7 @@
 #define __REMOTE_PAIRING_H__
 
 void
-remote_pairing_kickoff_bydevicepin(const char *devname, const char *pin);
+remote_pairing_kickoff_bypin(const char *pin);
 
 void
 remote_pairing_kickoff_byfile(char *path);


### PR DESCRIPTION
These changes allow to pair a remote (e. g. Apple Remote or Retune) by using the mpd sendmessage command. 

forked-daapd makes use of the 'sendmessage' command from the mpd protocol (https://www.musicpd.org/doc/protocol/client_to_client.html). A mpd client can send a message to the channel 'pairing' with a message consisting of devicename and pin separated by a colon ':'.

With mpc this wil look like:

```
mpc sendmessage pairing "My device name:1234"
``` 

@ejurgensen Do you know why multiple pairing requests are supported by forked-daapd (linked list of devices that announced a pairing request through mdns)? I think it is highly unlikely that a user wants to pair two devices at once. It should be enough to remember the last paring request and discard a previous one. That would eliminate the need to pass the devicename. 