### PR TITLE
[db] Fix adding urls to the queue that are not in the library

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -4268,8 +4268,8 @@ db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id)
   if (qp->results == 0)
     {
       db_query_end(qp);
-      ret = -1;
-      goto end_transaction;
+      db_transaction_end();
+      return 0;
     }
 
   while (((ret = db_query_fetch_file(qp, &dbmfi)) == 0) && (dbmfi.id))


### PR DESCRIPTION
This fixes a regression introduced in 912635e737319e2ec5d24f2922b3f31b38c8a88c that results in an error when trying to add a url to the current queue that is not in the library (e. g. `mpc add http://stream`)