### PR TITLE
[misc] Replace m_realpath with realpath from stdlib.h

### DIFF
--- a/src/httpd.c
+++ b/src/httpd.c
@@ -1006,7 +1006,7 @@ serve_file(struct evhttp_request *req, char *uri)
     }
   else if (S_ISLNK(sb.st_mode))
     {
-      deref = m_realpath(path);
+      deref = realpath(path, NULL);
       if (!deref)
 	{
 	  DPRINTF(E_LOG, L_HTTPD, "Could not dereference %s: %s\n", path, strerror(errno));

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -895,7 +895,7 @@ bulk_scan(int flags)
 
       parent_id = process_parent_directories(path);
 
-      deref = m_realpath(path);
+      deref = realpath(path, NULL);
       if (!deref)
 	{
 	  DPRINTF(E_LOG, L_SCAN, "Skipping library directory %s, could not dereference: %s\n", path, strerror(errno));

--- a/src/misc.c
+++ b/src/misc.c
@@ -512,27 +512,6 @@ keyval_sort(struct keyval *kv)
 }
 
 
-char *
-m_realpath(const char *pathname)
-{
-  char buf[PATH_MAX];
-  char *ret;
-
-  ret = realpath(pathname, buf);
-  if (!ret)
-    return NULL;
-
-  ret = strdup(buf);
-  if (!ret)
-    {
-      DPRINTF(E_LOG, L_MISC, "Out of memory for realpath\n");
-
-      return NULL;
-    }
-
-  return ret;
-}
-
 char **
 m_readfile(const char *path, int num_lines)
 {

--- a/src/misc.h
+++ b/src/misc.h
@@ -77,9 +77,6 @@ void
 keyval_sort(struct keyval *kv);
 
 
-char *
-m_realpath(const char *pathname);
-
 char **
 m_readfile(const char *path, int num_lines);
 


### PR DESCRIPTION
Looks like `realpath` with NULL as second parameter does exactly the same as `m_realpath` (since POSIX.1-2008, see http://man7.org/linux/man-pages/man3/realpath.3.html).