### PR TITLE
Explicit parameters for spotify login and remote pairing

### DIFF
--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -382,6 +382,12 @@ kickoff_spotify_login(char **arg)
 }
 #endif
 
+static void
+kickoff_paring(char **arg)
+{
+  remote_pairing_kickoff(arg[0]);
+}
+
 /* If we found a control file we want to kickoff some action */
 static void
 kickoff(void (*kickoff_func)(char **arg), const char *file, int lines)
@@ -568,7 +574,7 @@ process_file(char *file, struct stat *sb, int type, int flags, int dir_id)
 	if (flags & F_SCAN_BULK)
 	  DPRINTF(E_LOG, L_SCAN, "Bulk scan will ignore '%s' (to process, add it after startup)\n", file);
 	else
-	  kickoff(remote_pairing_kickoff, file, 1);
+	  kickoff(kickoff_paring, file, 1);
 	break;
 
       case FILE_CTRL_RAOP_VERIFICATION:

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -374,6 +374,14 @@ process_playlist(char *file, time_t mtime, int dir_id)
 #endif
 }
 
+#ifdef HAVE_SPOTIFY_H
+static void
+kickoff_spotify_login(char **arg)
+{
+  spotify_login(arg[0], arg[1]);
+}
+#endif
+
 /* If we found a control file we want to kickoff some action */
 static void
 kickoff(void (*kickoff_func)(char **arg), const char *file, int lines)
@@ -586,7 +594,7 @@ process_file(char *file, struct stat *sb, int type, int flags, int dir_id)
 	if (flags & F_SCAN_BULK)
 	  DPRINTF(E_LOG, L_SCAN, "Bulk scan will ignore '%s' (to process, add it after startup)\n", file);
 	else
-	  kickoff(spotify_login, file, 2);
+	  kickoff(kickoff_spotify_login, file, 2);
 #else
 	DPRINTF(E_LOG, L_SCAN, "Found '%s', but this version was built without Spotify support\n", file);
 #endif

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -3671,7 +3671,7 @@ channel_outputvolume(const char *message)
 static void
 channel_pairing(const char *message)
 {
-  remote_pairing_kickoff((char **)&message);
+  remote_pairing_kickoff(message);
 }
 
 static void

--- a/src/remote_pairing.c
+++ b/src/remote_pairing.c
@@ -714,22 +714,22 @@ touch_remote_cb(const char *name, const char *type, const char *domain, const ch
 
 /* Thread: filescanner, mpd */
 void
-remote_pairing_kickoff(char **arglist)
+remote_pairing_kickoff(const char *pin)
 {
   int ret;
 
-  ret = strlen(arglist[0]);
+  ret = strlen(pin);
   if (ret != 4)
     {
       DPRINTF(E_LOG, L_REMOTE, "Kickoff pairing failed, first line did not contain a 4-digit pin (got %d)\n", ret);
       return;
     }
 
-  DPRINTF(E_LOG, L_REMOTE, "Kickoff pairing with pin '%s'\n", arglist[0]);
+  DPRINTF(E_LOG, L_REMOTE, "Kickoff pairing with pin '%s'\n", pin);
 
   CHECK_ERR(L_REMOTE, pthread_mutex_lock(&remote_lck));
 
-  ret = add_remote_pin_data(arglist[0]);
+  ret = add_remote_pin_data(pin);
   if (ret == 0)
     kickoff_pairing();
 

--- a/src/remote_pairing.h
+++ b/src/remote_pairing.h
@@ -3,7 +3,7 @@
 #define __REMOTE_PAIRING_H__
 
 void
-remote_pairing_kickoff(char **arglist);
+remote_pairing_kickoff(const char *pin);
 
 int
 remote_pairing_init(void);

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -1841,7 +1841,7 @@ spotify_uri_register(const char *uri)
 
 /* Thread: library */
 void
-spotify_login(char **arglist)
+spotify_login(const char *user, const char *password)
 {
   sp_error err;
 
@@ -1875,10 +1875,10 @@ spotify_login(char **arglist)
       CHECK_ERR(L_SPOTIFY, pthread_mutex_unlock(&login_lck));
     }
 
-  if (arglist)
+  if (user && password)
     {
-      DPRINTF(E_LOG, L_SPOTIFY, "Spotify credentials file OK, logging in with username %s\n", arglist[0]);
-      err = fptr_sp_session_login(g_sess, arglist[0], arglist[1], 1, NULL);
+      DPRINTF(E_LOG, L_SPOTIFY, "Spotify credentials file OK, logging in with username %s\n", user);
+      err = fptr_sp_session_login(g_sess, user, password, 1, NULL);
     }
   else
     {
@@ -2253,7 +2253,7 @@ initscan()
    * Login to spotify needs to be done before scanning tracks from the web api.
    * (Scanned tracks need to be registered with libspotify for playback)
    */
-  spotify_login(NULL);
+  spotify_login(NULL, NULL);
 
   /*
    * Scan saved tracks from the web api
@@ -2321,7 +2321,7 @@ fullrescan()
     }
   else
     {
-      spotify_login(NULL);
+      spotify_login(NULL, NULL);
     }
 
   scanning = false;

--- a/src/spotify.h
+++ b/src/spotify.h
@@ -37,7 +37,7 @@ void
 spotify_oauth_callback(struct evbuffer *evbuf, struct evkeyvalq *param, const char *redirect_uri);
 
 void
-spotify_login(char **arglist);
+spotify_login(const char *user, const char *password);
 
 int
 spotify_init(void);


### PR DESCRIPTION
Use explicit parameters for spotify login and remote pairing. Makes it easier for non-file-based clients to call these functions. 
These changes makes it easier to call these functions from the web interface/json api. 