### PR TITLE
MPD protocol support improvements

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -4450,7 +4450,7 @@ db_queue_add_item(struct db_queue_item *queue_item, char reshuffle, uint32_t ite
 static int
 queue_enum_start(struct query_params *qp)
 {
-#define Q_TMPL "SELECT * FROM queue WHERE %s %s;"
+#define Q_TMPL "SELECT * FROM queue f WHERE %s %s;"
   sqlite3_stmt *stmt;
   char *query;
   const char *orderby;

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -608,16 +608,13 @@ mpd_command_currentsong(struct evbuffer *evbuf, int argc, char **argv, char **er
   player_get_status(&status);
 
   if (status.status == PLAY_STOPPED)
-    {
-      // Return empty evbuffer if there is no current playing song
-      return 0;
-    }
+    queue_item = db_queue_fetch_bypos(0, status.shuffle);
+  else
+    queue_item = db_queue_fetch_byitemid(status.item_id);
 
-  queue_item = db_queue_fetch_byitemid(status.item_id);
   if (!queue_item)
     {
-      *errmsg = safe_asprintf("Error adding queue item info for file with id: %d", status.item_id);
-      return ACK_ERROR_UNKNOWN;
+      return 0;
     }
 
   ret = mpd_add_db_queue_item(evbuf, queue_item);


### PR DESCRIPTION
Some MPD protocol support improvements:

- Report current and next song in 'status' and 'currentsong' commands (if the config of clear_queue_on_stop_disable = true, then clients are now able to display the next song if player is stopped)
- Implementation for commands 'playlistfind' and 'playlistsearch'
- Support for position parameter in command 'addid' (e. g. M.A.L.P. makes use of this to add a song as the next item in the queue) 