### PR TITLE
[daap] Configurable user agents

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -56,8 +56,41 @@ library {
 	# TCP port to listen on. Default port is 3689 (daap)
 	port = 3689
 
+        # User agents starting with one of the strings are considered
+	# remotes.  As they are required to be paired, the password is
+	# not required for them.
+#       remote_user_agents = { "Remote", "RetuneAndroid" }
+
 	# Password for the library. Optional.
 #	password = ""
+
+        # IPv4 address prefixes, which are allowed without password.
+        # If the client IP address begins with one of the prefixes, it
+        # is allowed without password check.
+	#
+	# If you wish to allow all internal clients, the setting
+	# {"127.0.0.", "192.168."} probably covers it in most cases.
+#       allow_nets = {}
+
+        # User agents starting with one of the strings are allowed
+        # without password check. Default is unset.
+	#
+	# The amarok plug-in can neither submit a password, nor can it
+	# be paired. Version 4.14.22 identifies as "User Agent:
+	# iTunes/4.6 (Windows; N)". Adding this to `allow_user_agents`
+	# grants Amarok access, while other clients may still require
+	# pairing or password authentication.
+#       allow_user_agents = {}
+
+        # URIs starting with one of the strings are allowed
+        # without password check.
+	#
+	# Giving out server information and content-codes seems
+	# uncritical.  However, allowing library queries without
+	# authentication over the internet is probably not a good idea
+	# and you might consider removing "/databases/1/items" from
+	# `allow_uris`.
+#       allow_uris = {"/server-info","/logout","/content-codes","/databases/1/items"}
 
 	# Directories to index
 	directories = { "/srv/music" }

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -71,7 +71,11 @@ static cfg_opt_t sec_library[] =
   {
     CFG_STR("name", "My Music on %h", CFGF_NONE),
     CFG_INT("port", 3689, CFGF_NONE),
+    CFG_STR_LIST("remote_user_agents", "{Remote,RetuneAndroid}", CFGF_NONE),
     CFG_STR("password", NULL, CFGF_NONE),
+    CFG_STR_LIST("allow_nets", NULL, CFGF_NONE),
+    CFG_STR_LIST("allow_user_agents", NULL, CFGF_NONE),
+    CFG_STR_LIST("allow_uris", "{/server-info,/logout,/content-codes,/databases/1/items}", CFGF_NONE),
     CFG_STR_LIST("directories", NULL, CFGF_NONE),
     CFG_STR_LIST("podcasts", NULL, CFGF_NONE),
     CFG_STR_LIST("audiobooks", NULL, CFGF_NONE),


### PR DESCRIPTION
This is an authentication enhancement in one fell swoop. I could break it down, but hope that it is not necessary. I have not changed the previous defaults, so the server still works the same as before (except one more remote is supported).

I found that the code to recognize "Remotes" was very inconsistent. Some of my Android clients were not even able to pair, when the library password was enabled. So I made the User-Agent prefix matches configurable, which allows to enable/disable remote clients by editing /etc/forked-daapd.conf.

The goal was to be able to cover the following use cases:

1. Library **password** must be enabled to allow access from the Internet
2. Option **remote_user_agents** can be used to configure remotes which are authenticated by pairing (password is not checked).
3. Amarok can neither use a password nor can it be paired. In such a case option **allow_user_agents** can be used to bypass both password and pairing check based on the user agent string.
4. Option **allow_nets** can be used as a simple method to allow access without password from the internal LAN/WLAN  (or more correctly  any IP).
5. The amount of information that is available without password can be configured through **allow_uris**. This is especially necessary for servers accessible from the internet. Giving out the entire catalog to anybody can cause traffic and other problems.

This sample configuration achieves that:

     remote_user_agents = {
       "Remote",        # Remote
       "Dalvik/",       # Remote for iTunes DJ & UpNext
       "RetuneAndroid", # Retune
     }

     password = "xx-xxx-x"

     allow_nets = { "127.0.0.", "192.168." }

     allow_user_agents = {
       "iTunes/4.6 (Windows; N)" # Amarok
     }

    allow_uris = {
      "/server-info",
      "/logout",
      "/content-codes"
    } # "/databases/1/items" removed
