### PR TITLE
Integrate last.fm into web interface

### DIFF
--- a/htdocs/admin.html
+++ b/htdocs/admin.html
@@ -68,113 +68,158 @@
 
 
 <!--
-  ############# Content section #############
+  ############# Status section #############
 -->
 <section class="section">
   <div class="container">
-    <div class="columns">
+    <!-- Section-heading -->
+    <div class="columns is-centered fd-section-heading">
+      <div class="column is-10"><h1 class="is-uppercase is-size-7">Status</h1></div>
+    </div>
 
-      <div class="column">
-        <div class="card">
-          <header class="card-header">
-            <p class="card-header-title">
-              <span class="icon" v-show="library.updating"><i class="fa fa-refresh fa-spin"></i></span>
-              <span class="icon" v-show="!library.updating"><i class="fa fa-refresh"></i></span>
-               Update library
-            </p>
-          </header>
-          <div class="card-content">
-            <div class="content">
-              Scan new and modified items into your library.
-            </div>
-          </div>
-          <footer class="card-footer">
-            <a class="card-footer-item is-primary" v-on:click="update" v-show="!library.updating">Update</a>
-            <span class="card-footer-item" v-show="library.updating">Update in progress ...</span>
-          </footer>
-        </div> <!-- card update library -->
-      </div> <!-- column -->
+    <!-- Library update -->
+    <div class="columns is-centered fd-section-content">
+      <div class="column is-3">
+        <h2 class="title is-5">
+          <span class="icon" v-show="library.updating"><i class="fa fa-refresh fa-spin"></i>
+          </span><span class="icon" v-show="!library.updating"><i class="fa fa-music"></i></span>
+           Library
+         </h2>
+      </div>
 
+      <div class="column is-7 content">
+        <a class="button" v-on:click="update" v-show="!library.updating">Update library</a>
+        <p v-show="library.updating">Update in progress ...</p>
+      </div>
+    </div>
 
-      <div class="column">
-        <div class="card">
-          <header class="card-header">
-            <p class="card-header-title">
-              <span class="icon"><i class="fa fa-mobile"></i></span> Remote pairing
-            </p>
-          </header>
-          <div class="card-content">
-            <div class="content" v-show="pairing.active">
-              <p>Remote pairing request from <b>{{pairing.remote}}</b></p>
-              <form v-on:submit.prevent="kickoffPairing">
-                <div class="field has-addons">
-                  <div class="control">
-                    <input class="input" type="text" placeholder="Enter pairing code" v-model="pairing_req.pin">
-                  </div>
-                  <div class="control">
-                    <button class="button is-primary" type="submit">Send</button>
-                  </div>
-                </div>
-              </form>
-            </div>
-            <div class="content" v-show="!pairing.active">
-              <p>No active pairing request.</p>
-              <a class="button"  v-on:click="loadPairing" v-show="!config.websocket_port">Refresh</a>
-            </div>
-          </div>
-        </div> <!-- card remote pairing -->
-      </div> <!-- column -->
+    <!-- Pairing -->
+    <div class="columns is-centered fd-section-content">
+      <div class="column is-3">
+        <h2 class="title is-5"><span class="icon"><i class="fa fa-mobile"></i></span> Remote Pairing</h2>
+      </div>
 
-
-      <div class="column">
-        <div class="card" v-show="spotify.enabled">
-          <header class="card-header">
-            <p class="card-header-title">
-              <span class="icon"><i class="fa fa-spotify"></i></span> Spotify
-            </p>
-          </header>
-          <div class="card-content">
-            <div class="content" v-show="!spotify.libspotify_installed">
-              <p><b>libspotify</b> is not installed (required for playing spotify tracks)</p>
-            </div>
-            <div class="content" v-show="spotify.libspotify_installed">
-              <div v-show="!spotify.libspotify_logged_in"><p><b>libspotify</b> (requires Spotify premium account, enables playback of Spotify songs):</p>
-                <form v-on:submit.prevent="loginLibspotify">
-                  <div class="field has-addons">
-                    <div class="control">
-                      <input class="input" type="text" placeholder="Username" v-model="libspotify.user">
-                      <p class="help is-danger">{{ libspotify.errors.user }}</p>
-                    </div>
-                    <div class="control">
-                      <input class="input" type="password" placeholder="Password" v-model="libspotify.password">
-                      <p class="help is-danger">{{ libspotify.errors.password }}</p>
-                    </div>
-                    <div class="control">
-                      <button class="button" type="submit">Login</button>
-                    </div>
-                  </div>
-                  <p class="help is-danger">{{ libspotify.errors.error }}</p>
-                </form>
+      <div class="column is-7 content">
+        <!-- Paring request active -->
+        <div class="content" v-show="pairing.active">
+          <p>Remote pairing request from <b>{{pairing.remote}}</b></p>
+          <form v-on:submit.prevent="kickoffPairing">
+            <div class="field has-addons">
+              <div class="control">
+                <input class="input" type="text" placeholder="Enter pairing code" v-model="pairing_req.pin">
               </div>
