### PR TITLE
Unique queue item ids and proper implementation of mpd commands 'plchanges' and 'plchangesposid'

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -428,6 +428,8 @@ struct db_queue_item
   uint32_t disc;
 
   char *artwork_url;
+
+  uint32_t queue_version;
 };
 
 char *

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -162,7 +162,7 @@
 
 #define T_QUEUE								\
   "CREATE TABLE IF NOT EXISTS queue ("					\
-  "   id                  INTEGER PRIMARY KEY NOT NULL,"		\
+  "   id                  INTEGER PRIMARY KEY AUTOINCREMENT,"		\
   "   file_id             INTEGER NOT NULL,"				\
   "   pos                 INTEGER NOT NULL,"				\
   "   shuffle_pos         INTEGER NOT NULL,"				\
@@ -184,7 +184,8 @@
   "   year                INTEGER DEFAULT 0,"				\
   "   track               INTEGER DEFAULT 0,"				\
   "   disc                INTEGER DEFAULT 0,"				\
-  "   artwork_url         VARCHAR(4096) DEFAULT NULL"			\
+  "   artwork_url         VARCHAR(4096) DEFAULT NULL,"			\
+  "   queue_version       INTEGER DEFAULT 0"				\
   ");"
 
 #define TRG_GROUPS_INSERT_FILES						\

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * forked-daapd after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 19
-#define SCHEMA_VERSION_MINOR 05
+#define SCHEMA_VERSION_MINOR 06
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/player.c
+++ b/src/player.c
@@ -385,26 +385,30 @@ metadata_update_cb(void *arg)
       goto out_free_metadata;
     }
 
-  // Since we won't be using the metadata struct values for anything else than
-  // this we just swap pointers
-  if (metadata->artist)
-    swap_pointers(&queue_item->artist, &metadata->artist);
-  if (metadata->title)
-    swap_pointers(&queue_item->title, &metadata->title);
-  if (metadata->album)
-    swap_pointers(&queue_item->album, &metadata->album);
-  if (metadata->genre)
-    swap_pointers(&queue_item->genre, &metadata->genre);
-  if (metadata->artwork_url)
-    swap_pointers(&queue_item->artwork_url, &metadata->artwork_url);
-  if (metadata->song_length)
-    queue_item->song_length = metadata->song_length;
-
-  ret = db_queue_update_item(queue_item);
-  if (ret < 0)
+  // Update queue item if metadata changed
+  if (metadata->artist || metadata->title || metadata->album || metadata->genre || metadata->artwork_url || metadata->song_length)
     {
-      DPRINTF(E_LOG, L_PLAYER, "Database error while updating queue with new metadata\n");
-      goto out_free_queueitem;
+      // Since we won't be using the metadata struct values for anything else than
+      // this we just swap pointers
+      if (metadata->artist)
+	swap_pointers(&queue_item->artist, &metadata->artist);
+      if (metadata->title)
+	swap_pointers(&queue_item->title, &metadata->title);
+      if (metadata->album)
+	swap_pointers(&queue_item->album, &metadata->album);
+      if (metadata->genre)
+	swap_pointers(&queue_item->genre, &metadata->genre);
+      if (metadata->artwork_url)
+	swap_pointers(&queue_item->artwork_url, &metadata->artwork_url);
+      if (metadata->song_length)
+	queue_item->song_length = metadata->song_length;
+
+      ret = db_queue_update_item(queue_item);
+      if (ret < 0)
+        {
+	  DPRINTF(E_LOG, L_PLAYER, "Database error while updating queue with new metadata\n");
+	  goto out_free_queueitem;
+	}
     }
 
   o_metadata = outputs_metadata_prepare(metadata->item_id);


### PR DESCRIPTION
Fixes #446 by making the queue item ids unique (not reusable after e. g. a queue clear) and implements the mpd commands 'plchanges' and 'plchangesposid' correctly (only return changed items and only in the given range).

This pr contains a db update from version 19.05 to 19.06 (i hope a minor version increase is correct):
- queue table: define id column as AUTOINCREMENT (requires drop+create)
- queue table: add column queue_version
- files table: update http-stream virtual paths (constructing the virtual path for http-streams changed in pr #449, this migrates existing databases to be consistent to the newly created paths)

As mentioned in #446 adding a queue item could result in the SQLITE_FULL error, if the autoincrement id reached its max value 9223372036854775807. I think that it is highly unlikely we will run into this problem.

The last commit 0b07cff is not related. It avoids triggering the QUEUE event in the metadata callback if nothing changed (currently it is always triggered at playback start).