### PR TITLE
[db_profile] Use sqlite3_trace_v2 instead of deprecated sqlite3_profile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -355,6 +355,9 @@ FORK_ARG_ENABLE([Chromecast support], [chromecast], [CHROMECAST],
 AM_CONDITIONAL([COND_CHROMECAST], [[test "x$enable_chromecast" = "xyes"]])
 AM_CONDITIONAL([COND_PROTOBUF_OLD], [[test "x$protobuf_old" = "xyes"]])
 
+dnl DB profiling support
+FORK_ARG_ENABLE([DB profiling support], [dbprofile], [DB_PROFILE])
+
 dnl iTunes playlists with libplist
 FORK_ARG_DISABLE([iTunes Music Library XML support], [itunes], [ITUNES],
 	[AS_IF([[test "x$with_libplist" = "xno"]],

--- a/src/logger.c
+++ b/src/logger.c
@@ -260,6 +260,12 @@ logger_reinit(void)
 }
 
 
+int
+logger_severity(void)
+{
+  return threshold;
+}
+
 /* The functions below are used at init time with a single thread running */
 void
 logger_domains(void)

--- a/src/logger.h
+++ b/src/logger.h
@@ -48,6 +48,7 @@
 #define E_SPAM    5
 
 
+
 void
 DPRINTF(int severity, int domain, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 
@@ -64,6 +65,9 @@ logger_alsa(const char *file, int line, const char *function, int err, const cha
 
 void
 logger_reinit(void);
+
+int
+logger_severity(void);
 
 void
 logger_domains(void);


### PR DESCRIPTION
This pr makes it a bit more convenient to analyse db queries used in forked-daapd.
It adds a configure switch (`--enable-dbprofile`) to activate the already present profiling support in forked-daapd. And additional updates the profiling support to avoid using deprecated sqlite3 functions.

To minimize performance impact due to active profiling, the logger now exposes the log severity and the profiling function returns early if no log entries would be written.

Here is an example log output:
```
[2018-01-13 11:18:20] [  LOG]   dbperf: SQL PROFILE query: SELECT f.genre, f.genre FROM files f WHERE f.disabled = 0 AND (((f.media_kind = 1 OR 1 = 0) AND (f.genre <> '' AND f.genre IS NOT NULL))) AND (f.data_kind <> 1) AND f.genre != '' GROUP BY f.genre ORDER BY f.genre ASC ;
[2018-01-13 11:18:20] [  LOG]   dbperf: SQL PROFILE time: 1783 ms
[2018-01-13 11:18:20] [  LOG]   dbperf: Query plan:
[2018-01-13 11:18:20] [  LOG]   dbperf: (0,0,0) SCAN TABLE files AS f
[2018-01-13 11:18:20] [  LOG]   dbperf: (0,0,0) USE TEMP B-TREE FOR GROUP BY
```