### PR TITLE
[main/httpd] Configurable web root directory over cli parameter

### DIFF
--- a/src/httpd.h
+++ b/src/httpd.h
@@ -157,7 +157,7 @@ int
 httpd_basic_auth(struct evhttp_request *req, const char *user, const char *passwd, const char *realm);
 
 int
-httpd_init(void);
+httpd_init(const char *webroot);
 
 void
 httpd_deinit(void);


### PR DESCRIPTION
This adds a command line parameter for setting the web root directory:

```
./forked-daapd -w <path to webroot directory>
```

It makes development of the web interface a bit more convenient, as it is now possible to point the web root directory directly to the source folder. I think this is in line with the parameters for the config file or the pid file.