### PR TITLE
Expand JSON/websocks interfaces to include more LISTENERS

### DIFF
--- a/htdocs/admin.html
+++ b/htdocs/admin.html
@@ -77,6 +77,36 @@
       <div class="column is-10"><h1 class="is-uppercase is-size-7">Status</h1></div>
     </div>
 
+<!-- Player update -->
+    <div class="columns is-centered fd-section-content">
+      <div class="column is-3">
+        <h2 class="title is-5">
+          <span class="icon" v-show="player.player_status == 2"><i class="fa fa-stop"></i></span>
+          <span class="icon" v-show="player.player_status == 3"><i class="fa fa-pause"></i></span>
+          <span class="icon" v-show="player.player_status == 4"><i class="fa fa-play-circle"></i></span>
+           Player
+         </h2>
+      </div>
+
+      <div class="column is-7 content">
+        <p v-show="player.player_status == 2">Stopped.</p>
+        <article class="level-left media-left" v-show="player.player_status > 2">
+	      	<div class="level-item">
+	  	    	<figure class="image is-128x128" style="margin:.5em">
+	    	    	<img :src="player.nowplayingurl">
+	    	  	</figure>
+	    	</div> 
+	        <div class="level-item">
+	        	<div class="content">
+	        		<p><strong>{{player.title}}</strong><br>
+	        		<i>{{player.album}}</i><br>
+	        		{{player.artist}}</p>
+	      		</div>
+	      	</div>
+        </article>
+      </div>
+    </div>
+
     <!-- Library update -->
     <div class="columns is-centered fd-section-content">
       <div class="column is-3">

