### PR TITLE
[db/library] Use "PRAGMA optimize" instead of "ANALYZE"

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -684,9 +684,9 @@ db_exec(const char *query, char **errmsg)
 
 /* Maintenance and DB hygiene */
 static void
-db_analyze(void)
+db_pragma_optimize(void)
 {
-  char *query = "ANALYZE;";
+  const char *query = "PRAGMA optimize;";
   char *errmsg;
   int ret;
 
@@ -695,7 +695,7 @@ db_analyze(void)
   ret = db_exec(query, &errmsg);
   if (ret != SQLITE_OK)
     {
-      DPRINTF(E_LOG, L_DB, "ANALYZE failed: %s\n", errmsg);
+      DPRINTF(E_LOG, L_DB, "PRAGMA optimize failed: %s\n", errmsg);
 
       sqlite3_free(errmsg);
     }
@@ -755,7 +755,7 @@ db_hook_post_scan(void)
 {
   DPRINTF(E_DBG, L_DB, "Running post-scan DB maintenance tasks...\n");
 
-  db_analyze();
+  db_pragma_optimize();
 
   DPRINTF(E_DBG, L_DB, "Done with post-scan DB maintenance\n");
 }
@@ -6412,8 +6412,6 @@ db_init(void)
 	  return -1;
 	}
     }
-
-  db_analyze();
 
   db_set_cfg_names();
 

--- a/src/library.c
+++ b/src/library.c
@@ -593,6 +593,9 @@ rescan(void *arg, int *ret)
 
   purge_cruft(starttime);
 
+  DPRINTF(E_DBG, L_LIB, "Running post library scan jobs\n");
+  db_hook_post_scan();
+
   endtime = time(NULL);
   DPRINTF(E_LOG, L_LIB, "Library rescan completed in %.f sec (%d changes)\n", difftime(endtime, starttime), deferred_update_notifications);
   scanning = false;
@@ -982,6 +985,7 @@ library(void *arg)
   if (!scan_exit)
     DPRINTF(E_FATAL, L_LIB, "Scan event loop terminated ahead of time!\n");
 
+  db_hook_post_scan();
   db_perthread_deinit();
 
   pthread_exit(NULL);


### PR DESCRIPTION
The "ANALYZE" statement takes around 2 seconds on my raspberry pi. It is called twice during startup (first at db_init, second after initscan).

According to the sqlite3 documentation it is recommended to use the "PRAGMA optimize" statement instead (https://www.sqlite.org/lang_analyze.html), which will call "ANALYZE" if it is likely the new data is helpful.

It does not make a big difference during startup ... but i thought i post it here nevertheless.  