### PR TITLE
[dacp] Start playback from selected song in shuffle mode

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -750,7 +750,7 @@ int
 db_queue_delete_byposrelativetoitem(uint32_t pos, uint32_t item_id, char shuffle);
 
 int
-db_queue_move_byitemid(uint32_t item_id, int pos_to);
+db_queue_move_byitemid(uint32_t item_id, int pos_to, char shuffle);
 
 int
 db_queue_move_bypos(int pos_from, int pos_to);

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1841,7 +1841,7 @@ mpd_command_moveid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       return ACK_ERROR_ARG;
     }
 
-  ret = db_queue_move_byitemid(songid, to_pos);
+  ret = db_queue_move_byitemid(songid, to_pos, 0);
   if (ret < 0)
     {
       ret = asprintf(errmsg, "Failed to move song with id '%s' to index '%s'", argv[1], argv[2]);


### PR DESCRIPTION
It is more of a workaround than a proper fix for #366. But it keeps the changes at a minimum. If shuffle is on, playback starts now at the selected track.

The command sequence in dacp_reply_playqueueedit_add is:

- stop playback
- find selected song id
- add songs to queue (and shuffle the queue)
- move selected song to the beginning of the shuffle queue
- start playback with the selected song
  