### PR TITLE
changed version to 25.1 with notes about web interface

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 ChangeLog for forked-daapd
 --------------------------
 
+version 25.1:
+	- added web interface
+
 version 25.0:
 	- improved playback resilience
 	- substitute packet skipping (producing audio "clicks") with start/stop

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([forked-daapd], [25.0])
+AC_INIT([forked-daapd], [25.1])
 
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_MACRO_DIR([m4])

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -139,7 +139,7 @@ pairing_get(struct evbuffer *evbuf)
  *
  * {
  *  "websocket_port": 6603,
- *  "version": "25.0"
+ *  "version": "25.1"
  * }
  */
 static int


### PR DESCRIPTION
also recommend creating a v25.1 release (I know at least the linuxserver Docker group uses release tags to build their images and right now they have a version built in January 2018 that still uses v25.0 code from August 2017, which is missing things.