### PR TITLE
[mpd] Initial support for stored playlists

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -264,6 +264,11 @@ mpd {
 	# the playlist like MPD does. Note that some dacp clients do not show
 	# the playqueue if playback is stopped.
 #	clear_queue_on_stop_disable = false
+
+	# A directory in one of the library directories that will be used as the default
+	# playlist directory. forked-dapd creates new playlists in this directory if only
+	# a playlist name is provided by the mpd client.
+#	default_playlist_directory = ""
 }
 
 # SQLite configuration (allows to modify the operation of the SQLite databases)

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -265,9 +265,14 @@ mpd {
 	# the playqueue if playback is stopped.
 #	clear_queue_on_stop_disable = false
 
+	# Allows creating, deleting and modifying m3u playlists in the library directories.
+	# Defaults to being disabled.
+#	allow_modifying_stored_playlists = false
+
 	# A directory in one of the library directories that will be used as the default
 	# playlist directory. forked-dapd creates new playlists in this directory if only
-	# a playlist name is provided by the mpd client.
+	# a playlist name is provided by the mpd client (requires "allow_modify_stored_playlists"
+	# set to true).
 #	default_playlist_directory = ""
 }
 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -156,6 +156,7 @@ static cfg_opt_t sec_mpd[] =
     CFG_INT("port", 6600, CFGF_NONE),
     CFG_INT("http_port", 0, CFGF_NONE),
     CFG_BOOL("clear_queue_on_stop_disable", cfg_false, CFGF_NONE),
+    CFG_STR("default_playlist_directory", NULL, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -156,6 +156,7 @@ static cfg_opt_t sec_mpd[] =
     CFG_INT("port", 6600, CFGF_NONE),
     CFG_INT("http_port", 0, CFGF_NONE),
     CFG_BOOL("clear_queue_on_stop_disable", cfg_false, CFGF_NONE),
+    CFG_BOOL("allow_modifying_stored_playlists", cfg_false, CFGF_NONE),
     CFG_STR("default_playlist_directory", NULL, CFGF_NONE),
     CFG_END()
   };

--- a/src/db.h
+++ b/src/db.h
@@ -536,7 +536,7 @@ struct media_file_info *
 db_file_fetch_byid(int id);
 
 struct media_file_info *
-db_file_fetch_byvirtualpath(char *path);
+db_file_fetch_byvirtualpath(const char *path);
 
 int
 db_file_add(struct media_file_info *mfi);
@@ -572,11 +572,14 @@ db_pl_ping(int id);
 void
 db_pl_ping_bymatch(char *path, int isdir);
 
+int
+db_pl_id_bypath(const char *path);
+
 struct playlist_info *
 db_pl_fetch_bypath(const char *path);
 
 struct playlist_info *
-db_pl_fetch_byvirtualpath(char *virtual_path);
+db_pl_fetch_byvirtualpath(const char *virtual_path);
 
 struct playlist_info *
 db_pl_fetch_bytitlepath(char *title, char *path);

--- a/src/library.h
+++ b/src/library.h
@@ -70,6 +70,21 @@ struct library_source
    * Scans metadata for the media file with the given path into the given mfi
    */
   int (*scan_metadata)(const char *path, struct media_file_info *mfi);
+
+  /*
+   * Save queue as a new playlist under the given virtual path
+   */
+  int (*playlist_add)(const char *vp_playlist, const char *vp_item);
+
+  /*
+   * Removes the playlist under the given virtual path
+   */
+  int (*playlist_remove)(const char *virtual_path);
+
+  /*
+   * Save queue as a new playlist under the given virtual path
+   */
+  int (*queue_save)(const char *virtual_path);
 };
 
 
@@ -102,6 +117,15 @@ library_is_exiting();
 
 void
 library_update_trigger(void);
+
+int
+library_playlist_add(const char *vp_playlist, const char *vp_item);
+
+int
+library_playlist_remove(char *virtual_path);
+
+int
+library_queue_save(char *path);
 
 int
 library_exec_async(command_function func, void *arg);

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -23,4 +23,7 @@ scan_itunes_itml(char *file);
 const char *
 filename_from_path(const char *path);
 
