### PR TITLE
[pipe] Do not rely on the DATABASE event to be triggered during startup

### DIFF
--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -925,7 +925,10 @@ init(void)
 
   pipe_autostart = cfg_getbool(cfg_getsec(cfg, "library"), "pipe_autostart");
   if (pipe_autostart)
-    CHECK_ERR(L_PLAYER, listener_add(pipe_listener_cb, LISTENER_DATABASE));
+    {
+      pipe_listener_cb(0);
+      CHECK_ERR(L_PLAYER, listener_add(pipe_listener_cb, LISTENER_DATABASE));
+    }
 
   return 0;
 }


### PR DESCRIPTION
@ejurgensen totally untested, but this should fix the automatic listening for pipes (https://github.com/ejurgensen/forked-daapd/commit/1cdb9f450d385618dbfc3ed8b04d2bea9900dbbb#commitcomment-26516503).

The cache should be fine. If the database did not change, there is no need to rebuild it. If the cache file was deleted, there is also no need to rebuild the cache as there are no cached daap-replies (the cache tables are created during cache init).