### PR TITLE
[logger] Return early if severity or domain do not match

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -164,6 +164,11 @@ DPRINTF(int severity, int domain, const char *fmt, ...)
 {
   va_list ap;
 
+  // If domain and severity do not match the current log configuration, return early to
+  // safe some unnecessary code execution (tiny performance gain)
+  if (logger_initialized && (!((1 << domain) & logdomains) || (severity > threshold)))
+    return;
+
   va_start(ap, fmt);
   vlogger(severity, domain, fmt, ap);
   va_end(ap);


### PR DESCRIPTION
This change saved 4 seconds from the startup scan in my not representative tests (raspberry pi 2 with 9430 songs). Normally the scan takes ~51 seconds and with this change it went down to ~47 seconds (no new/changed files).

It's not much ... 