### PR TITLE
[htdocs] Fix size of stats heading on mobile devices

### DIFF
--- a/htdocs/admin.html
+++ b/htdocs/admin.html
@@ -37,25 +37,25 @@
             <div class="level-item has-text-centered">
               <div>
                 <p class="heading">Artists</p>
-                <p class="title">{{ library.artists }}</p>
+                <p class="title is-size-6-mobile">{{ library.artists }}</p>
               </div>
             </div>
             <div class="level-item has-text-centered">
               <div>
                 <p class="heading">Albums</p>
-                <p class="title">{{ library.albums }}</p>
+                <p class="title is-size-6-mobile">{{ library.albums }}</p>
               </div>
             </div>
             <div class="level-item has-text-centered">
               <div>
                 <p class="heading">Songs</p>
-                <p class="title">{{ library.songs }}</p>
+                <p class="title is-size-6-mobile">{{ library.songs }}</p>
               </div>
             </div>
             <div class="level-item has-text-centered">
               <div>
                 <p class="heading">Total playtime</p>
-                <p class="title">{{ library.db_playtime | duration }}</p>
+                <p class="title is-size-6-mobile">{{ library.db_playtime | duration }}</p>
               </div>
             </div>
           </nav>


### PR DESCRIPTION
This slipped through ... should address the cluttered title bar you mentioned.