-              <p v-show="spotify.libspotify_logged_in"><b>libspotify</b> (requires Spotify premium account, enables playback of Spotify songs): logged in as <b>{{ spotify.libspotify_user }}</b></p>
-              <hr>
-              <div v-show="!spotify.webapi_token_valid">
-                <p><b>Spotify Web API</b> access is required to add saved albums and playlists to your library.</p>
-                <a class="button" v-bind:href="spotify.oauth_uri">Authorize Web API access</a>
-              </div>
-              <div v-show="spotify.webapi_token_valid">
-                <p><b>Spotify Web API</b>: access authorized for <b>{{ spotify.webapi_user }}</b></p>
-                <a class="button" v-bind:href="spotify.oauth_uri">Reauthorize Web API access</a>
+              <div class="control">
+                <button class="button is-primary" type="submit">Send</button>
               </div>
             </div>
-          </div>
-        </div> <!-- card spotify -->
-      </div> <!-- column -->
+          </form>
+        </div>
+        <!-- No pairing requests -->
+        <div class="content" v-show="!pairing.active">
+          <p>No active pairing request.</p>
+          <a class="button"  v-on:click="loadPairing" v-show="!config.websocket_port">Refresh</a>
+        </div>
+      </div>
+    </div>
 
-    </div> <!-- columns -->
-  </div> <!-- container -->
+  </div>
 </section>
 
+<!--
+  ############# Online accounts & services section #############
+-->
+<section class="section">
+  <div class="container">
+    <!-- Section-heading -->
+    <div class="columns is-centered fd-section-heading">
+      <div class="column is-10"><h1 class="is-uppercase is-size-7">Online accounts &amp; services</h1></div>
+    </div>
+
+    <!-- Spotify -->
+    <div class="columns is-centered fd-section-content" v-show="spotify.enabled">
+      <div class="column is-3">
+        <h2 class="title is-5"><span class="icon"><i class="fa fa-spotify"></i></span> Spotify</h2>
+      </div>
+
+      <div class="column is-7 content">
+        <div class="content" v-show="!spotify.libspotify_installed">
+          <p><b>libspotify</b> is not installed (required for playing spotify tracks)</p>
+        </div>
+        <div class="content" v-show="spotify.libspotify_installed">
+          <!-- libspotify -->
+          <div v-show="!spotify.libspotify_logged_in"><p><b>libspotify</b> (requires Spotify premium account, enables playback of Spotify songs)</p>
+            <form v-on:submit.prevent="loginLibspotify">
+              <div class="field has-addons">
+                <div class="control">
+                  <input class="input" type="text" placeholder="Username" v-model="libspotify.user">
+                  <p class="help is-danger">{{ libspotify.errors.user }}</p>
+                </div>
+                <div class="control">
+                  <input class="input" type="password" placeholder="Password" v-model="libspotify.password">
+                  <p class="help is-danger">{{ libspotify.errors.password }}</p>
+                </div>
+                <div class="control">
+                  <button class="button" type="submit">Login</button>
+                </div>
+              </div>
+              <p class="help is-danger">{{ libspotify.errors.error }}</p>
+            </form>
+          </div>
+          <p v-show="spotify.libspotify_logged_in"><b>libspotify</b> (requires Spotify premium account, enables playback of Spotify songs): logged in as <b>{{ spotify.libspotify_user }}</b></p>
+          <!-- Spotify web api -->
+          <div v-show="!spotify.webapi_token_valid">
+            <p><b>Spotify Web API</b> access is required to add saved albums and playlists to your library.</p>
+            <a class="button" v-bind:href="spotify.oauth_uri">Authorize Web API access</a>
+          </div>
+          <div v-show="spotify.webapi_token_valid">
+            <p><b>Spotify Web API</b>: access authorized for <b>{{ spotify.webapi_user }}</b></p>
+            <a class="button" v-bind:href="spotify.oauth_uri">Reauthorize Web API access</a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Last.fm -->
+    <div class="columns is-centered fd-section-content" v-show="lastfm.enabled">
+      <div class="column is-3">
+        <h2 class="title is-5"><span class="icon"><i class="fa fa-lastfm"></i></span> Last.fm</h2>
+      </div>
+
+      <div class="column is-7 content">
+        <!-- Scrobbling enabled -->
+        <div class="content" v-show="lastfm.scrobbling_enabled">
+          <a class="button" v-on:click="logoutLastfm">Stop scrobbling</a>
+        </div>
+        <!-- Scrobbling NOT enabled -->
+        <div class="content" v-show="!lastfm.scrobbling_enabled">
+          <p><b>Last.fm</b> (enable scrobbling)</p>
+          <form v-on:submit.prevent="loginLastfm">
+            <div class="field has-addons">
+              <div class="control">
+                <input class="input" type="text" placeholder="Username" v-model="lastfm_login.user">
+                <p class="help is-danger">{{ lastfm_login.errors.user }}</p>
+              </div>
+              <div class="control">
+                <input class="input" type="password" placeholder="Password" v-model="lastfm_login.password">
+                <p class="help is-danger">{{ lastfm_login.errors.password }}</p>
+              </div>
+              <div class="control">
+                <button class="button" type="submit">Login</button>
+              </div>
+            </div>
+            <p class="help is-danger">{{ lastfm_login.errors.error }}</p>
+          </form>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+
+<!--
+  ############# Footer #############
+-->
 <footer class="footer">
   <div class="container">
     <div class="content has-text-centered">
