### PR TITLE
[scan] After rescan, fullrescan inotify must be enabled

### DIFF
--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -1612,6 +1612,11 @@ filescanner_rescan()
   inofd_event_set();
   bulk_scan(F_SCAN_BULK | F_SCAN_RESCAN);
 
+  if (!library_is_exiting())
+    {
+      /* Enable inotify */
+      event_add(inoev, NULL);
+    }
   return 0;
 }
 
@@ -1624,6 +1629,11 @@ filescanner_fullrescan()
   inofd_event_set();
   bulk_scan(F_SCAN_BULK);
 
+  if (!library_is_exiting())
+    {
+      /* Enable inotify */
+      event_add(inoev, NULL);
+    }
   return 0;
 }
 


### PR DESCRIPTION
While testing the `database`/`update` events, I found that after an `update` command, the automatic detection of filesystem changes did not work anymore.

This change fixed it.