### PR TITLE
Endpoints to query/control playback through JSON/websocket api

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -145,6 +145,22 @@ process_notify_request(struct ws_session_data_notify *session_data, void *in, si
 		{
 		  session_data->events |= LISTENER_SPEAKER;
 		}
+	      else if (0 == strcmp(event_type, "player"))
+		{
+		  session_data->events |= LISTENER_PLAYER;
+		}
+	      else if (0 == strcmp(event_type, "options"))
+		{
+		  session_data->events |= LISTENER_OPTIONS;
+		}
+	      else if (0 == strcmp(event_type, "volume"))
+		{
+		  session_data->events |= LISTENER_VOLUME;
+		}
+	      else if (0 == strcmp(event_type, "queue"))
+		{
+		  session_data->events |= LISTENER_QUEUE;
+		}
 	    }
 	}
     }
@@ -192,6 +208,22 @@ send_notify_reply(short events, struct lws* wsi)
   if (events & LISTENER_SPEAKER)
     {
       json_object_array_add(notify, json_object_new_string("outputs"));
+    }
+  if (events & LISTENER_PLAYER)
+    {
+      json_object_array_add(notify, json_object_new_string("player"));
+    }
+  if (events & LISTENER_OPTIONS)
+    {
+      json_object_array_add(notify, json_object_new_string("options"));
+    }
+  if (events & LISTENER_VOLUME)
+    {
+      json_object_array_add(notify, json_object_new_string("volume"));
+    }
+  if (events & LISTENER_QUEUE)
+    {
+      json_object_array_add(notify, json_object_new_string("queue"));
     }
 
   reply = json_object_new_object();
@@ -274,7 +306,8 @@ static struct lws_protocols protocols[] =
 static void *
 websocket(void *arg)
 {
-  listener_add(listener_cb, LISTENER_UPDATE | LISTENER_PAIRING | LISTENER_SPOTIFY | LISTENER_LASTFM | LISTENER_SPEAKER);
+  listener_add(listener_cb, LISTENER_UPDATE | LISTENER_PAIRING | LISTENER_SPOTIFY | LISTENER_LASTFM | LISTENER_SPEAKER
+	       | LISTENER_PLAYER | LISTENER_OPTIONS | LISTENER_VOLUME | LISTENER_QUEUE);
 
   while(!ws_exit)
     {


### PR DESCRIPTION
Like pr #457 this pr adds new endpoints to the JSON/websocket api to query and control playback.

It is part of my work towards a simple web interface to control forked-daapd (https://github.com/chme/forked-daapd/tree/web_remote).