### PR TITLE
allow specification of pulseaudio server

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -177,6 +177,12 @@ audio {
 	# Type of the output (alsa, pulseaudio, dummy or disabled)
 #	type = "alsa"
 
+	# For pulseaudio output, an optional server can be specified.
+	# See http://billauer.co.il/blog/2014/01/pa-multiple-users/
+	# for an example how to set up access to the daemon started
+	# by a logged-in user.
+#	server = "localhost"
+
 	# Audio PCM device name for local audio output - ALSA only
 #	card = "default"
 

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -177,11 +177,9 @@ audio {
 	# Type of the output (alsa, pulseaudio, dummy or disabled)
 #	type = "alsa"
 
-	# For pulseaudio output, an optional server can be specified.
-	# See http://billauer.co.il/blog/2014/01/pa-multiple-users/
-	# for an example how to set up access to the daemon started
-	# by a logged-in user.
-#	server = "localhost"
+        # For pulseaudio output, an optional server can be specified.
+        # If not set, connection is made via local socket.
+#       server = ""
 
 	# Audio PCM device name for local audio output - ALSA only
 #	card = "default"

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -104,6 +104,7 @@ static cfg_opt_t sec_audio[] =
   {
     CFG_STR("nickname", "Computer", CFGF_NONE),
     CFG_STR("type", NULL, CFGF_NONE),
+    CFG_STR("server", NULL, CFGF_NONE),
     CFG_STR("card", "default", CFGF_NONE),
     CFG_STR("mixer", NULL, CFGF_NONE),
     CFG_STR("mixer_device", NULL, CFGF_NONE),

--- a/src/outputs/pulse.c
+++ b/src/outputs/pulse.c
@@ -891,12 +891,15 @@ static int
 pulse_init(void)
 {
   char *type;
+  char *server;
   int state;
   int ret;
 
   type = cfg_getstr(cfg_getsec(cfg, "audio"), "type");
   if (type && (strcasecmp(type, "pulseaudio") != 0))
     return -1;
+
+  server = cfg_getstr(cfg_getsec(cfg, "audio"), "server");
 
   ret = 0;
 
@@ -914,8 +917,8 @@ pulse_init(void)
     goto fail;
 
   pa_context_set_state_callback(pulse.context, context_state_cb, NULL);
-
-  if (pa_context_connect(pulse.context, NULL, 0, NULL) < 0)
+  
+  if (pa_context_connect(pulse.context, server, 0, NULL) < 0)
     {
       ret = pa_context_errno(pulse.context);
       goto fail;


### PR DESCRIPTION
This is needed to access a pulseaudio server via TCP.
If server is not specified in configuration, the behaviour is unchanged.