### PR TITLE
[mpd] Notify MPD clients of library changes and fix idle command

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -873,7 +873,7 @@ cache_daap_update(void *arg, int *retval)
 
 /* Callback from filescanner thread */
 static void
-cache_daap_listener_cb(enum listener_event_type type)
+cache_daap_listener_cb(short event_mask)
 {
   commands_exec_async(cmdbase, cache_daap_update, NULL);
 }

--- a/src/db.h
+++ b/src/db.h
@@ -680,8 +680,14 @@ db_spotify_files_delete(void);
 int
 db_admin_set(const char *key, const char *value);
 
+int
+db_admin_setint64(const char *key, int64_t value);
+
 char *
 db_admin_get(const char *key);
+
+int64_t
+db_admin_getint64(const char *key);
 
 int
 db_admin_delete(const char *key);

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -719,12 +719,12 @@ playstatusupdate_cb(int fd, short what, void *arg)
 
 /* Thread: player */
 static void
-dacp_playstatus_update_handler(enum listener_event_type type)
+dacp_playstatus_update_handler(short event_mask)
 {
   int ret;
 
   // Only send status update on player change events
-  if (type != LISTENER_PLAYER)
+  if (!(event_mask & LISTENER_PLAYER))
     return;
 
 #ifdef HAVE_EVENTFD

--- a/src/httpd_streaming.c
+++ b/src/httpd_streaming.c
@@ -185,7 +185,7 @@ streaming_send_cb(evutil_socket_t fd, short event, void *arg)
 
 // Thread: player (not fully thread safe, but hey...)
 static void
-player_change_cb(enum listener_event_type type)
+player_change_cb(short event_mask)
 {
   streaming_player_changed = 1;
 }

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -764,7 +764,7 @@ pipelist_create(void)
 // the pipe thread to watch the pipes. If no pipes in library, it will shut down
 // the pipe thread.
 static void
-pipe_listener_cb(enum listener_event_type type)
+pipe_listener_cb(short event_mask)
 {
   union pipe_arg *cmdarg;
 

--- a/src/library.c
+++ b/src/library.c
@@ -77,11 +77,16 @@ static bool scan_exit;
 /* Flag for scan in progress */
 static bool scanning;
 
-// After being told by db that the library was updated through update_trigger(),
-// wait 60 seconds before notifying listeners of LISTENER_DATABASE. This is to
-// avoid bombarding the listeners while there are many db updates, and to make
-// sure they only get a single update (useful for the cache).
-static struct timeval library_update_wait = { 60, 0 };
+// After being told by db that the library was updated through
+// library_update_trigger(), wait 5 seconds before notifying listeners
+// of LISTENER_DATABASE. This is to catch bulk updates like automated
+// tag editing, music file imports/renames.  This way multiple updates
+// are collected for a single update notification (useful to avoid
+// repeated library reads from clients).
+//
+// Note: this update delay does not apply to library scans.  The scans
+// use the flag `scanning` for deferring update notifcations.
+static struct timeval library_update_wait = { 5, 0 };
 static struct event *updateev;
 
 

--- a/src/library.h
+++ b/src/library.h
@@ -115,9 +115,6 @@ library_set_scanning(bool is_scanning);
 bool
 library_is_exiting();
 
-time_t
-library_update_time_get(void);
-
 void
 library_update_trigger(void);
 

--- a/src/library.h
+++ b/src/library.h
@@ -115,6 +115,9 @@ library_set_scanning(bool is_scanning);
 bool
 library_is_exiting();
 
+time_t
+library_update_time_get(void);
+
 void
 library_update_trigger(void);
 

--- a/src/listener.h
+++ b/src/listener.h
@@ -28,18 +28,18 @@ enum listener_event_type
   LISTENER_LASTFM = (1 << 10),
 };
 
-typedef void (*notify)(enum listener_event_type type);
+typedef void (*notify)(short event_mask);
 
 /*
  * Registers the given callback function to the given event types.
  * This function is not thread safe. Listeners must be added once at startup.
  *
  * @param notify_cb Callback function
- * @param events Event mask, one or more of LISTENER_*
+ * @param event_mask Event mask, one or more of LISTENER_*
  * @return 0 on success, -1 on failure
  */
 int
-listener_add(notify notify_cb, short events);
+listener_add(notify notify_cb, short event_mask);
 
 /*
  * Removes the given callback function

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -836,14 +836,14 @@ mpd_command_stats(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
       "songs: %d\n"
       "uptime: %d\n" //in seceonds
       "db_playtime: %" PRIu64 "\n"
-      "db_update: %d\n"
+      "db_update: %ld\n"
       "playtime: %d\n",
         artists,
         albums,
         fci.count,
         4,
         (fci.length / 1000),
-        6,
+        library_update_time_get(),
         7);
 
   return 0;

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -632,6 +632,7 @@ mpd_command_currentsong(struct evbuffer *evbuf, int argc, char **argv, char **er
 
 static int
 mpd_notify_idle_client(struct mpd_client_ctx *client_ctx, short events);
+
 /*
  * Example input:
  * idle "database" "mixer" "options" "output" "player" "playlist" "sticker" "update"
@@ -679,41 +680,16 @@ mpd_command_idle(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, s
   return 0;
 }
 
-//static void
-//mpd_remove_client(struct evbuffer *evbuf)
-//{
-//  struct idle_client *client;
-//  struct idle_client *prev;
-//
-//  client = idle_clients;
-//  prev = NULL;
-//
-//  while (client)
-//    {
-//      if (client->evbuffer == evbuf)
-//	{
-//	  DPRINTF(E_DBG, L_MPD, "Removing idle client for evbuffer\n");
-//
-//	  if (prev)
-//	    prev->next = client->next;
-//	  else
-//	    idle_clients = client->next;
-//
-//	  free(client);
-//	  break;
-//	}
-//
-//      prev = client;
-//      client = client->next;
-//    }
-//}
-
 static int
 mpd_command_noidle(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, struct mpd_client_ctx *ctx)
 {
-  ctx->is_idle = false;
-  ctx->idle_events = 0;
-  return 0;
+  /*
+   * The protocol specifies: "The idle command can be canceled by
+   * sending the command noidle (no other commands are allowed). MPD
+   * will then leave idle mode and print results immediately; might be
+   * empty at this time."
+   */
+  return mpd_notify_idle_client(ctx, 0);
 }
 
 /*
@@ -859,7 +835,7 @@ mpd_command_stats(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, 
       "songs: %d\n"
       "uptime: %d\n" //in seceonds
       "db_playtime: %" PRIi64 "\n"
-      "db_update: %ld\n"
+      "db_update: %" PRIi64 "\n"
       "playtime: %d\n",
       artists,
       albums,

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4711,6 +4711,14 @@ mpd_notify_idle_client(struct idle_client *client, enum listener_event_type type
 
   switch (type)
     {
+      case LISTENER_DATABASE:
+	evbuffer_add(client->evbuffer, "changed: database\n", 18);
+	break;
+
+      case LISTENER_UPDATE:
+	evbuffer_add(client->evbuffer, "changed: update\n", 16);
+	break;
+
       case LISTENER_PLAYER:
 	evbuffer_add(client->evbuffer, "changed: player\n", 16);
 	break;
@@ -5069,7 +5077,7 @@ int mpd_init(void)
 #endif
 
   idle_clients = NULL;
-  listener_add(mpd_listener_cb, LISTENER_PLAYER | LISTENER_QUEUE | LISTENER_VOLUME | LISTENER_SPEAKER | LISTENER_OPTIONS);
+  listener_add(mpd_listener_cb, LISTENER_PLAYER | LISTENER_QUEUE | LISTENER_VOLUME | LISTENER_SPEAKER | LISTENER_OPTIONS | LISTENER_DATABASE | LISTENER_UPDATE | LISTENER_STORED_PLAYLIST);
 
   return 0;
 

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -829,22 +829,22 @@ mpd_command_stats(struct evbuffer *evbuf, int argc, char **argv, char **errmsg)
   artists = db_files_get_artist_count();
   albums = db_files_get_album_count();
 
-  //TODO [mpd] Implement missing stats attributes (uptime, db_update, playtime)
+  //TODO [mpd] Implement missing stats attributes (uptime, playtime)
   evbuffer_add_printf(evbuf,
       "artists: %d\n"
       "albums: %d\n"
       "songs: %d\n"
       "uptime: %d\n" //in seceonds
-      "db_playtime: %" PRIu64 "\n"
+      "db_playtime: %" PRIi64 "\n"
       "db_update: %ld\n"
       "playtime: %d\n",
-        artists,
-        albums,
-        fci.count,
-        4,
-        (fci.length / 1000),
-        library_update_time_get(),
-        7);
+      artists,
+      albums,
+      fci.count,
+      4,
+      (fci.length / 1000),
+      (time_t) db_admin_getint64("db_update"),
+      7);
 
   return 0;
 }

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4768,12 +4768,12 @@ mpd_notify_idle_client(struct mpd_client_ctx *client_ctx, short events)
 static enum command_state
 mpd_notify_idle(void *arg, int *retval)
 {
-  enum listener_event_type type;
+  short event_mask;
   struct mpd_client_ctx *client;
   int i;
 
-  type = *(enum listener_event_type *)arg;
-  DPRINTF(E_DBG, L_MPD, "Notify clients waiting for idle results: %d\n", type);
+  event_mask = *(short *)arg;
+  DPRINTF(E_DBG, L_MPD, "Notify clients waiting for idle results: %d\n", event_mask);
 
   i = 0;
   client = mpd_clients;
@@ -4781,7 +4781,7 @@ mpd_notify_idle(void *arg, int *retval)
     {
       DPRINTF(E_DBG, L_MPD, "Notify client #%d\n", i);
 
-      mpd_notify_idle_client(client, type);
+      mpd_notify_idle_client(client, event_mask);
       client = client->next;
       i++;
     }
@@ -4791,14 +4791,14 @@ mpd_notify_idle(void *arg, int *retval)
 }
 
 static void
-mpd_listener_cb(enum listener_event_type type)
+mpd_listener_cb(short event_mask)
 {
-  enum listener_event_type *ptr;
+  short *ptr;
 
-  ptr = (enum listener_event_type *)malloc(sizeof(enum listener_event_type));
-  *ptr = type;
+  ptr = (short *)malloc(sizeof(short));
+  *ptr = event_mask;
 
-  DPRINTF(E_DBG, L_MPD, "Listener callback called with event type %d.\n", type);
+  DPRINTF(E_DBG, L_MPD, "Listener callback called with event type %d.\n", event_mask);
   commands_exec_async(cmdbase, mpd_notify_idle, ptr);
 }
 

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -50,10 +50,10 @@ static short write_events;
 
 /* Thread: library (the thread the event occurred) */
 static void
-listener_cb(enum listener_event_type type)
+listener_cb(short event_mask)
 {
   // Add event to the event mask, clients will be notified at the next break of the libwebsockets service loop
-  events |= type;
+  events |= event_mask;
 }
 
 /*


### PR DESCRIPTION
I rebased #436, squashed some commits and did some small cleanups (mainly some code documentation, naming).

The  changes are (for details see the discussion in #436):
- fix the idle command handling: do not lose events if a mpd client is not in idle mode
- store last update time of the library in the admin db table and report the update time in the mpd stats command
- fix for sending database event on init-/rescan even if nothing changes
- change listener implementation to support notifying of multiple events in one call (required to properly send the DATABASE/UPDATE events to mpd clients)
- notify mpd clients of DATABASE and UPDATE events 
- fix noidle command: report change events in noidle response (if any exist)

@wolfmanx Thank you for working on this! I hope it is ok, that i picked your commits and created a new pull request. But i think, this saves us some back and forth.

@ejurgensen This is now ready to be reviewed/merged.