### PR TITLE
New endpoints for the JSON api (library, queue)

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -4,8 +4,18 @@ Available API endpoints:
 
 * [Player](#player): control playback, volume, shuffle/repeat modes
 * [Outputs / Speakers](#outputs--speakers): list available outputs and enable/disable outputs
+* [Queue](#queue): list, add or modify the current queue
+* [Library](#library): list playlists, artists, albums and tracks from your library
 * [Server info](#server-info): get server information
 * [Push notifications](#push-notifications): receive push notifications
+
+JSON-Object model:
+
+* [Queue item](#queue-item-object)
+* [Playlist](#playlist-object)
+* [Artist](#artist-object)
+* [Album](#album-object)
+* [Track](#track-object)
 
 ## Player
 
@@ -429,6 +439,574 @@ On success returns the HTTP `204 No Content` success status response code.
 curl -X PUT "http://localhost:3689/api/outputs/0" --data "{\"selected\":true, \"volume\": 50}"
 ```
 
+
+
+## Queue
+
+| Method    | Endpoint                                                    | Description                          |
+| --------- | ----------------------------------------------------------- | ------------------------------------ |
+| GET       | [/api/queue](#list-queue-items)                             | Get a list of queue items            |
+| PUT       | [/api/queue/clear](#clearing-the-queue)                     | Remove all items from the queue      |
+| POST      | [/api/queue/items/add](#adding-items-to-the-queue)          | Add items to the queue               |
+| PUT       | [/api/queue/items/{id}](#moving-a-queue-item)               | Move a queue item in the queue       |
+| DELETE    | [/api/queue/items/{id}](#removing-a-queue-item)             | Remove a queue item form the queue   |
+
+
+
+### List queue items
+
+Lists the items in the current queue
+
+**Endpoint**
+
+```
+GET /api/queue
+```
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| id              | *(Optional)* If a queue item id is given, only the item with the id will be returend. |
+| start           | *(Optional)* If a `start`and an `end` position is given, only the items from `start` (included) to `end` (excluded) will be returned. If only a `start` position is given, only the item at this position will be returned. |
+| end             | *(Optional)* See `start` parameter |
+
+**Response**
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| version         | integer  | Version number of the current queue       |
+| count           | integer  | Number of items in the current queue      |
+| items           | array    | Array of [`queue item`](#queue-item-object) objects |
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/queue"
+```
+
+```
+{
+  "version": 833,
+  "count": 20,
+  "items": [
+    {
+      "id": 12122,
+      "position": 0,
+      "track_id": 10749,
+      "title": "Angels",
+      "artist": "The xx",
+      "artist_sort": "xx, The",
+      "album": "Coexist",
+      "album_sort": "Coexist",
+      "albumartist": "The xx",
+      "albumartist_sort": "xx, The",
+      "genre": "Indie Rock",
+      "year": 2012,
+      "track_number": 1,
+      "disc_number": 1,
+      "length_ms": 171735,
+      "media_kind": "music",
+      "data_kind": "file",
+      "path": "/home/asiate/MusicTest/The xx/Coexist/01 Angels.mp3",
+      "uri": "library:track:10749"
+    },
+    ...
+  ]
+}
+```
+
+
+### Clearing the queue
+
+Remove all items form the current queue
+
+**Endpoint**
+
+```
+PUT /api/queue/clear
+```
+
+**Response**
+
+On success returns the HTTP `204 No Content` success status response code.
+
+**Example**
+
+```
+curl -X PUT "http://localhost:3689/api/queue/clear"
+```
+
+
+### Adding items to the queue
+
+Add tracks, playlists artists or albums to the current queue
+
+**Endpoint**
+
+```
+POST /api/queue/items/add
+```
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| uris            | Comma seperated list of resource identifiers (`track`, `playlist`, `artist` or `album` object `uri`) |
+
+**Response**
+
+On success returns the HTTP `204 No Content` success status response code.
+
+**Example**
+
+```
+curl -X POST "http://localhost:3689/api/queue/items/add?uris=library:playlist:68,library:artist:2932599850102967727"
+```
+
+
+### Moving a queue item
+
+Move a queue item in the current queue
+
+**Endpoint**
+
+```
+PUT /api/queue/items/{id}
+```
+
+**Path parameters**
+
+| Parameter       | Value                |
+| --------------- | -------------------- |
+| id              | Queue item id        |
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| new_position    | The new position for the queue item in the current queue.   |
+
+**Response**
+
+On success returns the HTTP `204 No Content` success status response code.
+
+**Example**
+
+```
+curl -X PUT "http://localhost:3689/api/queue/items/3?new_position=0"
+```
+
+
+### Removing a queue item
+
+Remove a queue item from the current queue
+
+**Endpoint**
+
+```
+DELETE /api/queue/items/{id}
+```
+
+**Path parameters**
+
+| Parameter       | Value                |
+| --------------- | -------------------- |
+| id              | Queue item id        |
+
+**Response**
+
+On success returns the HTTP `204 No Content` success status response code.
+
+**Example**
+
+```
+curl -X PUT "http://localhost:3689/api/queue/items/2"
+```
+
+
+
+## Library
+
+| Method    | Endpoint                                                    | Description                          |
+| --------- | ----------------------------------------------------------- | ------------------------------------ |
+| GET       | [/api/library/playlists](#list-playlists)                   | Get a list of playlists              |
+| GET       | [/api/library/playlists/{id}/tracks](#list-playlist-tracks) | Get list of tracks for a playlist    |
+| GET       | [/api/library/artists](#list-artists)                       | Get a list of artists                |
+| GET       | [/api/library/artists/{id}/albums](#list-artist-albums)     | Get list of albums for an artist     |
+| GET       | [/api/library/albums](#list-albums)                         | Get a list of albums                 |
+| GET       | [/api/library/albums/{id}/tracks](#list-album-tracks)       | Get list of tracks for an album      |
+
+
+
+### List playlists
+
+Lists the playlists in your library
+
+**Endpoint**
+
+```
+GET /api/library/playlists
+```
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| offset          | *(Optional)* Offset of the first playlist to return         |
+| limit           | *(Optional)* Maximum number of playlists to return          |
+
+**Response**
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| items           | array    | Array of [`playlist`](#playlist-object) objects              |
+| total           | integer  | Total number of playlists in the library  |
+| offset          | integer  | Requested offset of the first playlist    |
+| limit           | integer  | Requested maximum number of playlists     |
+
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/library/playlists"
+```
+
+```
+{
+  "items": [
+    {
+      "id": 1,
+      "name": "radio",
+      "path": "/music/srv/radio.m3u",
+      "smart_playlist": false,
+      "uri": "library:playlist:1"
+    },
+    ...
+  ],
+  "total": 20,
+  "offset": 0,
+  "limit": -1
+}
+```
+
+
+### List playlist tracks
+
+Lists the tracks in a playlists
+
+**Endpoint**
+
+```
+GET /api/library/playlists/{id}/tracks
+```
+
+**Path parameters**
+
+| Parameter       | Value                |
+| --------------- | -------------------- |
+| id              | Playlist id          |
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| offset          | *(Optional)* Offset of the first track to return            |
+| limit           | *(Optional)* Maximum number of tracks to return             |
+
+**Response**
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| items           | array    | Array of [`track`](#track-object) objects |
+| total           | integer  | Total number of tracks in the playlist    |
+| offset          | integer  | Requested offset of the first track       |
+| limit           | integer  | Requested maximum number of tracks        |
+
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/library/playlists/1/tracks"
+```
+
+```
+{
+  "items": [
+    {
+      "id": 10766,
+      "title": "Solange wir tanzen",
+      "artist": "Heinrich",
+      "artist_sort": "Heinrich",
+      "album": "Solange wir tanzen",
+      "album_sort": "Solange wir tanzen",
+      "albumartist": "Heinrich",
+      "albumartist_sort": "Heinrich",
+      "genre": "Electronica",
+      "year": 2014,
+      "track_number": 1,
+      "disc_number": 1,
+      "length_ms": 223085,
+      "play_count": 2,
+      "last_time_played": "2018-02-23T10:31:20Z",
+      "media_kind": "music",
+      "data_kind": "file",
+      "path": "/music/srv/Heinrich/Solange wir tanzen/01 Solange wir tanzen.mp3",
+      "uri": "library:track:10766"
+    },
+    ...
+  ],
+  "total": 20,
+  "offset": 0,
+  "limit": -1
+}
+```
+
+
+### List artists
+
+Lists the artists in your library
+
+**Endpoint**
+
+```
+GET /api/library/artists
+```
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| offset          | *(Optional)* Offset of the first artist to return           |
+| limit           | *(Optional)* Maximum number of artists to return            |
+
+**Response**
+
+| Key             | Type     | Value                                       |
+| --------------- | -------- | ------------------------------------------- |
+| items           | array    | Array of [`artist`](#artist-object) objects |
+| total           | integer  | Total number of artists in the library      |
+| offset          | integer  | Requested offset of the first artist        |
+| limit           | integer  | Requested maximum number of artists         |
+
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/library/artists"
+```
+
+```
+{
+  "items": [
+    {
+      "id": "3815427709949443149",
+      "name": "ABAY",
+      "name_sort": "ABAY",
+      "album_count": 1,
+      "track_count": 10,
+      "length_ms": 2951554,
+      "uri": "library:artist:3815427709949443149"
+    },
+    ...
+  ],
+  "total": 20,
+  "offset": 0,
+  "limit": -1
+}
+```
+
+
+### List artist albums
+
+Lists the albums of an artist
+
+**Endpoint**
+
+```
+GET /api/library/artists/{id}/albums
+```
+
+**Path parameters**
+
+| Parameter       | Value                |
+| --------------- | -------------------- |
+| id              | Artist id            |
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| offset          | *(Optional)* Offset of the first album to return            |
+| limit           | *(Optional)* Maximum number of albums to return             |
+
+**Response**
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| items           | array    | Array of [`album`](#album-object) objects |
+| total           | integer  | Total number of albums of this artist     |
+| offset          | integer  | Requested offset of the first album       |
+| limit           | integer  | Requested maximum number of albums        |
+
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/library/artists/32561671101664759/albums"
+```
+
+```
+{
+  "items": [
+    {
+      "id": "8009851123233197743",
+      "name": "Add Violence",
+      "name_sort": "Add Violence",
+      "artist": "Nine Inch Nails",
+      "artist_id": "32561671101664759",
+      "track_count": 5,
+      "length_ms": 1634961,
+      "uri": "library:album:8009851123233197743"
+    },
+    ...
+  ],
+  "total": 20,
+  "offset": 0,
+  "limit": -1
+}
+```
+
+
+### List albums
+
+Lists the albums in your library
+
+**Endpoint**
+
+```
+GET /api/library/albums
+```
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| offset          | *(Optional)* Offset of the first album to return            |
+| limit           | *(Optional)* Maximum number of albums to return             |
+
+**Response**
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| items           | array    | Array of [`album`](#album-object) objects |
+| total           | integer  | Total number of albums in the library     |
+| offset          | integer  | Requested offset of the first albums      |
+| limit           | integer  | Requested maximum number of albums        |
+
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/library/albums"
+```
+
+```
+{
+  "items": [
+    {
+      "id": "8009851123233197743",
+      "name": "Add Violence",
+      "name_sort": "Add Violence",
+      "artist": "Nine Inch Nails",
+      "artist_id": "32561671101664759",
+      "track_count": 5,
+      "length_ms": 1634961,
+      "uri": "library:album:8009851123233197743"
+    },
+    ...
+  ],
+  "total": 20,
+  "offset": 0,
+  "limit": -1
+}
+```
+
+
+### List album tracks
+
+Lists the tracks in an album
+
+**Endpoint**
+
+```
+GET /api/library/albums/{id}/tracks
+```
+
+**Path parameters**
+
+| Parameter       | Value                |
+| --------------- | -------------------- |
+| id              | Album id             |
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| offset          | *(Optional)* Offset of the first track to return            |
+| limit           | *(Optional)* Maximum number of tracks to return             |
+
+**Response**
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| items           | array    | Array of [`track`](#track-object) objects |
+| total           | integer  | Total number of tracks                    |
+| offset          | integer  | Requested offset of the first track       |
+| limit           | integer  | Requested maximum number of tracks        |
+
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/library/albums/1/tracks"
+```
+
+```
+{
+  "items": [
+    {
+      "id": 10766,
+      "title": "Solange wir tanzen",
+      "artist": "Heinrich",
+      "artist_sort": "Heinrich",
+      "album": "Solange wir tanzen",
+      "album_sort": "Solange wir tanzen",
+      "albumartist": "Heinrich",
+      "albumartist_sort": "Heinrich",
+      "genre": "Electronica",
+      "year": 2014,
+      "track_number": 1,
+      "disc_number": 1,
+      "length_ms": 223085,
+      "play_count": 2,
+      "last_time_played": "2018-02-23T10:31:20Z",
+      "media_kind": "music",
+      "data_kind": "file",
+      "path": "/music/srv/Heinrich/Solange wir tanzen/01 Solange wir tanzen.mp3",
+      "uri": "library:track:10766"
+    },
+    ...
+  ],
+  "total": 20,
+  "offset": 0,
+  "limit": -1
+}
+```
+
+
+
+
 ## Server info
 
 | Method    | Endpoint                                         | Description                          |
@@ -525,3 +1103,94 @@ curl --include \
   ]
 }
 ```
+
+
+## Object model
+
+
+### `queue item` object
+
+| Key                | Type     | Value                                     |
+| ------------------ | -------- | ----------------------------------------- |
+| id                 | string   | Item id                                   |
+| position           | integer  | Position in the queue (starting with zero) |
+| track_id           | string   | Track id                                   |
+| title              | string   | Title                                     |
+| artist             | string   | Track artist name                         |
+| artist_sort        | string   | Track artist sort name                    |
+| album              | string   | Album name                                |
+| album_sort         | string   | Album sort name                           |
+| album_artist       | string   | Album artist name                         |
+| album_artist_sort  | string   | Album artist sort name                    |
+| genre              | string   | Genre                                     |
+| year               | integer  | Release year                              |
+| track_number       | integer  | Track number                              |
+| disc_number        | integer  | Disc number                               |
+| length_ms          | integer  | Track length in milliseconds              |
+| media_kind         | string   | Media type of this track: `music`, `movie`, `podcast`, `audiobook`, `musicvideo`, `tvshow` |
+| data_kind          | string   | Data type of this track: `file`, `url`, `spotify`, `pipe` |
+| path               | string   | Path                                      |
+| uri                | string   | Resource identifier                       |
+
+
+### `playlist` object
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| id              | string   | Playlist id                               |
+| name            | string   | Playlist name                             |
+| path            | string   | Path                                      |
+| smart_playlist  | boolean  | `true` if playlist is a smart playlist   |
+| uri             | string   | Resource identifier                       |
+
+
+### `artist` object
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| id              | string   | Artist id                                 |
+| name            | string   | Artist name                               |
+| name_sort       | string   | Artist sort name                          |
+| album_count     | integer  | Number of albums                          |
+| track_count     | integer  | Number of tracks                          |
+| length_ms       | integer  | Total length of tracks in milliseconds    |
+| uri             | string   | Resource identifier                       |
+
+
+### `album` object
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| id              | string   | Album id                                  |
+| name            | string   | Album name                                |
+| name_sort       | string   | Album sort name                           |
+| artist_id       | string   | Album artist id                           |
+| artist          | string   | Album artist name                         |
+| track_count     | integer  | Number of tracks                          |
+| length_ms       | integer  | Total length of tracks in milliseconds    |
+| uri             | string   | Resource identifier                       |
+
+
+### `track` object
+
+| Key                | Type     | Value                                     |
+| ------------------ | -------- | ----------------------------------------- |
+| id                 | string   | Track id                                  |
+| title              | string   | Title                                     |
+| artist             | string   | Track artist name                         |
+| artist_sort        | string   | Track artist sort name                    |
+| album              | string   | Album name                                |
+| album_sort         | string   | Album sort name                           |
+| album_artist       | string   | Album artist name                         |
+| album_artist_sort  | string   | Album artist sort name                    |
+| genre              | string   | Genre                                     |
+| year               | integer  | Release year                              |
+| track_number       | integer  | Track number                              |
+| disc_number        | integer  | Disc number                               |
+| length_ms          | integer  | Track length in milliseconds              |
+| play_count         | integer  | How many times the track was played       |
+| time_played        | string   | The timestamp in `ISO 8601` format      |
+| media_kind         | string   | Media type of this track: `music`, `movie`, `podcast`, `audiobook`, `musicvideo`, `tvshow` |
+| data_kind          | string   | Data type of this track: `file`, `stream`, `spotify`, `pipe` |
+| path               | string   | Path                                      |
+| uri                | string   | Resource identifier                       |

--- a/src/db.c
+++ b/src/db.c
@@ -333,6 +333,68 @@ static const struct browse_clause browse_clause[] =
     { "f.path, f.path",                        "f.path",           "f.path" },
   };
 
+
+struct media_kind_label {
+  enum media_kind type;
+  const char *label;
+};
+
+/* Keep in sync with enum media_kind */
+static const struct media_kind_label media_kind_labels[] =
+  {
+    { MEDIA_KIND_MUSIC,      "music" },
+    { MEDIA_KIND_MOVIE,      "movie" },
+    { MEDIA_KIND_PODCAST,    "podcast" },
+    { MEDIA_KIND_AUDIOBOOK,  "audiobook" },
+    { MEDIA_KIND_MUSICVIDEO, "musicvideo" },
+    { MEDIA_KIND_TVSHOW,     "tvshow" },
+  };
+
+const char *
+db_media_kind_label(enum media_kind media_kind)
+{
+  int i;
+
+  for (i = 0; i < ARRAY_SIZE(media_kind_labels); i++)
+    {
+      if (media_kind == media_kind_labels[i].type)
+	return media_kind_labels[i].label;
+    }
+
+  return NULL;
+}
+
+enum media_kind
+db_media_kind_enum(const char *label)
+{
+  int i;
+
+  if (!label)
+    return 0;
+
+  for (i = 0; i < ARRAY_SIZE(media_kind_labels); i++)
+    {
+      if (strcmp(label, media_kind_labels[i].label) == 0)
+	return media_kind_labels[i].type;
+    }
+
+  return 0;
+}
+
+/* Keep in sync with enum data_kind */
+static char *data_kind_label[] = { "file", "url", "spotify", "pipe" };
+
+const char *
+db_data_kind_label(enum data_kind data_kind)
+{
+  if (data_kind < ARRAY_SIZE(data_kind_label))
+    {
+      return data_kind_label[data_kind];
+    }
+
+  return NULL;
+}
+
 /* Shuffle RNG state */
 struct rng_ctx shuffle_rng;
 

--- a/src/db.h
+++ b/src/db.h
@@ -105,6 +105,7 @@ struct pairing_info {
   char *guid;
 };
 
+/* Keep in sync with media_kind_labels[] */
 enum media_kind {
   MEDIA_KIND_MUSIC = 1,
   MEDIA_KIND_MOVIE = 2,
@@ -114,12 +115,22 @@ enum media_kind {
   MEDIA_KIND_TVSHOW = 64,
 };
 
+const char *
+db_media_kind_label(enum media_kind media_kind);
+
+enum media_kind
+db_media_kind_enum(const char *label);
+
+/* Keep in sync with data_kind_label[] */
 enum data_kind {
   DATA_KIND_FILE = 0,    /* normal file */
   DATA_KIND_HTTP = 1,    /* network stream (radio) */
   DATA_KIND_SPOTIFY = 2, /* iTunes has no spotify data kind, but we use 2 */
   DATA_KIND_PIPE = 3,    /* iTunes has no pipe data kind, but we use 3 */
 };
+
+const char *
+db_data_kind_label(enum data_kind data_kind);
 
 /* Note that fields marked as integers in the metadata map in filescanner_ffmpeg must be uint32_t here */
 struct media_file_info {

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -743,9 +743,7 @@ httpd_gen_cb(struct evhttp_request *req, void *arg)
       output_headers = evhttp_request_get_output_headers(req);
 
       evhttp_add_header(output_headers, "Access-Control-Allow-Origin", allow_origin);
-
-      // Allow only GET method and authorization header in cross origin requests
-      evhttp_add_header(output_headers, "Access-Control-Allow-Method", "GET");
+      evhttp_add_header(output_headers, "Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
       evhttp_add_header(output_headers, "Access-Control-Allow-Headers", "authorization");
 
       // In this case there is no reason to go through httpd_send_reply

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -255,12 +255,25 @@ httpd_fixup_uri(struct evhttp_request *req)
 
 /* --------------------------- REQUEST HELPERS ------------------------------ */
 
+
+
+void
+httpd_redirect_to_admin(struct evhttp_request *req)
+{
+  struct evkeyvalq *headers;
+
+  headers = evhttp_request_get_output_headers(req);
+  evhttp_add_header(headers, "Location", "/admin.html");
+
+  httpd_send_reply(req, HTTP_MOVETEMP, "Moved", NULL, HTTPD_SEND_NO_GZIP);
+}
+
 static void
 serve_file(struct evhttp_request *req, const char *uri)
 {
   char *ext;
   char path[PATH_MAX];
-  char *deref;
+  char deref[PATH_MAX];
   char *ctype;
   struct evbuffer *evbuf;
   struct evkeyvalq *input_headers;
@@ -272,6 +285,7 @@ serve_file(struct evhttp_request *req, const char *uri)
   const char *modified_since;
   char last_modified[1000];
   struct tm *tm_modified;
+  bool slashed;
   int ret;
 
   /* Check authentication */
@@ -298,16 +312,9 @@ serve_file(struct evhttp_request *req, const char *uri)
       return;
     }
 
-  if (S_ISDIR(sb.st_mode))
+  if (S_ISLNK(sb.st_mode))
     {
-      httpd_redirect_to_index(req, uri);
-
-      return;
-    }
-  else if (S_ISLNK(sb.st_mode))
-    {
-      deref = realpath(path, NULL);
-      if (!deref)
+      if (!realpath(path, deref))
 	{
 	  DPRINTF(E_LOG, L_HTTPD, "Could not dereference %s: %s\n", path, strerror(errno));
 
@@ -322,12 +329,10 @@ serve_file(struct evhttp_request *req, const char *uri)
 
 	  httpd_send_error(req, HTTP_NOTFOUND, "Not Found");
 
-	  free(deref);
 	  return;
 	}
 
       strcpy(path, deref);
-      free(deref);
 
       ret = stat(path, &sb);
       if (ret < 0)
@@ -338,12 +343,37 @@ serve_file(struct evhttp_request *req, const char *uri)
 
 	  return;
 	}
+    }
 
-      if (S_ISDIR(sb.st_mode))
-	{
-	  httpd_redirect_to_index(req, uri);
+  if (S_ISDIR(sb.st_mode))
+    {
+      slashed = (path[strlen(path) - 1] == '/');
 
+      ret = snprintf(deref, sizeof(deref), "%s%sindex.html", path, (slashed) ? "" : "/");
+      if ((ret < 0) || (ret >= sizeof(deref)))
+        {
+	  DPRINTF(E_LOG, L_HTTPD, "Redirection URL exceeds buffer length\n");
+
+	  httpd_send_error(req, HTTP_NOTFOUND, "Not Found");
 	  return;
+	}
+
+      strcpy(path, deref);
+
+      ret = stat(path, &sb);
+      if (ret < 0)
+        {
+	  if (strcmp(uri, "/") == 0)
+	    {
+	      httpd_redirect_to_admin(req);
+	      return;
+	    }
+	  else
+	    {
+	      DPRINTF(E_LOG, L_HTTPD, "Could not stat() %s: %s\n", path, strerror(errno));
+	      httpd_send_error(req, HTTP_NOTFOUND, "Not Found");
+	      return;
+	    }
 	}
     }
 
@@ -732,10 +762,15 @@ httpd_gen_cb(struct evhttp_request *req, void *arg)
     }
 
   parsed = httpd_uri_parse(uri);
-  if (!parsed || !parsed->path || (strcmp(parsed->path, "/") == 0))
+  if (!parsed || !parsed->path)
     {
       httpd_redirect_to_admin(req);
       goto out;
+    }
+
+  if (strcmp(parsed->path, "/") == 0)
+    {
+      goto serve_file;
     }
 
   /* Dispatch protocol-specific handlers */
@@ -773,6 +808,7 @@ httpd_gen_cb(struct evhttp_request *req, void *arg)
   DPRINTF(E_DBG, L_HTTPD, "HTTP request: '%s'\n", parsed->uri);
 
   /* Serve web interface files */
+ serve_file:
   serve_file(req, parsed->path);
 
  out:
@@ -1377,42 +1413,6 @@ httpd_send_error(struct evhttp_request* req, int error, const char* reason)
 
   if (evbuf)
     evbuffer_free(evbuf);
-}
-
-void
-httpd_redirect_to_admin(struct evhttp_request *req)
-{
-  struct evkeyvalq *headers;
-
-  headers = evhttp_request_get_output_headers(req);
-  evhttp_add_header(headers, "Location", "/admin.html");
-
-  httpd_send_reply(req, HTTP_MOVETEMP, "Moved", NULL, HTTPD_SEND_NO_GZIP);
-}
-
-void
-httpd_redirect_to_index(struct evhttp_request *req, const char *uri)
-{
-  struct evkeyvalq *headers;
-  char buf[256];
-  int slashed;
-  int ret;
-
-  slashed = (uri[strlen(uri) - 1] == '/');
-
-  ret = snprintf(buf, sizeof(buf), "%s%sindex.html", uri, (slashed) ? "" : "/");
-  if ((ret < 0) || (ret >= sizeof(buf)))
-    {
-      DPRINTF(E_LOG, L_HTTPD, "Redirection URL exceeds buffer length\n");
-
-      httpd_send_error(req, HTTP_NOTFOUND, "Not Found");
-      return;
-    }
-
-  headers = evhttp_request_get_output_headers(req);
-  evhttp_add_header(headers, "Location", buf);
-
-  httpd_send_reply(req, HTTP_MOVETEMP, "Moved", NULL, HTTPD_SEND_NO_GZIP);
 }
 
 bool

--- a/src/httpd.h
+++ b/src/httpd.h
@@ -145,11 +145,6 @@ httpd_send_error(struct evhttp_request *req, int error, const char *reason);
 void
 httpd_redirect_to_admin(struct evhttp_request *req);
 
-/*
- * Redirects to [uri]/index.html
- */
-void
-httpd_redirect_to_index(struct evhttp_request *req, const char *uri);
 
 bool
 httpd_admin_check_auth(struct evhttp_request *req);

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -33,6 +33,7 @@
 #include <regex.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "httpd_jsonapi.h"
 #include "conffile.h"
@@ -54,81 +55,340 @@
 
 /* -------------------------------- HELPERS --------------------------------- */
 
-/*
- * Kicks off pairing of a daap/dacp client
- *
- * Expects the paring pin to be present in the post request body, e. g.:
- *
- * {
- *   "pin": "1234"
- * }
- */
-static int
-jsonapi_reply_pairing_kickoff(struct httpd_request *hreq)
+static inline void
+safe_json_add_string(json_object *obj, const char *key, const char *value)
 {
-  struct evbuffer *evbuf;
-  json_object* request;
-  const char* message;
-
-  evbuf = evhttp_request_get_input_buffer(hreq->req);
-  request = jparse_obj_from_evbuffer(evbuf);
-  if (!request)
-    {
-      DPRINTF(E_LOG, L_WEB, "Failed to parse incoming request\n");
-      return HTTP_BADREQUEST;
-    }
-
-  DPRINTF(E_DBG, L_WEB, "Received pairing post request: %s\n", json_object_to_json_string(request));
-
-  message = jparse_str_from_obj(request, "pin");
-  if (message)
-    remote_pairing_kickoff((char **)&message);
-  else
-    DPRINTF(E_LOG, L_WEB, "Missing pin in request body: %s\n", json_object_to_json_string(request));
-
-  jparse_free(request);
-
-  return HTTP_NOCONTENT;
+  if (value)
+    json_object_object_add(obj, key, json_object_new_string(value));
 }
 
-/*
- * Retrieves pairing information
- *
- * Example response:
- *
- * {
- *  "active": true,
- *  "remote": "remote name"
- * }
- */
-static int
-jsonapi_reply_pairing_get(struct httpd_request *hreq)
+static inline void
+safe_json_add_int_from_string(json_object *obj, const char *key, const char *value)
 {
-  char *remote_name;
-  json_object *jreply;
+  int intval;
+  int ret;
 
-  remote_name = remote_pairing_get_name();
+  if (!value)
+    return;
 
-  CHECK_NULL(L_WEB, jreply = json_object_new_object());
-
-  if (remote_name)
-    {
-      json_object_object_add(jreply, "active", json_object_new_boolean(true));
-      json_object_object_add(jreply, "remote", json_object_new_string(remote_name));
-    }
-  else
-    {
-      json_object_object_add(jreply, "active", json_object_new_boolean(false));
-    }
-
-  CHECK_ERRNO(L_WEB, evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(jreply)));
-
-  jparse_free(jreply);
-  free(remote_name);
-
-  return HTTP_OK;
+  ret = safe_atoi32(value, &intval);
+  if (ret == 0)
+    json_object_object_add(obj, key, json_object_new_int(intval));
 }
 
+static inline void
+safe_json_add_time_from_string(json_object *obj, const char *key, const char *value)
+{
+  uint32_t tmp;
+  time_t timestamp;
+  struct tm tm;
+  char result[32];
+
+  if (!value)
+    return;
+
+  if (safe_atou32(value, &tmp) != 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "Error converting timestamp to uint32_t: %s\n", value);
+      return;
+    }
+
+  if (!tmp)
+    return;
+
+  timestamp = tmp;
+  if (gmtime_r(&timestamp, &tm) == NULL)
+    {
+      DPRINTF(E_LOG, L_WEB, "Error converting timestamp to gmtime: %s\n", value);
+      return;
+    }
+
+  strftime(result, sizeof(result), "%FT%TZ", &tm);
+
+  json_object_object_add(obj, key, json_object_new_string(result));
+}
+
+static json_object *
+artist_to_json(struct db_group_info *dbgri)
+{
+  json_object *item;
+  char uri[100];
+  int ret;
+
+  item = json_object_new_object();
+
+  safe_json_add_string(item, "id", dbgri->persistentid);
+  safe_json_add_string(item, "name", dbgri->itemname);
+  safe_json_add_string(item, "name_sort", dbgri->itemname_sort);
+  safe_json_add_int_from_string(item, "album_count", dbgri->groupalbumcount);
+  safe_json_add_int_from_string(item, "track_count", dbgri->itemcount);
+  safe_json_add_int_from_string(item, "length_ms", dbgri->song_length);
+
+  ret = snprintf(uri, sizeof(uri), "%s:%s:%s", "library", "artist", dbgri->persistentid);
+  if (ret < sizeof(uri))
+    json_object_object_add(item, "uri", json_object_new_string(uri));
+
+  return item;
+}
+
+static json_object *
+album_to_json(struct db_group_info *dbgri)
+{
+  json_object *item;
+  char uri[100];
+  int ret;
+
+  item = json_object_new_object();
+
+  safe_json_add_string(item, "id", dbgri->persistentid);
+  safe_json_add_string(item, "name", dbgri->itemname);
+  safe_json_add_string(item, "name_sort", dbgri->itemname_sort);
+  safe_json_add_string(item, "artist", dbgri->songalbumartist);
+  safe_json_add_string(item, "artist_id", dbgri->songartistid);
+  safe_json_add_int_from_string(item, "track_count", dbgri->itemcount);
+  safe_json_add_int_from_string(item, "length_ms", dbgri->song_length);
+
+  ret = snprintf(uri, sizeof(uri), "%s:%s:%s", "library", "album", dbgri->persistentid);
+  if (ret < sizeof(uri))
+    json_object_object_add(item, "uri", json_object_new_string(uri));
+
+  return item;
+}
+
+static json_object *
+track_to_json(struct db_media_file_info *dbmfi)
+{
+  json_object *item;
+  char uri[100];
+  int intval;
+  int ret;
+
+  item = json_object_new_object();
+
+  safe_json_add_int_from_string(item, "id", dbmfi->id);
+  safe_json_add_string(item, "title", dbmfi->title);
+  safe_json_add_string(item, "artist", dbmfi->artist);
+  safe_json_add_string(item, "artist_sort", dbmfi->artist_sort);
+  safe_json_add_string(item, "album", dbmfi->album);
+  safe_json_add_string(item, "album_sort", dbmfi->album_sort);
+  safe_json_add_string(item, "album_artist", dbmfi->album_artist);
+  safe_json_add_string(item, "album_artist_sort", dbmfi->album_artist_sort);
+  safe_json_add_string(item, "genre", dbmfi->genre);
+  safe_json_add_int_from_string(item, "year", dbmfi->year);
+  safe_json_add_int_from_string(item, "track_number", dbmfi->track);
+  safe_json_add_int_from_string(item, "disc_number", dbmfi->disc);
+  safe_json_add_int_from_string(item, "length_ms", dbmfi->song_length);
+
+  safe_json_add_int_from_string(item, "play_count", dbmfi->play_count);
+  safe_json_add_time_from_string(item, "time_played", dbmfi->time_played);
+
+  ret = safe_atoi32(dbmfi->media_kind, &intval);
+  if (ret == 0)
+    safe_json_add_string(item, "media_kind", db_media_kind_label(intval));
+
+  ret = safe_atoi32(dbmfi->data_kind, &intval);
+  if (ret == 0)
+    safe_json_add_string(item, "data_kind", db_data_kind_label(intval));
+
+  safe_json_add_string(item, "path", dbmfi->path);
+
+  ret = snprintf(uri, sizeof(uri), "%s:%s:%s", "library", "track", dbmfi->id);
+  if (ret < sizeof(uri))
+    json_object_object_add(item, "uri", json_object_new_string(uri));
+
+  return item;
+}
+
+static json_object *
+playlist_to_json(struct db_playlist_info *dbpli)
+{
+  json_object *item;
+  char uri[100];
+  int intval;
+  int ret;
+
+  item = json_object_new_object();
+
+  safe_json_add_int_from_string(item, "id", dbpli->id);
+  safe_json_add_string(item, "name", dbpli->title);
+  safe_json_add_string(item, "path", dbpli->path);
+  ret = safe_atoi32(dbpli->type, &intval);
+  if (ret == 0)
+    json_object_object_add(item, "smart_playlist", json_object_new_boolean(intval == PL_SMART));
+
+  ret = snprintf(uri, sizeof(uri), "%s:%s:%s", "library", "playlist", dbpli->id);
+  if (ret < sizeof(uri))
+    json_object_object_add(item, "uri", json_object_new_string(uri));
+
+  return item;
+}
+
+static int
+fetch_tracks(struct query_params *query_params, json_object *items, int *total)
+{
+  struct db_media_file_info dbmfi;
+  json_object *item;
+  int ret = 0;
+
+  ret = db_query_start(query_params);
+  if (ret < 0)
+    goto error;
+
+  while (((ret = db_query_fetch_file(query_params, &dbmfi)) == 0) && (dbmfi.id))
+    {
+      item = track_to_json(&dbmfi);
+      if (!item)
+	{
+	  ret = -1;
+	  goto error;
+	}
+
+      json_object_array_add(items, item);
+    }
+
+  if (total)
+    *total = query_params->results;
+
+ error:
+  db_query_end(query_params);
+
+  return ret;
+}
+
+static int
+fetch_artists(struct query_params *query_params, json_object *items, int *total)
+{
+  struct db_group_info dbgri;
+  json_object *item;
+  int ret = 0;
+
+  ret = db_query_start(query_params);
+  if (ret < 0)
+    goto error;
+
+  while ((ret = db_query_fetch_group(query_params, &dbgri)) == 0)
+    {
+      /* Don't add item if no name (eg blank album name) */
+      if (strlen(dbgri.itemname) == 0)
+	continue;
+
+      item = artist_to_json(&dbgri);
+      if (!item)
+	{
+	  ret = -1;
+	  goto error;
+	}
+
+      json_object_array_add(items, item);
+    }
+
+  if (total)
+    *total = query_params->results;
+
+ error:
+  db_query_end(query_params);
+
+  return ret;
+}
+
+static int
+fetch_albums(struct query_params *query_params, json_object *items, int *total)
+{
+  struct db_group_info dbgri;
+  json_object *item;
+  int ret = 0;
+
+  ret = db_query_start(query_params);
+  if (ret < 0)
+    goto error;
+
+  while ((ret = db_query_fetch_group(query_params, &dbgri)) == 0)
+    {
+      /* Don't add item if no name (eg blank album name) */
+      if (strlen(dbgri.itemname) == 0)
+	continue;
+
+      item = album_to_json(&dbgri);
+      if (!item)
+	{
+	  ret = -1;
+	  goto error;
+	}
+
+      json_object_array_add(items, item);
+    }
+
+  if (total)
+    *total = query_params->results;
+
+ error:
+  db_query_end(query_params);
+
+  return ret;
+}
+
+static int
+fetch_playlists(struct query_params *query_params, json_object *items, int *total)
+{
+  struct db_playlist_info dbpli;
+  json_object *item;
+  int ret = 0;
+
+  ret = db_query_start(query_params);
+  if (ret < 0)
+    goto error;
+
+  while (((ret = db_query_fetch_pl(query_params, &dbpli, 0)) == 0) && (dbpli.id))
+    {
+      item = playlist_to_json(&dbpli);
+      if (!item)
+	{
+	  ret = -1;
+	  goto error;
+	}
+
+      json_object_array_add(items, item);
+    }
+
+  if (total)
+    *total = query_params->results;
+
+ error:
+  db_query_end(query_params);
+
+  return ret;
+}
+
+static int
+query_params_limit_set(struct query_params *query_params, struct httpd_request *hreq)
+{
+  const char *param;
+
+  query_params->idx_type = I_NONE;
+  query_params->limit = -1;
+  query_params->offset = 0;
+
+  param = evhttp_find_header(hreq->query, "limit");
+  if (param)
+    {
+      query_params->idx_type = I_SUB;
+
+      if (safe_atoi32(param, &query_params->limit) < 0)
+        {
+	  DPRINTF(E_LOG, L_WEB, "Invalid value for query parameter 'limit' (%s)\n", param);
+	  return -1;
+	}
+
+      param = evhttp_find_header(hreq->query, "offset");
+      if (param && safe_atoi32(param, &query_params->offset) < 0)
+        {
+	  DPRINTF(E_LOG, L_WEB, "Invalid value for query parameter 'offset' (%s)\n", param);
+	  return -1;
+	}
+    }
+
+  return 0;
+}
 
 /* --------------------------- REPLY HANDLERS ------------------------------- */
 
@@ -152,6 +412,12 @@ jsonapi_reply_config(struct httpd_request *hreq)
   int i;
 
   CHECK_NULL(L_WEB, jreply = json_object_new_object());
+
+  // library name
+  json_object_object_add(jreply, "library_name", json_object_new_string(cfg_getstr(cfg_getsec(cfg, "library"), "name")));
+
+  // hide singles
+  json_object_object_add(jreply, "hide_singles", json_object_new_boolean(cfg_getbool(cfg_getsec(cfg, "library"), "hide_singles")));
 
   // Websocket port
 #ifdef HAVE_LIBWEBSOCKETS
@@ -477,6 +743,81 @@ jsonapi_reply_lastfm_logout(struct httpd_request *hreq)
   return HTTP_NOCONTENT;
 }
 
+/*
+ * Kicks off pairing of a daap/dacp client
+ *
+ * Expects the paring pin to be present in the post request body, e. g.:
+ *
+ * {
+ *   "pin": "1234"
+ * }
+ */
+static int
+jsonapi_reply_pairing_kickoff(struct httpd_request *hreq)
+{
+  struct evbuffer *evbuf;
+  json_object* request;
+  const char* message;
+
+  evbuf = evhttp_request_get_input_buffer(hreq->req);
+  request = jparse_obj_from_evbuffer(evbuf);
+  if (!request)
+    {
+      DPRINTF(E_LOG, L_WEB, "Failed to parse incoming request\n");
+      return HTTP_BADREQUEST;
+    }
+
+  DPRINTF(E_DBG, L_WEB, "Received pairing post request: %s\n", json_object_to_json_string(request));
+
+  message = jparse_str_from_obj(request, "pin");
+  if (message)
+    remote_pairing_kickoff((char **)&message);
+  else
+    DPRINTF(E_LOG, L_WEB, "Missing pin in request body: %s\n", json_object_to_json_string(request));
+
+  jparse_free(request);
+
+  return HTTP_NOCONTENT;
+}
+
+/*
+ * Retrieves pairing information
+ *
+ * Example response:
+ *
+ * {
+ *  "active": true,
+ *  "remote": "remote name"
+ * }
+ */
+static int
+jsonapi_reply_pairing_get(struct httpd_request *hreq)
+{
+  char *remote_name;
+  json_object *jreply;
+
+  remote_name = remote_pairing_get_name();
+
+  CHECK_NULL(L_WEB, jreply = json_object_new_object());
+
+  if (remote_name)
+    {
+      json_object_object_add(jreply, "active", json_object_new_boolean(true));
+      json_object_object_add(jreply, "remote", json_object_new_string(remote_name));
+    }
+  else
+    {
+      json_object_object_add(jreply, "active", json_object_new_boolean(false));
+    }
+
+  CHECK_ERRNO(L_WEB, evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(jreply)));
+
+  jparse_free(jreply);
+  free(remote_name);
+
+  return HTTP_OK;
+}
+
 struct outputs_param
 {
   json_object *output;
@@ -724,9 +1065,79 @@ jsonapi_reply_outputs_set(struct httpd_request *hreq)
 }
 
 static int
+play_item_with_id(const char *param)
+{
+  uint32_t item_id;
+  struct db_queue_item *queue_item;
+  int ret;
+
+  ret = safe_atou32(param, &item_id);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "No valid item id given '%s'\n", param);
+
+      return HTTP_BADREQUEST;
+    }
+
+  queue_item = db_queue_fetch_byitemid(item_id);
+  if (!queue_item)
+    {
+      DPRINTF(E_LOG, L_WEB, "No queue item with item id '%d'\n", item_id);
+
+      return HTTP_BADREQUEST;
+    }
+
+  player_playback_stop();
+  ret = player_playback_start_byitem(queue_item);
+  free_queue_item(queue_item, 0);
+
+  return HTTP_NOCONTENT;
+}
+
+static int
+play_item_at_position(const char *param)
+{
+  uint32_t position;
+  struct db_queue_item *queue_item;
+  int ret;
+
+  ret = safe_atou32(param, &position);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "No valid position given '%s'\n", param);
+
+      return HTTP_BADREQUEST;
+    }
+
+  queue_item = db_queue_fetch_bypos(position, 0);
+  if (!queue_item)
+    {
+      DPRINTF(E_LOG, L_WEB, "No queue item at position '%d'\n", position);
+
+      return HTTP_BADREQUEST;
+    }
+
+  player_playback_stop();
+  ret = player_playback_start_byitem(queue_item);
+  free_queue_item(queue_item, 0);
+
+  return HTTP_NOCONTENT;
+}
+
+static int
 jsonapi_reply_player_play(struct httpd_request *hreq)
 {
+  const char *param;
   int ret;
+
+  if ((param = evhttp_find_header(hreq->query, "item_id")))
+    {
+      return play_item_with_id(param);
+    }
+  else if ((param = evhttp_find_header(hreq->query, "position")))
+    {
+      return play_item_at_position(param);
+    }
 
   ret = player_playback_start();
   if (ret < 0)
@@ -816,6 +1227,7 @@ static int
 jsonapi_reply_player(struct httpd_request *hreq)
 {
   struct player_status status;
+  struct db_queue_item *queue_item;
   json_object *reply;
 
   player_get_status(&status);
@@ -856,9 +1268,30 @@ jsonapi_reply_player(struct httpd_request *hreq)
   json_object_object_add(reply, "shuffle", json_object_new_boolean(status.shuffle));
   json_object_object_add(reply, "volume", json_object_new_int(status.volume));
 
-  json_object_object_add(reply, "item_id", json_object_new_int(status.item_id));
-  json_object_object_add(reply, "item_length_ms", json_object_new_int(status.len_ms));
-  json_object_object_add(reply, "item_progress_ms", json_object_new_int(status.pos_ms));
+  if (status.item_id)
+    {
+      json_object_object_add(reply, "item_id", json_object_new_int(status.item_id));
+      json_object_object_add(reply, "item_length_ms", json_object_new_int(status.len_ms));
+      json_object_object_add(reply, "item_progress_ms", json_object_new_int(status.pos_ms));
+    }
+  else
+    {
+      queue_item = db_queue_fetch_bypos(0, status.shuffle);
+
+      if (queue_item)
+	{
+	  json_object_object_add(reply, "item_id", json_object_new_int(queue_item->id));
+	  json_object_object_add(reply, "item_length_ms", json_object_new_int(queue_item->song_length));
+	  json_object_object_add(reply, "item_progress_ms", json_object_new_int(0));
+	  free_queue_item(queue_item, 0);
+	}
+      else
+	{
+	  json_object_object_add(reply, "item_id", json_object_new_int(0));
+	  json_object_object_add(reply, "item_length_ms", json_object_new_int(0));
+	  json_object_object_add(reply, "item_progress_ms", json_object_new_int(0));
+	}
+    }
 
   CHECK_ERRNO(L_WEB, evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply)));
 
@@ -868,32 +1301,276 @@ jsonapi_reply_player(struct httpd_request *hreq)
 }
 
 static json_object *
-queue_item_to_json(struct db_queue_item *queue_item)
+queue_item_to_json(struct db_queue_item *queue_item, char shuffle)
 {
   json_object *item;
+  char uri[100];
+  int ret;
 
   item = json_object_new_object();
 
   json_object_object_add(item, "id", json_object_new_int(queue_item->id));
-  json_object_object_add(item, "position", json_object_new_int(queue_item->pos));
-  json_object_object_add(item, "shuffle_position", json_object_new_int(queue_item->shuffle_pos));
+  if (shuffle)
+    json_object_object_add(item, "position", json_object_new_int(queue_item->shuffle_pos));
+  else
+    json_object_object_add(item, "position", json_object_new_int(queue_item->pos));
 
-  json_object_object_add(item, "file_id", json_object_new_int(queue_item->file_id));
-  json_object_object_add(item, "path", json_object_new_string(queue_item->path));
-  json_object_object_add(item, "virtual_path", json_object_new_string(queue_item->virtual_path));
+  json_object_object_add(item, "track_id", json_object_new_int(queue_item->file_id));
 
-  json_object_object_add(item, "title", json_object_new_string(queue_item->title));
-  json_object_object_add(item, "artist", json_object_new_string(queue_item->artist));
-  json_object_object_add(item, "albumartist", json_object_new_string(queue_item->album_artist));
-  json_object_object_add(item, "album", json_object_new_string(queue_item->album));
-  json_object_object_add(item, "genre", json_object_new_string(queue_item->genre));
-  json_object_object_add(item, "artist_sort", json_object_new_string(queue_item->artist_sort));
-  json_object_object_add(item, "albumartist_sort", json_object_new_string(queue_item->album_artist_sort));
-  json_object_object_add(item, "album_sort", json_object_new_string(queue_item->album_sort));
+  safe_json_add_string(item, "title", queue_item->title);
+  safe_json_add_string(item, "artist", queue_item->artist);
+  safe_json_add_string(item, "artist_sort", queue_item->artist_sort);
+  safe_json_add_string(item, "album", queue_item->album);
+  safe_json_add_string(item, "album_sort", queue_item->album_sort);
+  safe_json_add_string(item, "album_artist", queue_item->album_artist);
+  safe_json_add_string(item, "album_artist_sort", queue_item->album_artist_sort);
+  safe_json_add_string(item, "genre", queue_item->genre);
+
   json_object_object_add(item, "year", json_object_new_int(queue_item->year));
+  json_object_object_add(item, "track_number", json_object_new_int(queue_item->track));
+  json_object_object_add(item, "disc_number", json_object_new_int(queue_item->disc));
   json_object_object_add(item, "length_ms", json_object_new_int(queue_item->song_length));
 
+  safe_json_add_string(item, "media_kind", db_media_kind_label(queue_item->media_kind));
+  safe_json_add_string(item, "data_kind", db_data_kind_label(queue_item->data_kind));
+
+  safe_json_add_string(item, "path", queue_item->path);
+
+  if (queue_item->file_id > 0)
+    {
+      ret = snprintf(uri, sizeof(uri), "%s:%s:%d", "library", "track", queue_item->file_id);
+      if (ret < sizeof(uri))
+	json_object_object_add(item, "uri", json_object_new_string(uri));
+    }
+  else
+    {
+      safe_json_add_string(item, "uri", queue_item->path);
+    }
+
   return item;
+}
+
+static int
+queue_tracks_add_artist(const char *id)
+{
+  struct query_params query_params;
+  struct player_status status;
+  int ret = 0;
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  query_params.type = Q_ITEMS;
+  query_params.sort = S_ALBUM;
+  query_params.idx_type = I_NONE;
+  query_params.filter = db_mprintf("(f.songartistid = %q)", id);
+
+  player_get_status(&status);
+
+  ret = db_queue_add_by_query(&query_params, status.shuffle, status.item_id);
+
+  free(query_params.filter);
+
+  return ret;
+}
+
+static int
+queue_tracks_add_album(const char *id)
+{
+  struct query_params query_params;
+  struct player_status status;
+  int ret = 0;
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  query_params.type = Q_ITEMS;
+  query_params.sort = S_ALBUM;
+  query_params.idx_type = I_NONE;
+  query_params.filter = db_mprintf("(f.songalbumid = %q)", id);
+
+  player_get_status(&status);
+
+  ret = db_queue_add_by_query(&query_params, status.shuffle, status.item_id);
+
+  free(query_params.filter);
+
+  return ret;
+}
+
+static int
+queue_tracks_add_track(const char *id)
+{
+  struct query_params query_params;
+  struct player_status status;
+  int ret = 0;
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  query_params.type = Q_ITEMS;
+  query_params.sort = S_ALBUM;
+  query_params.idx_type = I_NONE;
+  query_params.filter = db_mprintf("(f.id = %q)", id);
+
+  player_get_status(&status);
+
+  ret = db_queue_add_by_query(&query_params, status.shuffle, status.item_id);
+
+  free(query_params.filter);
+
+  return ret;
+}
+
+static int
+queue_tracks_add_playlist(const char *id)
+{
+  struct player_status status;
+  int playlist_id;
+  int ret;
+
+  ret = safe_atoi32(id, &playlist_id);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "No valid playlist id given '%s'\n", id);
+
+      return HTTP_BADREQUEST;
+    }
+
+  player_get_status(&status);
+
+  ret = db_queue_add_by_playlistid(playlist_id, status.shuffle, status.item_id);
+
+  return ret;
+}
+
+static int
+jsonapi_reply_queue_tracks_add(struct httpd_request *hreq)
+{
+  const char *param;
+  char *uris;
+  char *uri;
+  const char *id;
+  int ret = 0;
+
+  param = evhttp_find_header(hreq->query, "uris");
+  if (!param)
+    {
+      DPRINTF(E_LOG, L_WEB, "Missing query parameter 'uris'\n");
+
+      return HTTP_BADREQUEST;
+    }
+
+  uris = strdup(param);
+  uri = strtok(uris, ",");
+
+  do
+    {
+      if (strncmp(uri, "library:artist:", strlen("library:artist:")) == 0)
+	{
+	  id = uri + (strlen("library:artist:"));
+	  queue_tracks_add_artist(id);
+	}
+      else if (strncmp(uri, "library:album:", strlen("library:album:")) == 0)
+	{
+	  id = uri + (strlen("library:album:"));
+	  queue_tracks_add_album(id);
+	}
+      else if (strncmp(uri, "library:track:", strlen("library:track:")) == 0)
+	{
+	  id = uri + (strlen("library:track:"));
+	  queue_tracks_add_track(id);
+	}
+      else if (strncmp(uri, "library:playlist:", strlen("library:playlist:")) == 0)
+	{
+	  id = uri + (strlen("library:playlist:"));
+	  queue_tracks_add_playlist(id);
+	}
+      else
+	{
+	  DPRINTF(E_LOG, L_WEB, "Invalid uri '%s'\n", uri);
+	}
+    }
+  while ((uri = strtok(NULL, ",")));
+
+  free(uris);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_NOCONTENT;
+}
+
+static int
+jsonapi_reply_queue_tracks_move(struct httpd_request *hreq)
+{
+  uint32_t item_id;
+  uint32_t new_position;
+  const char *param;
+  struct player_status status;
+  int ret;
+
+  ret = safe_atou32(hreq->uri_parsed->path_parts[3], &item_id);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "No valid item id given '%s'\n", hreq->uri_parsed->path);
+
+      return HTTP_BADREQUEST;
+    }
+
+  param = evhttp_find_header(hreq->query, "new_position");
+  if (!param)
+    {
+      DPRINTF(E_LOG, L_WEB, "Missing parameter 'new_position'\n");
+
+      return HTTP_BADREQUEST;
+    }
+  if (safe_atou32(param, &new_position) < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "No valid item new_position '%s'\n", param);
+
+      return HTTP_BADREQUEST;
+    }
+
+  player_get_status(&status);
+  ret = db_queue_move_byitemid(item_id, new_position, status.shuffle);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "Moving item '%d' to new position %d failed\n", item_id, new_position);
+
+      return HTTP_INTERNAL;
+    }
+
+  return HTTP_NOCONTENT;
+}
+
+static int
+jsonapi_reply_queue_tracks_delete(struct httpd_request *hreq)
+{
+  uint32_t item_id;
+  int ret;
+
+  ret = safe_atou32(hreq->uri_parsed->path_parts[3], &item_id);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "No valid item id given '%s'\n", hreq->uri_parsed->path);
+
+      return HTTP_BADREQUEST;
+    }
+
+  ret = db_queue_delete_byitemid(item_id);
+  if (ret < 0)
+    {
+      return HTTP_INTERNAL;
+    }
+
+  return HTTP_NOCONTENT;
+}
+
+static int
+jsonapi_reply_queue_clear(struct httpd_request *hreq)
+{
+  player_playback_stop();
+  db_queue_clear(0);
+
+  return HTTP_NOCONTENT;
 }
 
 static int
@@ -905,6 +1582,7 @@ jsonapi_reply_queue(struct httpd_request *hreq)
   int start_pos, end_pos;
   int version;
   int count;
+  struct player_status status;
   struct db_queue_item queue_item;
   json_object *reply;
   json_object *items;
@@ -923,11 +1601,9 @@ jsonapi_reply_queue(struct httpd_request *hreq)
   items = json_object_new_array();
   json_object_object_add(reply, "items", items);
 
-  param = evhttp_find_header(hreq->query, "sort");
-  if (param && strcmp(param, "shuffle") == 0)
-    {
-      query_params.sort = S_SHUFFLE_POS;
-    }
+  player_get_status(&status);
+  if (status.shuffle)
+    query_params.sort = S_SHUFFLE_POS;
 
   param = evhttp_find_header(hreq->query, "id");
   if (param && safe_atou32(param, &item_id) == 0)
@@ -958,7 +1634,7 @@ jsonapi_reply_queue(struct httpd_request *hreq)
 
   while ((ret = db_queue_enum_fetch(&query_params, &queue_item)) == 0 && queue_item.id > 0)
     {
-      item = queue_item_to_json(&queue_item);
+      item = queue_item_to_json(&queue_item, status.shuffle);
       if (!item)
 	goto error;
 
@@ -1077,38 +1753,503 @@ jsonapi_reply_player_volume(struct httpd_request *hreq)
   return HTTP_NOCONTENT;
 }
 
+static int
+jsonapi_reply_library_artists(struct httpd_request *hreq)
+{
+  struct query_params query_params;
+  const char *param;
+  enum media_kind media_kind;
+  json_object *reply;
+  json_object *items;
+  int total;
+  int ret = 0;
+
+  media_kind = 0;
+  param = evhttp_find_header(hreq->query, "media_kind");
+  if (param)
+    {
+      media_kind = db_media_kind_enum(param);
+      if (!media_kind)
+	{
+	  DPRINTF(E_LOG, L_WEB, "Invalid media kind '%s'\n", param);
+	  return HTTP_BADREQUEST;
+	}
+    }
+
+  reply = json_object_new_object();
+  items = json_object_new_array();
+  json_object_object_add(reply, "items", items);
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  ret = query_params_limit_set(&query_params, hreq);
+  if (ret < 0)
+    goto error;
+
+  query_params.type = Q_GROUP_ARTISTS;
+  query_params.sort = S_ARTIST;
+
+  if (media_kind)
+    query_params.filter = db_mprintf("(f.media_kind = %d)", media_kind);
+
+  ret = fetch_artists(&query_params, items, &total);
+  if (ret < 0)
+    goto error;
+
+  json_object_object_add(reply, "total", json_object_new_int(total));
+  json_object_object_add(reply, "offset", json_object_new_int(query_params.offset));
+  json_object_object_add(reply, "limit", json_object_new_int(query_params.limit));
+
+  ret = evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply));
+  if (ret < 0)
+    DPRINTF(E_LOG, L_WEB, "browse: Couldn't add artists to response buffer.\n");
+
+ error:
+  jparse_free(reply);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_OK;
+}
+
+static int
+jsonapi_reply_library_artist_albums(struct httpd_request *hreq)
+{
+  struct query_params query_params;
+  const char *artist_id;
+  json_object *reply;
+  json_object *items;
+  int total;
+  int ret = 0;
+
+  artist_id = hreq->uri_parsed->path_parts[3];
+
+  reply = json_object_new_object();
+  items = json_object_new_array();
+  json_object_object_add(reply, "items", items);
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  ret = query_params_limit_set(&query_params, hreq);
+  if (ret < 0)
+    goto error;
+
+  query_params.type = Q_GROUP_ALBUMS;
+  query_params.sort = S_ALBUM;
+  query_params.filter = db_mprintf("(f.songartistid = %q)", artist_id);
+
+  ret = fetch_albums(&query_params, items, &total);
+  free(query_params.filter);
+
+  if (ret < 0)
+    goto error;
+
+  json_object_object_add(reply, "total", json_object_new_int(total));
+  json_object_object_add(reply, "offset", json_object_new_int(query_params.offset));
+  json_object_object_add(reply, "limit", json_object_new_int(query_params.limit));
+
+  ret = evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply));
+  if (ret < 0)
+    DPRINTF(E_LOG, L_WEB, "browse: Couldn't add albums to response buffer.\n");
+
+ error:
+  jparse_free(reply);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_OK;
+}
+
+static int
+jsonapi_reply_library_albums(struct httpd_request *hreq)
+{
+  struct query_params query_params;
+  const char *param;
+  enum media_kind media_kind;
+  json_object *reply;
+  json_object *items;
+  int total;
+  int ret = 0;
+
+  media_kind = 0;
+  param = evhttp_find_header(hreq->query, "media_kind");
+  if (param)
+    {
+      media_kind = db_media_kind_enum(param);
+      if (!media_kind)
+	{
+	  DPRINTF(E_LOG, L_WEB, "Invalid media kind '%s'\n", param);
+	  return HTTP_BADREQUEST;
+	}
+    }
+
+  reply = json_object_new_object();
+  items = json_object_new_array();
+  json_object_object_add(reply, "items", items);
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  ret = query_params_limit_set(&query_params, hreq);
+  if (ret < 0)
+    goto error;
+
+  query_params.type = Q_GROUP_ALBUMS;
+  query_params.sort = S_ALBUM;
+
+  if (media_kind)
+    query_params.filter = db_mprintf("(f.media_kind = %d)", media_kind);
+
+  ret = fetch_albums(&query_params, items, &total);
+  if (ret < 0)
+    goto error;
+
+  json_object_object_add(reply, "total", json_object_new_int(total));
+  json_object_object_add(reply, "offset", json_object_new_int(query_params.offset));
+  json_object_object_add(reply, "limit", json_object_new_int(query_params.limit));
+
+  ret = evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply));
+  if (ret < 0)
+    DPRINTF(E_LOG, L_WEB, "browse: Couldn't add albums to response buffer.\n");
+
+ error:
+  jparse_free(reply);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_OK;
+}
+
+static int
+jsonapi_reply_library_album_tracks(struct httpd_request *hreq)
+{
+  struct query_params query_params;
+  const char *album_id;
+  json_object *reply;
+  json_object *items;
+  int total;
+  int ret = 0;
+
+  album_id = hreq->uri_parsed->path_parts[3];
+
+  reply = json_object_new_object();
+  items = json_object_new_array();
+  json_object_object_add(reply, "items", items);
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  ret = query_params_limit_set(&query_params, hreq);
+  if (ret < 0)
+    goto error;
+
+  query_params.type = Q_ITEMS;
+  query_params.sort = S_ALBUM;
+  query_params.filter = db_mprintf("(f.songalbumid = %q)", album_id);
+
+  ret = fetch_tracks(&query_params, items, &total);
+  free(query_params.filter);
+
+  if (ret < 0)
+    goto error;
+
+  json_object_object_add(reply, "total", json_object_new_int(total));
+  json_object_object_add(reply, "offset", json_object_new_int(query_params.offset));
+  json_object_object_add(reply, "limit", json_object_new_int(query_params.limit));
+
+  ret = evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply));
+  if (ret < 0)
+    DPRINTF(E_LOG, L_WEB, "browse: Couldn't add tracks to response buffer.\n");
+
+ error:
+  jparse_free(reply);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_OK;
+}
+
+static int
+jsonapi_reply_library_playlists(struct httpd_request *hreq)
+{
+  struct query_params query_params;
+  json_object *reply;
+  json_object *items;
+  int total;
+  int ret = 0;
+
+  reply = json_object_new_object();
+  items = json_object_new_array();
+  json_object_object_add(reply, "items", items);
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  ret = query_params_limit_set(&query_params, hreq);
+  if (ret < 0)
+    goto error;
+
+  query_params.type = Q_PL;
+  query_params.sort = S_PLAYLIST;
+  query_params.filter = db_mprintf("(f.type = %d OR f.type = %d)", PL_PLAIN, PL_SMART);
+
+  ret = fetch_playlists(&query_params, items, &total);
+  free(query_params.filter);
+
+  if (ret < 0)
+    goto error;
+
+  json_object_object_add(reply, "total", json_object_new_int(total));
+  json_object_object_add(reply, "offset", json_object_new_int(query_params.offset));
+  json_object_object_add(reply, "limit", json_object_new_int(query_params.limit));
+
+  ret = evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply));
+  if (ret < 0)
+    DPRINTF(E_LOG, L_WEB, "browse: Couldn't add playlists to response buffer.\n");
+
+ error:
+  jparse_free(reply);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_OK;
+}
+
+static int
+jsonapi_reply_library_playlist_tracks(struct httpd_request *hreq)
+{
+  struct query_params query_params;
+  json_object *reply;
+  json_object *items;
+  int playlist_id;
+  int total;
+  int ret = 0;
+
+  ret = safe_atoi32(hreq->uri_parsed->path_parts[3], &playlist_id);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "No valid playlist id given '%s'\n", hreq->uri_parsed->path);
+
+      return HTTP_BADREQUEST;
+    }
+
+  reply = json_object_new_object();
+  items = json_object_new_array();
+  json_object_object_add(reply, "items", items);
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  ret = query_params_limit_set(&query_params, hreq);
+  if (ret < 0)
+    goto error;
+
+  query_params.type = Q_PLITEMS;
+  query_params.id = playlist_id;
+
+  ret = fetch_tracks(&query_params, items, &total);
+  if (ret < 0)
+    goto error;
+
+  json_object_object_add(reply, "total", json_object_new_int(total));
+  json_object_object_add(reply, "offset", json_object_new_int(query_params.offset));
+  json_object_object_add(reply, "limit", json_object_new_int(query_params.limit));
+
+  ret = evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply));
+  if (ret < 0)
+    DPRINTF(E_LOG, L_WEB, "playlist tracks: Couldn't add tracks to response buffer.\n");
+
+ error:
+  jparse_free(reply);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_OK;
+}
+
+static int
+jsonapi_reply_search(struct httpd_request *hreq)
+{
+  const char *param_type;
+  const char *param_query;
+  struct query_params query_params;
+  json_object *reply;
+  json_object *type;
+  json_object *items;
+  int total;
+  int ret = 0;
+
+  reply = NULL;
+
+  param_type = evhttp_find_header(hreq->query, "type");
+  param_query = evhttp_find_header(hreq->query, "query");
+
+  if (!param_type || !param_query)
+    {
+      DPRINTF(E_LOG, L_WEB, "Missing request parameter\n");
+
+      return HTTP_BADREQUEST;
+    }
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  ret = query_params_limit_set(&query_params, hreq);
+  if (ret < 0)
+    goto error;
+
+  reply = json_object_new_object();
+
+  if (strstr(param_type, "track"))
+    {
+      type = json_object_new_object();
+      json_object_object_add(reply, "tracks", type);
+      items = json_object_new_array();
+      json_object_object_add(type, "items", items);
+
+
+      query_params.type = Q_ITEMS;
+      query_params.sort = S_NAME;
+      query_params.filter = db_mprintf("(f.title LIKE '%%%q%%')", param_query);
+
+      ret = fetch_tracks(&query_params, items, &total);
+      free(query_params.filter);
+
+      if (ret < 0)
+	goto error;
+
+      json_object_object_add(type, "total", json_object_new_int(total));
+      json_object_object_add(type, "offset", json_object_new_int(query_params.offset));
+      json_object_object_add(type, "limit", json_object_new_int(query_params.limit));
+    }
+
+  if (strstr(param_type, "artist"))
+    {
+      type = json_object_new_object();
+      json_object_object_add(reply, "artists", type);
+      items = json_object_new_array();
+      json_object_object_add(type, "items", items);
+
+      query_params.type = Q_GROUP_ARTISTS;
+      query_params.sort = S_ARTIST;
+      query_params.filter = db_mprintf("(f.album_artist LIKE '%%%q%%')", param_query);
+
+      ret = fetch_artists(&query_params, items, &total);
+      free(query_params.filter);
+
+      if (ret < 0)
+	goto error;
+
+      json_object_object_add(type, "total", json_object_new_int(total));
+      json_object_object_add(type, "offset", json_object_new_int(query_params.offset));
+      json_object_object_add(type, "limit", json_object_new_int(query_params.limit));
+    }
+
+  if (strstr(param_type, "album"))
+    {
+      type = json_object_new_object();
+      json_object_object_add(reply, "albums", type);
+      items = json_object_new_array();
+      json_object_object_add(type, "items", items);
+
+      query_params.type = Q_GROUP_ALBUMS;
+      query_params.sort = S_ALBUM;
+      query_params.filter = db_mprintf("(f.album LIKE '%%%q%%')", param_query);
+
+      ret = fetch_albums(&query_params, items, &total);
+      free(query_params.filter);
+
+      if (ret < 0)
+        goto error;
+
+      json_object_object_add(type, "total", json_object_new_int(total));
+      json_object_object_add(type, "offset", json_object_new_int(query_params.offset));
+      json_object_object_add(type, "limit", json_object_new_int(query_params.limit));
+    }
+
+  if (strstr(param_type, "playlist"))
+    {
+      type = json_object_new_object();
+      json_object_object_add(reply, "playlists", type);
+      items = json_object_new_array();
+      json_object_object_add(type, "items", items);
+
+      query_params.type = Q_PL;
+      query_params.sort = S_PLAYLIST;
+      query_params.filter = db_mprintf("((f.type = %d OR f.type = %d) AND f.title LIKE '%%%q%%')", PL_PLAIN, PL_SMART, param_query);
+
+      ret = fetch_playlists(&query_params, items, &total);
+      free(query_params.filter);
+
+      if (ret < 0)
+        goto error;
+
+      json_object_object_add(type, "total", json_object_new_int(total));
+      json_object_object_add(type, "offset", json_object_new_int(query_params.offset));
+      json_object_object_add(type, "limit", json_object_new_int(query_params.limit));
+    }
+
+  ret = evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply));
+  if (ret < 0)
+    DPRINTF(E_LOG, L_WEB, "playlist tracks: Couldn't add tracks to response buffer.\n");
+
+ error:
+  jparse_free(reply);
+
+  if (ret < 0)
+    return HTTP_INTERNAL;
+
+  return HTTP_OK;
+}
+
 static struct httpd_uri_map adm_handlers[] =
   {
-    { EVHTTP_REQ_GET,    "^/api/config$",               jsonapi_reply_config },
-    { EVHTTP_REQ_GET,    "^/api/library$",              jsonapi_reply_library },
-    { EVHTTP_REQ_GET,    "^/api/update$",               jsonapi_reply_update },
-    { EVHTTP_REQ_POST,   "^/api/spotify-login$",        jsonapi_reply_spotify_login },
-    { EVHTTP_REQ_GET,    "^/api/spotify$",              jsonapi_reply_spotify },
-    { EVHTTP_REQ_GET,    "^/api/pairing$",              jsonapi_reply_pairing_get },
-    { EVHTTP_REQ_POST,   "^/api/pairing$",              jsonapi_reply_pairing_kickoff },
-    { EVHTTP_REQ_POST,   "^/api/lastfm-login$",         jsonapi_reply_lastfm_login },
-    { EVHTTP_REQ_GET,    "^/api/lastfm-logout$",        jsonapi_reply_lastfm_logout },
-    { EVHTTP_REQ_GET,    "^/api/lastfm$",               jsonapi_reply_lastfm },
-    { EVHTTP_REQ_POST,   "^/api/verification$",         jsonapi_reply_verification },
+    { EVHTTP_REQ_GET,    "^/api/config$",                                jsonapi_reply_config },
+    { EVHTTP_REQ_GET,    "^/api/library$",                               jsonapi_reply_library },
+    { EVHTTP_REQ_GET,    "^/api/update$",                                jsonapi_reply_update },
+    { EVHTTP_REQ_POST,   "^/api/spotify-login$",                         jsonapi_reply_spotify_login },
+    { EVHTTP_REQ_GET,    "^/api/spotify$",                               jsonapi_reply_spotify },
+    { EVHTTP_REQ_GET,    "^/api/pairing$",                               jsonapi_reply_pairing_get },
+    { EVHTTP_REQ_POST,   "^/api/pairing$",                               jsonapi_reply_pairing_kickoff },
+    { EVHTTP_REQ_POST,   "^/api/lastfm-login$",                          jsonapi_reply_lastfm_login },
+    { EVHTTP_REQ_GET,    "^/api/lastfm-logout$",                         jsonapi_reply_lastfm_logout },
+    { EVHTTP_REQ_GET,    "^/api/lastfm$",                                jsonapi_reply_lastfm },
+    { EVHTTP_REQ_POST,   "^/api/verification$",                          jsonapi_reply_verification },
 
-    { EVHTTP_REQ_GET,    "^/api/outputs$",              jsonapi_reply_outputs },
-    { EVHTTP_REQ_PUT,    "^/api/outputs/set$",          jsonapi_reply_outputs_set },
-    { EVHTTP_REQ_POST,   "^/api/select-outputs$",       jsonapi_reply_outputs_set }, // deprecated: use "/api/outputs/set"
-    { EVHTTP_REQ_GET,    "^/api/outputs/[[:digit:]]+$", jsonapi_reply_outputs_get_byid },
-    { EVHTTP_REQ_PUT,    "^/api/outputs/[[:digit:]]+$", jsonapi_reply_outputs_put_byid },
+    { EVHTTP_REQ_GET,    "^/api/outputs$",                               jsonapi_reply_outputs },
+    { EVHTTP_REQ_PUT,    "^/api/outputs/set$",                           jsonapi_reply_outputs_set },
+    { EVHTTP_REQ_POST,   "^/api/select-outputs$",                        jsonapi_reply_outputs_set }, // deprecated: use "/api/outputs/set"
+    { EVHTTP_REQ_GET,    "^/api/outputs/[[:digit:]]+$",                  jsonapi_reply_outputs_get_byid },
+    { EVHTTP_REQ_PUT,    "^/api/outputs/[[:digit:]]+$",                  jsonapi_reply_outputs_put_byid },
 
-    { EVHTTP_REQ_PUT,    "^/api/player/play$",          jsonapi_reply_player_play },
-    { EVHTTP_REQ_PUT,    "^/api/player/pause$",         jsonapi_reply_player_pause },
-    { EVHTTP_REQ_PUT,    "^/api/player/stop$",          jsonapi_reply_player_stop },
-    { EVHTTP_REQ_PUT,    "^/api/player/next$",          jsonapi_reply_player_next },
-    { EVHTTP_REQ_PUT,    "^/api/player/previous$",      jsonapi_reply_player_previous },
-    { EVHTTP_REQ_PUT,    "^/api/player/shuffle$",       jsonapi_reply_player_shuffle },
-    { EVHTTP_REQ_PUT,    "^/api/player/repeat$",        jsonapi_reply_player_repeat },
-    { EVHTTP_REQ_PUT,    "^/api/player/consume$",       jsonapi_reply_player_consume },
-    { EVHTTP_REQ_PUT,    "^/api/player/volume$",        jsonapi_reply_player_volume },
-    { EVHTTP_REQ_GET,    "^/api/player$",               jsonapi_reply_player },
+    { EVHTTP_REQ_GET,    "^/api/player$",                                jsonapi_reply_player },
+    { EVHTTP_REQ_PUT,    "^/api/player/play$",                           jsonapi_reply_player_play },
+    { EVHTTP_REQ_PUT,    "^/api/player/pause$",                          jsonapi_reply_player_pause },
+    { EVHTTP_REQ_PUT,    "^/api/player/stop$",                           jsonapi_reply_player_stop },
+    { EVHTTP_REQ_PUT,    "^/api/player/next$",                           jsonapi_reply_player_next },
+    { EVHTTP_REQ_PUT,    "^/api/player/previous$",                       jsonapi_reply_player_previous },
+    { EVHTTP_REQ_PUT,    "^/api/player/shuffle$",                        jsonapi_reply_player_shuffle },
+    { EVHTTP_REQ_PUT,    "^/api/player/repeat$",                         jsonapi_reply_player_repeat },
+    { EVHTTP_REQ_PUT,    "^/api/player/consume$",                        jsonapi_reply_player_consume },
+    { EVHTTP_REQ_PUT,    "^/api/player/volume$",                         jsonapi_reply_player_volume },
 
-    { EVHTTP_REQ_GET,    "^/api/queue$",                jsonapi_reply_queue },
+    { EVHTTP_REQ_GET,    "^/api/queue$",                                 jsonapi_reply_queue },
+    { EVHTTP_REQ_PUT,    "^/api/queue/clear$",                           jsonapi_reply_queue_clear },
+    { EVHTTP_REQ_POST,   "^/api/queue/items/add$",                       jsonapi_reply_queue_tracks_add },
+    { EVHTTP_REQ_PUT,    "^/api/queue/items/[[:digit:]]+$",              jsonapi_reply_queue_tracks_move },
+    { EVHTTP_REQ_DELETE, "^/api/queue/items/[[:digit:]]+$",              jsonapi_reply_queue_tracks_delete },
+
+    { EVHTTP_REQ_GET,    "^/api/library/playlists$",                     jsonapi_reply_library_playlists },
+    { EVHTTP_REQ_GET,    "^/api/library/playlists/[[:digit:]]+/tracks$", jsonapi_reply_library_playlist_tracks },
+//    { EVHTTP_REQ_POST,   "^/api/library/playlists/[[:digit:]]+/tracks$", jsonapi_reply_library_playlists_tracks },
+//    { EVHTTP_REQ_DELETE, "^/api/library/playlists/[[:digit:]]+$",        jsonapi_reply_library_playlist_tracks },
+    { EVHTTP_REQ_GET,    "^/api/library/artists$",                       jsonapi_reply_library_artists },
+    { EVHTTP_REQ_GET,    "^/api/library/artists/[[:digit:]]+/albums",    jsonapi_reply_library_artist_albums },
+    { EVHTTP_REQ_GET,    "^/api/library/albums$",                        jsonapi_reply_library_albums },
+    { EVHTTP_REQ_GET,    "^/api/library/albums/[[:digit:]]+/tracks$",    jsonapi_reply_library_album_tracks },
+
+    { EVHTTP_REQ_GET,    "^/api/search$",                                jsonapi_reply_search },
 
     { 0, NULL, NULL }
   };

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1146,10 +1146,10 @@ jsonapi_request(struct evhttp_request *req, struct httpd_uri_parsed *uri_parsed)
       case HTTP_OK:                  /* 200 OK */
 	headers = evhttp_request_get_output_headers(req);
 	evhttp_add_header(headers, "Content-Type", "application/json");
-	httpd_send_reply(req, status_code, "OK", hreq->reply, 0);
+	httpd_send_reply(req, status_code, "OK", hreq->reply, HTTPD_SEND_NO_GZIP);
 	break;
       case HTTP_NOCONTENT:           /* 204 No Content */
-	httpd_send_reply(req, status_code, "No Content", hreq->reply, 0);
+	httpd_send_reply(req, status_code, "No Content", hreq->reply, HTTPD_SEND_NO_GZIP);
 	break;
 
       case HTTP_BADREQUEST:          /* 400 Bad Request */

--- a/src/misc.h
+++ b/src/misc.h
@@ -15,6 +15,7 @@
 #define STOB(s) ((s) * 4)
 #define BTOS(b) ((b) / 4)
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
 struct onekeyval {
   char *name;
@@ -56,7 +57,6 @@ safe_strdup(const char *str);
 
 char *
 safe_asprintf(const char *fmt, ...);
-
 
 /* Key/value functions */
 struct keyval *


### PR DESCRIPTION
@ejurgensen i know you are not so thrilled about expanding the JSON api to an extent that allows building full fledged applications based on it. But the current possibilities - daap/dacp and mpd - have all drawbacks, so that i believe, a client protocol that is in our control would really be beneficial to forked-daapd.

It would allow building clients that make fully use of the features in forked-daapd, e. g.:
* Control volume for individual outputs (something mpd clients cannot do)
* Display separate lists for audiobooks, podcasts, music, ... (something mpd clients cannot do)
* List files in a directory structure (something the dacp/daap clients cannot do)
* Save and modify playlists in the library (something dacp/daap clients cannot do)
* ...

A new protocol (with new client applications) will also allow to add new features to forked-daapd (e. g. allowing to add songs from spotify that are not in a saved album or playlist).

So i really hope, you are fine with adding some more endpoints to the JSON api :-)

This pull request implements new endpoints for reading/modifying the queue and reading artists/albums/... from the library (best to take a look at the documentation: https://github.com/chme/forked-daapd/blob/jsonapi/README_JSON_API.md).

The changes are quite large, so if you prefer multiple smaller pr's (assuming you approve of expanding the JSON api), just let me know.

----

I started implementing a full webinterface for forked-daapd in https://github.com/chme/forked-daapd-web. If you like to take a look at it, the branch at https://github.com/chme/forked-daapd/tree/forked-daapd-web contains the changes from this branch and the webinterface. 

Now playing - screenshot:

![image](https://user-images.githubusercontent.com/1037620/36897704-ef4e101a-1e17-11e8-8a93-5037cd34589c.png)


Queue - screenshot:

![image](https://user-images.githubusercontent.com/1037620/36897743-15820002-1e18-11e8-8fca-a386b682fc76.png)
