### PR TITLE
[db] Queue notification when metadata changes

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -4115,6 +4115,9 @@ db_queue_update_item(struct db_queue_item *qi)
 
   ret = db_query_run(query, 1, 0);
 
+  /* MPD changes playlist version when metadata changes */
+  queue_inc_version_and_notify();
+
   return ret;
 #undef Q_TMPL
 }


### PR DESCRIPTION
When playing HTTP streams, the metadata changes are not detected by cantata.
Comparison of the conversations between the client, MPD and forked-daapd shows that MPD triggers a `changed: playlist` event when the metadata changes.

This PR makes the metadata update work in cantata and does not seem to have an adverse effect on DAAP clients (Retune, Remote).