### PR TITLE
Set speaker/output volume with mpd sendmessage command

### DIFF
--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3820,6 +3820,21 @@ mpd_find_channel(const char *name)
 }
 
 static int
+mpd_command_channels(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
+{
+  int i;
+
+  for (i = 0; mpd_channels[i].handler; i++)
+    {
+      evbuffer_add_printf(evbuf,
+      		      "channel: %s\n",
+      		      mpd_channels[i].channel);
+    }
+
+  return 0;
+}
+
+static int
 mpd_command_sendmessage(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 {
   const char *channelname;
@@ -4381,7 +4396,7 @@ static struct mpd_command mpd_handlers[] =
     },
     {
       .mpdcommand = "channels",
-      .handler = mpd_command_ignore
+      .handler = mpd_command_channels
     },
     {
       .mpdcommand = "readmessages",

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3735,6 +3735,7 @@ channel_outputvolume(const char *message)
   ptr = strrchr(tmp, ':');
   if (!ptr)
     {
+      free(tmp);
       DPRINTF(E_LOG, L_MPD, "Failed to parse output id and volume from message '%s' (expected format: \"output-id:volume\"\n", message);
       return;
     }
@@ -3760,6 +3761,8 @@ channel_outputvolume(const char *message)
   outputvolume_set(shortid, volume, &errmsg);
   if (errmsg)
     DPRINTF(E_LOG, L_MPD, "Failed to set output volume from message: '%s' (error='%s')\n", message, errmsg);
+
+  free(tmp);
 }
 
 static void

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3636,6 +3636,91 @@ mpd_command_outputs(struct evbuffer *evbuf, int argc, char **argv, char **errmsg
   return 0;
 }
 
+static int
+outputvolume_set(uint32_t shortid, int volume, char **errmsg)
+{
+  struct outputs outputs;
+  struct output *output;
+  int ret;
+
+  outputs.count = 0;
+  outputs.active = 0;
+  outputs.outputs = NULL;
+
+  player_speaker_enumerate(outputs_enum_cb, &outputs);
+
+  output = outputs.outputs;
+  while (output)
+    {
+      if (output->shortid == shortid)
+	{
+	  break;
+	}
+      output = output->next;
+    }
+
+  if (!output)
+    {
+      free_outputs(outputs.outputs);
+      ret = asprintf(errmsg, "No speaker found for short id: %d", shortid);
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_UNKNOWN;
+    }
+
+  ret = player_volume_setabs_speaker(output->id, volume);
+
+  free_outputs(outputs.outputs);
+
+  if (ret < 0)
+    {
+      ret = asprintf(errmsg, "Setting volume to %d for speaker with short-id %d failed", volume, shortid);
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_UNKNOWN;
+    }
+
+  return 0;
+}
+
+static int
+mpd_command_outputvolume(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
+{
+  uint32_t shortid;
+  int volume;
+  int ret;
+
+  if (argc < 3)
+    {
+      ret = asprintf(errmsg, "Missing argument for command 'outputvolume'");
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_ARG;
+    }
+
+  ret = safe_atou32(argv[1], &shortid);
+  if (ret < 0)
+    {
+      ret = asprintf(errmsg, "Argument doesn't convert to integer: '%s'", argv[1]);
+      if (ret < 0)
+      DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_ARG;
+    }
+
+  ret = safe_atoi32(argv[2], &volume);
+  if (ret < 0)
+    {
+      ret = asprintf(errmsg, "Argument doesn't convert to integer: '%s'", argv[2]);
+      if (ret < 0)
+	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
+      return ACK_ERROR_ARG;
+    }
+
+  ret = outputvolume_set(shortid, volume, errmsg);
+
+  return ret;
+}
+
 static void
 channel_pairing(const char *message)
 {
@@ -3717,82 +3802,6 @@ mpd_command_sendmessage(struct evbuffer *evbuf, int argc, char **argv, char **er
     }
 
   channel->handler(message);
-  return 0;
-}
-
-static int
-mpd_command_outputvolume(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
-{
-  uint32_t shortid;
-  int volume;
-  struct outputs outputs;
-  struct output *output;
-  int ret;
-
-  if (argc < 3)
-    {
-      ret = asprintf(errmsg, "Missing argument for command 'outputvolume'");
-      if (ret < 0)
-	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
-      return ACK_ERROR_ARG;
-    }
-
-  ret = safe_atou32(argv[1], &shortid);
-  if (ret < 0)
-    {
-      ret = asprintf(errmsg, "Argument doesn't convert to integer: '%s'", argv[1]);
-      if (ret < 0)
-      DPRINTF(E_LOG, L_MPD, "Out of memory\n");
-      return ACK_ERROR_ARG;
-    }
-
-  ret = safe_atoi32(argv[2], &volume);
-  if (ret < 0)
-    {
-      ret = asprintf(errmsg, "Argument doesn't convert to integer: '%s'", argv[2]);
-      if (ret < 0)
-	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
-      return ACK_ERROR_ARG;
-    }
-
-  outputs.count = 0;
-  outputs.active = 0;
-  outputs.outputs = NULL;
-
-  player_speaker_enumerate(outputs_enum_cb, &outputs);
-
-  output = outputs.outputs;
-  while (output)
-    {
-      if (output->shortid == shortid)
-	{
-	  break;
-	}
-      output = output->next;
-    }
-
-  if (!output)
-    {
-      free_outputs(outputs.outputs);
-      ret = asprintf(errmsg, "No speaker found for short id: %d", shortid);
-      if (ret < 0)
-	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
-      return ACK_ERROR_UNKNOWN;
-    }
-
-  ret = player_volume_setabs_speaker(output->id, volume);
-
-  if (ret < 0)
-    {
-      free_outputs(outputs.outputs);
-      ret = asprintf(errmsg, "Setting volume to %d for speaker with short-id %d failed", volume, shortid);
-      if (ret < 0)
-	DPRINTF(E_LOG, L_MPD, "Out of memory\n");
-      return ACK_ERROR_UNKNOWN;
-    }
-
-  free_outputs(outputs.outputs);
-
   return 0;
 }
 


### PR DESCRIPTION
This pr allows controlling output volume through the mpd sendmessage command as suggested by @LordMyschkin. The channel is `outputvolume` and the message consists of the output id and the volume separated by a colon.

Using mpc setting the volume to 50% for speaker with id = 0 looks like
```
mpc sendmessage outputvolume "0:50"
```

Note that the output id is *not* the id shown by `mpc outputs` because mpc adds one to the id reported by the server. 

I am not sure if this is really helpful. Maybe @snizzleorg and @LordMyschkin can say if it is something they can make use of.

This pr is based on #373 
