### PR TITLE
[mpd] Quoted argument unescaping fixed

### DIFF
--- a/src/mpd.c
+++ b/src/mpd.c
@@ -313,32 +313,36 @@ static char*
 mpd_pars_quoted(char **input)
 {
   char *arg;
+  char *src;
+  char *dst;
+  char ch;
 
   // skip double quote character
   (*input)++;
 
-  arg = *input;
-
-  while (**input != '"')
+  src = dst = arg = *input;
+  while ((ch = *src) != '"')
     {
-      // A backslash character escapes the following character
-      if (**input == '\\')
+      // A backslash character escapes the following character and should be removed
+      if (ch == '\\')
 	{
-	  (*input)++;
+          ch = *(++src);
 	}
+      *dst++ = ch;
 
-      if (**input == 0)
+      if (ch == 0)
 	{
 	  // Error handling for missing double quote at end of parameter
 	  DPRINTF(E_LOG, L_MPD, "Error missing closing double quote in argument\n");
+          *input = src;
 	  return NULL;
 	}
 
-      (*input)++;
+      ++src;
     }
 
-  **input = '\0';
-  (*input)++;
+  *dst = '\0';
+  *input = ++src;
 
   return arg;
 }


### PR DESCRIPTION
When there is an album directory containing quotes, e.g.:

    Charlie "The Bird" Parker: Portrait 01 ~ Groovin' High

If quoted MPD arguments are not unescaped, the virtual path is not found:

    Directory info not found for virtual-path '/file:/srv/music/Charlie Parker/Charlie \"The Bird\" Parker: Portrait 01 ~ Groovin' High'

This pull request fixes this.