### PR TITLE
[scan] Consistent HTTP virtual paths

### DIFF
--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -1640,13 +1640,21 @@ filescanner_fullrescan()
 static int
 scan_metadata(const char *path, struct media_file_info *mfi)
 {
+  char *pos;
   int ret;
 
   if (strncasecmp(path, "http://", strlen("http://")) == 0)
     {
       memset(mfi, 0, sizeof(struct media_file_info));
       mfi->path = strdup(path);
-      mfi->fname = strdup(filename_from_path(mfi->path));
+      mfi->virtual_path = safe_asprintf("/%s", mfi->path);
+
+      pos = strchr(path, '#');
+      if (pos)
+	mfi->fname = strdup(pos+1);
+      else
+	mfi->fname = strdup(filename_from_path(mfi->path));
+
       mfi->data_kind = DATA_KIND_HTTP;
       mfi->directory_id = DIR_HTTP;
 
@@ -1658,6 +1666,9 @@ scan_metadata(const char *path, struct media_file_info *mfi)
 	  mfi->codectype = strdup("mpeg");
 	  mfi->description = strdup("MPEG audio file");
 	}
+
+      if (!mfi->title)
+	mfi->title = strdup(mfi->fname);
 
       return LIBRARY_OK;
     }

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -76,6 +76,7 @@ static int
 process_url(int pl_id, const char *path, time_t mtime, int extinf, struct media_file_info *mfi)
 {
   char virtual_path[PATH_MAX];
+  char *pos;
   int ret;
 
   if (extinf)
@@ -83,7 +84,13 @@ process_url(int pl_id, const char *path, time_t mtime, int extinf, struct media_
 
   mfi->id = db_file_id_bypath(path);
   mfi->path = strdup(path);
-  mfi->fname = strdup(filename_from_path(path));
+
+  pos = strchr(path, '#');
+  if (pos)
+    mfi->fname = strdup(pos+1);
+  else
+    mfi->fname = strdup(filename_from_path(mfi->path));
+
   mfi->data_kind = DATA_KIND_HTTP;
   mfi->time_modified = mtime;
   mfi->directory_id = DIR_HTTP;
@@ -100,7 +107,7 @@ process_url(int pl_id, const char *path, time_t mtime, int extinf, struct media_
   if (!mfi->title)
     mfi->title = strdup(mfi->fname);
 
-  snprintf(virtual_path, sizeof(virtual_path), "/http:/%s", mfi->title);
+  snprintf(virtual_path, sizeof(virtual_path), "/%s", mfi->path);
   mfi->virtual_path = strdup(virtual_path);
 
   library_add_media(mfi);


### PR DESCRIPTION
When adding a http stream URL to the playlist with an `add` command, the virtual path is just duplicated from the URL.
When the playlist is then retrieved via `playlistinfo`, the leading character `h` is cut off, which causes problems in e.g. cantata.

This fixes it, but I don't know what the implications are.