### PR TITLE
[db] Report directory names that end in spaces

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3412,7 +3412,16 @@ db_directory_add(struct directory_info *di, int *id)
 
   char *query;
   char *errmsg;
+  int vp_len = strlen(di->virtual_path);
   int ret;
+
+  if (vp_len && di->virtual_path[vp_len-1] == ' ')
+    {
+      /* Since sqlite removes the trailing space, so these
+       * directories will be found as new in perpetuity.
+       */
+      DPRINTF(E_LOG, L_DB, "Directory name ends with space: [%s]\n", di->virtual_path);
+    }
 
   query = sqlite3_mprintf(QADD_TMPL, di->virtual_path, di->db_timestamp, di->disabled, di->parent_id);
 


### PR DESCRIPTION
When a music tree contains directories with trailing spaces, they are not found in the database during a rescan, because sqlite removes the trailing space in the database. These non-changes are reported as changes  triggering library reloads and cache updates.

I think at least a hint in the log file would be most helpful.

BTW: The correct solution would be to store directories with a trailing slash, but it does not help with files having trailing spaces.