### PR TITLE
[travis] Run separate make command in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
 script:
   - autoreconf -fi
   - ./configure $CFG
+  - make
+  - make clean
   - scan-build --status-bugs -disable-checker deadcode.DeadStores make
 
 before_install:


### PR DESCRIPTION
I noticed that travis builds do not fail if there are compile errors. The "--status-bugs" option only returns an error code if there are scan build issues and apparently success if compilation failed.

Running make as a separate step in the travis build makes sure that it fails if there are compile errors.

Build with a compile error without this pr:
https://travis-ci.org/chme/forked-daapd/builds/246714070

Build with a compile error with this pr:
https://travis-ci.org/chme/forked-daapd/builds/246716807