@@ -190,7 +235,7 @@
 
 </div> <!-- #root -->
 
-<script src="/js/vue.min.js"></script>
+<script src="/js/vue.js"></script>
 <script src="/js/axios.min.js"></script>
 <script src="/js/forked-daapd.js"></script>
 

--- a/htdocs/css/forked-daapd.css
+++ b/htdocs/css/forked-daapd.css
@@ -1,3 +1,10 @@
 [v-cloak] {
   display: none;
 }
+
+.fd-section-heading {
+  margin-bottom: 24px !important;
+}
+.fd-section-content + .fd-section-content {
+  margin-top: 24px !important;
+}

--- a/src/lastfm.h
+++ b/src/lastfm.h
@@ -2,10 +2,24 @@
 #ifndef __LASTFM_H__
 #define __LASTFM_H__
 
+#include <stdbool.h>
+
+int
+lastfm_login_user(const char *user, const char *password, char **errmsg);
+
 void
 lastfm_login(char **arglist);
 
+void
+lastfm_logout(void);
+
 int
 lastfm_scrobble(int id);
+
+bool
+lastfm_is_enabled(void);
+
+int
+lastfm_init(void);
 
 #endif /* !__LASTFM_H__ */

--- a/src/listener.h
+++ b/src/listener.h
@@ -24,6 +24,8 @@ enum listener_event_type
   LISTENER_PAIRING = (1 << 8),
   /* Spotify status changes (login, logout) */
   LISTENER_SPOTIFY = (1 << 9),
+  /* Last.fm status changes (enable/disable scrobbling) */
+  LISTENER_LASTFM = (1 << 10),
 };
 
 typedef void (*notify)(enum listener_event_type type);

--- a/src/main.c
+++ b/src/main.c
@@ -70,6 +70,9 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 #include "player.h"
 #include "worker.h"
 #include "library.h"
+#ifdef LASTFM
+# include "lastfm.h"
+#endif
 
 #ifdef HAVE_LIBCURL
 # include <curl/curl.h>
@@ -782,6 +785,10 @@ main(int argc, char **argv)
   mdns_no_mpd = 0;
 #else
   mdns_no_mpd = 1;
+#endif
+
+#ifdef LASTFM
+  lastfm_init();
 #endif
 
   /* Start Remote pairing service */

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -137,6 +137,10 @@ process_notify_request(struct ws_session_data_notify *session_data, void *in, si
 		{
 		  session_data->events |= LISTENER_SPOTIFY;
 		}
+	      else if (0 == strcmp(event_type, "lastfm"))
+		{
+		  session_data->events |= LISTENER_LASTFM;
+		}
 	    }
 	}
     }
@@ -176,6 +180,10 @@ send_notify_reply(short events, struct lws* wsi)
   if (events & LISTENER_SPOTIFY)
     {
       json_object_array_add(notify, json_object_new_string("spotify"));
+    }
+  if (events & LISTENER_LASTFM)
+    {
+      json_object_array_add(notify, json_object_new_string("lastfm"));
     }
 
   reply = json_object_new_object();
@@ -258,7 +266,7 @@ static struct lws_protocols protocols[] =
 static void *
 websocket(void *arg)
 {
-  listener_add(listener_cb, LISTENER_UPDATE | LISTENER_PAIRING | LISTENER_SPOTIFY);
+  listener_add(listener_cb, LISTENER_UPDATE | LISTENER_PAIRING | LISTENER_SPOTIFY | LISTENER_LASTFM);
 
   while(!ws_exit)
     {


### PR DESCRIPTION
This integrates the last.fm login/logout into the web interface.
It also changes the layout of the web interface (see screenshots). I think the new layout will better scale if additional options/configurations) make it into the web interface.

last.fm login:

![image](https://user-images.githubusercontent.com/1037620/31860075-2bf7a6da-b715-11e7-8721-1aa37c8a37df.png)

last.fm logout:

![image](https://user-images.githubusercontent.com/1037620/31860062-0a0bc434-b715-11e7-8ecc-d8349fd3866e.png)