+char *
+strip_extension(const char *path);
+
 #endif /* !__FILESCANNER_H__ */

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -256,22 +256,11 @@ scan_playlist(char *file, time_t mtime, int dir_id)
       pli->type = PL_PLAIN;
 
       /* Get only the basename, to be used as the playlist title */
-      ptr = strrchr(filename, '.');
-      if (ptr)
-	*ptr = '\0';
-
-      pli->title = strdup(filename);
-
-      /* Restore the full filename */
-      if (ptr)
-	*ptr = '.';
+      pli->title = strip_extension(filename);
 
       pli->path = strdup(file);
       snprintf(virtual_path, PATH_MAX, "/file:%s", file);
-      ptr = strrchr(virtual_path, '.');
-      if (ptr)
-	*ptr = '\0';
-      pli->virtual_path = strdup(virtual_path);
+      pli->virtual_path = strip_extension(virtual_path);
 
       pli->directory_id = dir_id;
 

--- a/src/listener.h
+++ b/src/listener.h
@@ -16,6 +16,8 @@ enum listener_event_type
   LISTENER_OPTIONS   = (1 << 4),
   /* The library has been modified */
   LISTENER_DATABASE  = (1 << 5),
+  /* A stored playlist has been modified (create, delete, add, rename) */
+  LISTENER_STORED_PLAYLIST = (1 << 6),
 };
 
 typedef void (*notify)(enum listener_event_type type);

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -72,6 +72,7 @@ struct evconnlistener *listener;
 
 // Virtual path to the default playlist directory
 static char *default_pl_dir;
+static bool allow_modifying_stored_playlists;
 
 #define COMMAND_ARGV_MAX 37
 
@@ -2205,6 +2206,12 @@ mpd_command_playlistadd(struct evbuffer *evbuf, int argc, char **argv, char **er
   char *vp_item;
   int ret;
 
+  if (!allow_modifying_stored_playlists)
+    {
+      *errmsg = safe_asprintf("Modifying stored playlists is not enabled");
+      return ACK_ERROR_PERMISSION;
+    }
+
   if (argc < 3)
     {
       *errmsg = safe_asprintf("Missing argument for command 'playlistadd'");
@@ -2242,6 +2249,12 @@ mpd_command_rm(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
   char *virtual_path;
   int ret;
 
+  if (!allow_modifying_stored_playlists)
+    {
+      *errmsg = safe_asprintf("Modifying stored playlists is not enabled");
+      return ACK_ERROR_PERMISSION;
+    }
+
   if (argc < 2)
     {
       *errmsg = safe_asprintf("Missing argument for command 'rm'");
@@ -2275,6 +2288,12 @@ mpd_command_save(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
 {
   char *virtual_path;
   int ret;
+
+  if (!allow_modifying_stored_playlists)
+    {
+      *errmsg = safe_asprintf("Modifying stored playlists is not enabled");
+      return ACK_ERROR_PERMISSION;
+    }
 
   if (argc < 2)
     {
@@ -4943,6 +4962,7 @@ int mpd_init(void)
 	}
     }
 
+  allow_modifying_stored_playlists = cfg_getbool(cfg_getsec(cfg, "mpd"), "allow_modifying_stored_playlists");
   pl_dir = cfg_getstr(cfg_getsec(cfg, "mpd"), "default_playlist_directory");
   if (pl_dir)
     default_pl_dir = safe_asprintf("/file:%s", pl_dir);


### PR DESCRIPTION
The mpd protocol offers commands to create/edit/delete local m3u-playlists. This pr adds some support for it in forked-daapd.

The commands supported are:

- [x] Saving the queue to a playlist (or adding the queue to an existing playlist)
- [x] Adding a file/directory to a playlist (creates a new playlist if it does not exist)
- [x] Delete a playlist

Not supported commands are:
- [ ] Delete a song from a playlist
- [ ] Rearrange songs in a playlist
- [ ] Rename a playlist

The playlists are identified by their virtual path. The virtual path can be quite long, therefor i added a config option to define a default playlist folder. Playlists in this folder can be addressed simply by their name. 

I still need to do some more tests, but from my side this is good for a first review. The changes should not break existing functionality. This pr also includes the changes from #381.

