### PR TITLE
[scan] configuration option to follow symlinks

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -62,6 +62,9 @@ library {
 	# Directories to index
 	directories = { "/srv/music" }
 
+	# Follow symlinks. Default: true.	
+#	follow_symlinks = true
+
 	# Directories containing podcasts
 	# For each directory that is indexed the path is matched against these
 	# names. If there is a match all items in the directory are marked as 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -73,6 +73,7 @@ static cfg_opt_t sec_library[] =
     CFG_INT("port", 3689, CFGF_NONE),
     CFG_STR("password", NULL, CFGF_NONE),
     CFG_STR_LIST("directories", NULL, CFGF_NONE),
+    CFG_BOOL("follow_symlinks", cfg_true, CFGF_NONE),
     CFG_STR_LIST("podcasts", NULL, CFGF_NONE),
     CFG_STR_LIST("audiobooks", NULL, CFGF_NONE),
     CFG_STR_LIST("compilations", NULL, CFGF_NONE),


### PR DESCRIPTION
I have a lot of ´symlinks,which leads to duplicate entries and a lot of spam in the log.
By ignoring symlinks, real errors become visible again.
The default is to follow symlinks.