### PR TITLE
fix the compilation problem because of gperf changes in 3.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,27 @@ to install it.]])],
 		[AC_MSG_ERROR([[GNU gperf required, please install it.]])])
 	])
 
+GPERF_TEST="$(echo foo,bar | ${GPERF} -L ANSI-C)"
+
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM([
+		#include <string.h>
+		const char * in_word_set(const char *, size_t);
+		$GPERF_TEST]
+	)],
+	[GPERF_LEN_TYPE=size_t],
+	[AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM([
+			#include <string.h>
+			const char * in_word_set(const char *, unsigned);
+			$GPERF_TEST]
+		)],
+		[GPERF_LEN_TYPE=unsigned],
+		[AC_MSG_ERROR([** unable to determine gperf len type])]
+	)]
+)
+
+AC_DEFINE_UNQUOTED([GPERF_LEN_TYPE], [$GPERF_LEN_TYPE], [gperf len type])
 AC_PATH_PROG([ANTLR], [[antlr3]])
 AS_IF([[test -z "$ANTLR"]],
 	[AS_IF([[test -f "$srcdir/src/SMARTPLLexer.h"]],

--- a/src/dmap_common.h
+++ b/src/dmap_common.h
@@ -2,6 +2,7 @@
 #ifndef __DMAP_HELPERS_H__
 #define __DMAP_HELPERS_H__
 
+#include "config.h"
 #include <event2/buffer.h>
 #include <event2/http.h>
 
@@ -46,7 +47,7 @@ dmap_get_fields_table(int *nfields);
 
 /* From dmap_fields.gperf - keep in sync, don't alter */
 const struct dmap_field *
-dmap_find_field (register const char *str, register unsigned int len);
+dmap_find_field (register const char *str, register GPERF_LEN_TYPE len);
 
 
 void


### PR DESCRIPTION
gperf-3.1 generates lookup functions that take a size_t length
parameter instead of unsigned int.
Fix is more or less the same as used in systemd https://github.com/elogind/elogind/commit/947a6c107a40f43b64adb3736a495e47caad7414