--- a/htdocs/js/forked-daapd.js
+++ b/htdocs/js/forked-daapd.js
@@ -5,6 +5,7 @@ var app = new Vue({
   data: {
     config: {},
     library: {},
+    player: {},
     outputs: [],
     verification_req: { pin: '' },
     spotify: {},
@@ -18,6 +19,7 @@ var app = new Vue({
   created: function () {
     this.loadConfig();
     this.loadLibrary();
+    this.loadPlayer();
     this.loadOutputs();
     this.loadSpotify();
     this.loadPairing();
@@ -33,6 +35,13 @@ var app = new Vue({
 
     loadLibrary: function() {
       axios.get('/api/library').then(response => this.library = response.data);
+    },
+
+    loadPlayer: function() {
+      axios.get('/api/player').then(response => { 
+      	this.player = response.data;
+       	this.player.nowplayingurl = '/ctrl-int/1/nowplayingartwork?mw=256&mh=256?x='+this.player.file_id;
+      });
     },
 
     loadOutputs: function() {
@@ -133,7 +142,7 @@ var app = new Vue({
       var socket = new WebSocket('ws://' + document.domain + ':' + this.config.websocket_port, 'notify');
       const vm = this;
       socket.onopen = function() {
-          socket.send(JSON.stringify({ notify: ['update', 'pairing', 'spotify', 'lastfm', 'outputs']}));
+          socket.send(JSON.stringify({ notify: ['update', 'pairing', 'spotify', 'lastfm', 'outputs', 'player']}));
           socket.onmessage = function(response) {
               console.log(response.data); // upon message
               var data = JSON.parse(response.data);
@@ -151,6 +160,9 @@ var app = new Vue({
               }
               if (data.notify.includes('outputs')) {
                 vm.loadOutputs();
+              }
+              if (data.notify.includes('player')) {
+                  vm.loadPlayer();
               }
           };
       };

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -754,6 +754,7 @@ static struct httpd_uri_map adm_handlers[] =
     { .regexp = "^/api/queue", .handler = jsonapi_reply_queue },
     { .regexp = "^/api/select-outputs", .handler = jsonapi_reply_select_outputs },
     { .regexp = "^/api/verification", .handler = jsonapi_reply_verification },
+    { .regexp = "^/api/volume", .handler = jsonapi_reply_outputs },
     { .regexp = NULL, .handler = NULL }
   };
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -538,6 +538,113 @@ jsonapi_reply_outputs(struct httpd_request *hreq)
 }
 
 static int
+jsonapi_reply_queue(struct httpd_request *hreq)
+{
+  int version;
+  int count;
+  json_object *jreply;
+
+  CHECK_NULL(L_WEB, jreply = json_object_new_object());
+
+  version = db_admin_getint(DB_ADMIN_QUEUE_VERSION);
+  count = db_queue_get_count();
+
+  json_object_object_add(jreply, "version", json_object_new_int(version));
+  json_object_object_add(jreply, "count", json_object_new_int(count));
+
+  CHECK_ERRNO(L_WEB, evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(jreply)));
+
+  jparse_free(jreply);
+
+  return 0;
+}
+
+static int
+jsonapi_reply_options(struct httpd_request *hreq)
+{
+  struct player_status status;
+
+  json_object *jreply;
+
+  CHECK_NULL(L_WEB, jreply = json_object_new_object());
+
+  player_get_status(&status);
+
+  json_object_object_add(jreply, "player_status", json_object_new_int(status.status));/* play status, 2 = stopped, 3 = paused, 4 = playing */
+  json_object_object_add(jreply, "shuffle", json_object_new_int(status.shuffle));
+  json_object_object_add(jreply, "repeat", json_object_new_int(status.repeat));
+
+  CHECK_ERRNO(L_WEB, evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(jreply)));
+
+  jparse_free(jreply);
+
+  return 0;
+}
+
+static int
+jsonapi_reply_player(struct httpd_request *hreq)
+{
+  struct player_status status;
+  struct db_queue_item *queue_item = NULL;
+  json_object *jreply;
+
+  CHECK_NULL(L_WEB, jreply = json_object_new_object());
+
+  player_get_status(&status);
+
+  json_object_object_add(jreply, "player_status", json_object_new_int(status.status));/* play status, 2 = stopped, 3 = paused, 4 = playing */
+  json_object_object_add(jreply, "shuffle", json_object_new_int(status.shuffle));
+  json_object_object_add(jreply, "repeat", json_object_new_int(status.repeat));
+
+  if (status.status != PLAY_STOPPED)
+  {
+    queue_item = db_queue_fetch_byitemid(status.item_id);
+	if (!queue_item)
+	{
+	  DPRINTF(E_LOG, L_WEB, "Could not fetch item id %d (file id %d)\n", status.item_id, status.id);
+	  jparse_free(jreply);
+	  return -1;
+	}
+    uint32_t rtime_ms = 0;
+
+    if (queue_item->song_length)
+      rtime_ms = queue_item->song_length - status.pos_ms;
+
+    json_object_object_add(jreply, "id", json_object_new_int(queue_item->id));
+    json_object_object_add(jreply, "file_id", json_object_new_int(queue_item->file_id));
+    json_object_object_add(jreply, "pos", json_object_new_int(queue_item->pos));
+    json_object_object_add(jreply, "shuffle_pos", json_object_new_int(queue_item->shuffle_pos));
+    json_object_object_add(jreply, "data_kind", json_object_new_int(queue_item->data_kind));
+    json_object_object_add(jreply, "media_kind", json_object_new_int(queue_item->media_kind));
+    json_object_object_add(jreply, "song_length", json_object_new_int(queue_item->song_length));
+    json_object_object_add(jreply, "time_remaining", json_object_new_int(rtime_ms));
+    json_object_object_add(jreply, "path", json_object_new_string(queue_item->path));
+    json_object_object_add(jreply, "virtual_path", json_object_new_string(queue_item->virtual_path));
+    json_object_object_add(jreply, "title", json_object_new_string(queue_item->title));
+    json_object_object_add(jreply, "artist", json_object_new_string(queue_item->artist));
+    json_object_object_add(jreply, "album_artist", json_object_new_string(queue_item->album_artist));
+    json_object_object_add(jreply, "album", json_object_new_string(queue_item->album));
+    json_object_object_add(jreply, "genre", json_object_new_string(queue_item->genre));
+    json_object_object_add(jreply, "song_album_id", json_object_new_int64(queue_item->songalbumid));
+    json_object_object_add(jreply, "time_modified", json_object_new_int(queue_item->time_modified));
+    json_object_object_add(jreply, "year", json_object_new_int(queue_item->year));
+    json_object_object_add(jreply, "track", json_object_new_int(queue_item->track));
+    json_object_object_add(jreply, "disc", json_object_new_int(queue_item->disc));
+
+	if (queue_item->artwork_url)
+		json_object_object_add(jreply, "artwork_url", json_object_new_string(queue_item->artwork_url));
+
+    free_queue_item(queue_item, 0);
+  }
+
+  CHECK_ERRNO(L_WEB, evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(jreply)));
+
+  jparse_free(jreply);
+
+  return 0;
+}
+
+static int
 jsonapi_reply_verification(struct httpd_request *hreq)
 {
   struct evbuffer *in_evbuf;
@@ -641,7 +748,10 @@ static struct httpd_uri_map adm_handlers[] =
     { .regexp = "^/api/lastfm-login", .handler = jsonapi_reply_lastfm_login },
     { .regexp = "^/api/lastfm-logout", .handler = jsonapi_reply_lastfm_logout },
     { .regexp = "^/api/lastfm", .handler = jsonapi_reply_lastfm },
+    { .regexp = "^/api/options", .handler = jsonapi_reply_options },
     { .regexp = "^/api/outputs", .handler = jsonapi_reply_outputs },
+    { .regexp = "^/api/player", .handler = jsonapi_reply_player },
+    { .regexp = "^/api/queue", .handler = jsonapi_reply_queue },
     { .regexp = "^/api/select-outputs", .handler = jsonapi_reply_select_outputs },
     { .regexp = "^/api/verification", .handler = jsonapi_reply_verification },
     { .regexp = NULL, .handler = NULL }

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -145,6 +145,22 @@ process_notify_request(struct ws_session_data_notify *session_data, void *in, si
 		{
 		  session_data->events |= LISTENER_SPEAKER;
 		}
+	     else if (0 == strcmp(event_type, "player"))
+		{
+		  session_data->events |= LISTENER_PLAYER;
+		}
+	     else if (0 == strcmp(event_type, "volume"))
+		{
+		  session_data->events |= LISTENER_VOLUME;
+		}
+	     else if (0 == strcmp(event_type, "options"))
+		{
+		  session_data->events |= LISTENER_OPTIONS;
+		}
+	     else if (0 == strcmp(event_type, "queue"))
+		{
+		  session_data->events |= LISTENER_QUEUE;
+		}
 	    }
 	}
     }
@@ -193,6 +209,22 @@ send_notify_reply(short events, struct lws* wsi)
     {
       json_object_array_add(notify, json_object_new_string("outputs"));
     }
+  if (events & LISTENER_PLAYER)
+    {
+      json_object_array_add(notify, json_object_new_string("player"));
+    }
+  if (events & LISTENER_VOLUME)
+    {
+      json_object_array_add(notify, json_object_new_string("volume"));
+    }
+  if (events & LISTENER_OPTIONS)
+     {
+       json_object_array_add(notify, json_object_new_string("options"));
+     }
+  if (events & LISTENER_QUEUE)
+     {
+       json_object_array_add(notify, json_object_new_string("queue"));
+     }
 
   reply = json_object_new_object();
   json_object_object_add(reply, "notify", notify);
@@ -274,7 +306,7 @@ static struct lws_protocols protocols[] =
 static void *
 websocket(void *arg)
 {
-  listener_add(listener_cb, LISTENER_UPDATE | LISTENER_PAIRING | LISTENER_SPOTIFY | LISTENER_LASTFM | LISTENER_SPEAKER);
+  listener_add(listener_cb, LISTENER_UPDATE | LISTENER_PAIRING | LISTENER_SPOTIFY | LISTENER_LASTFM | LISTENER_SPEAKER | LISTENER_PLAYER | LISTENER_VOLUME | LISTENER_OPTIONS | LISTENER_QUEUE);
 
   while(!ws_exit)
     {


### PR DESCRIPTION
An expanded JSON api and websockets interface would allow for easier development of alternative remotes and whatnot.  I started with the LISTENERS I thought most useful.  

I add the "PLAYER" interface to the admin.html as a test case.  