### PR TITLE
[mpd] Draft of rating sticker translator

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1072,6 +1072,9 @@ dacp_propset_userrating(const char *value, struct evkeyvalq *query)
 
   mfi->rating = rating;
 
+  /* rating is shared as MPD sticker `rating` */
+  listener_notify(LISTENER_STICKER);
+  
   /* We're not touching any string field in mfi, so it's safe to
    * skip unicode_fixup_mfi() before the update
    */

--- a/src/listener.h
+++ b/src/listener.h
@@ -26,6 +26,8 @@ enum listener_event_type
   LISTENER_SPOTIFY = (1 << 9),
   /* Last.fm status changes (enable/disable scrobbling) */
   LISTENER_LASTFM = (1 << 10),
+  /* The sticker database has been modified (MPD) */
+  LISTENER_STICKER  = (1 << 11),
 };
 
 typedef void (*notify)(short event_mask);


### PR DESCRIPTION
@chme  This is not a real sticker implementation, but a translation layer between the DAAP rating and the sticker rating as used by cantata. I.e., These are just virtual stickers.

I have used several possible ways for detecting the rating parameters, where sending a message to the rating channel is the preferred method: `sendmessage rating "rating-name [max [step]]"`
