### PR TITLE
Add option to enable memory-mapped I/O for sqlite3

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -315,6 +315,16 @@ sqlite {
 	# Change the setting of the "synchronous" flag
 	# 0: OFF, 1: NORMAL, 2: FULL (default)
 #	pragma_synchronous = 2
+	
+	# Number of bytes set aside for memory-mapped I/O  for the library database
+	# (requires sqlite 3.7.17 or later)
+	# 0: disables mmap (default), any other value > 0: number of bytes for mmap
+#	pragma_mmap_size_library = 0
+
+	# Number of bytes set aside for memory-mapped I/O for the cache database
+	# (requires sqlite 3.7.17 or later)
+	# 0: disables mmap (default), any other value > 0: number of bytes for mmap
+#	pragma_mmap_size_cache = 0
 
 	# Should the database be vacuumed on startup? (increases startup time,
 	# but may reduce database size). Default is yes.

--- a/src/cache.c
+++ b/src/cache.c
@@ -445,11 +445,13 @@ cache_create(void)
 #define Q_PRAGMA_CACHE_SIZE "PRAGMA cache_size=%d;"
 #define Q_PRAGMA_JOURNAL_MODE "PRAGMA journal_mode=%s;"
 #define Q_PRAGMA_SYNCHRONOUS "PRAGMA synchronous=%d;"
+#define Q_PRAGMA_MMAP_SIZE "PRAGMA mmap_size=%d;"
   char *errmsg;
   int ret;
   int cache_size;
   char *journal_mode;
   int synchronous;
+  int mmap_size;
   char *query;
 
   // Open db
@@ -534,12 +536,29 @@ cache_create(void)
 	}
     }
 
+  // Set mmap size
+  mmap_size = cfg_getint(cfg_getsec(cfg, "sqlite"), "pragma_mmap_size_cache");
+  if (synchronous > -1)
+    {
+      query = sqlite3_mprintf(Q_PRAGMA_MMAP_SIZE, mmap_size);
+      ret = sqlite3_exec(g_db_hdl, query, NULL, NULL, &errmsg);
+      if (ret != SQLITE_OK)
+	{
+	  DPRINTF(E_LOG, L_CACHE, "Error setting pragma_mmap_size: %s\n", errmsg);
+
+	  sqlite3_free(errmsg);
+	  sqlite3_close(g_db_hdl);
+	  return -1;
+	}
+    }
+
   DPRINTF(E_DBG, L_CACHE, "Cache created\n");
 
   return 0;
 #undef Q_PRAGMA_CACHE_SIZE
 #undef Q_PRAGMA_JOURNAL_MODE
 #undef Q_PRAGMA_SYNCHRONOUS
+#undef Q_PRAGMA_MMAP_SIZE
 }
 
 static void

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -151,6 +151,8 @@ static cfg_opt_t sec_sqlite[] =
     CFG_INT("pragma_cache_size_cache", -1, CFGF_NONE),
     CFG_STR("pragma_journal_mode", NULL, CFGF_NONE),
     CFG_INT("pragma_synchronous", -1, CFGF_NONE),
+    CFG_INT("pragma_mmap_size_library", -1, CFGF_NONE),
+    CFG_INT("pragma_mmap_size_cache", -1, CFGF_NONE),
     CFG_BOOL("vacuum", cfg_true, CFGF_NONE),
     CFG_END()
   };


### PR DESCRIPTION
This adds a config option to allow setting the sqlite3 pragma "mmap_size" to enable memory mapped io in sqlite3 (https://www.sqlite.org/mmap.html).

Enabling it saves some data copies and therefor has a small performance gain. I am running forked-daapd with this enabled for month and did not encounter any issues. On my setup (raspberry pi 2), i have the feeling, it gives a small performance gain (especially when the system is under load, e. g. playing and loading artwork, ...), but i have to admit, that there was no measurable gain during startup/rescan.