### PR TITLE
Refactor adding non library items the queue

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -454,6 +454,12 @@ struct db_queue_item
   uint32_t queue_version;
 };
 
+struct db_queue_add_info
+{
+  int queue_version;
+  int pos;
+};
+
 char *
 db_escape_string(const char *str); // TODO Remove this, use db_mprintf instead
 
@@ -483,6 +489,9 @@ free_queue_item(struct db_queue_item *queue_item, int content_only);
 
 void
 unicode_fixup_mfi(struct media_file_info *mfi);
+
+void
+fixup_tags_mfi(struct media_file_info *mfi);
 
 /* Maintenance and DB hygiene */
 void
@@ -764,7 +773,13 @@ int
 db_queue_add_by_fileid(int id, char reshuffle, uint32_t item_id);
 
 int
-db_queue_add_item(struct db_queue_item *queue_item, char reshuffle, uint32_t item_id);
+db_queue_add_start(struct db_queue_add_info *queue_add_info);
+
+void
+db_queue_add_end(struct db_queue_add_info *queue_add_info, int ret);
+
+int
+db_queue_add_item(struct db_queue_add_info *queue_add_info, struct db_queue_item *item);
 
 int
 db_queue_enum_start(struct query_params *qp);

--- a/src/db.h
+++ b/src/db.h
@@ -78,6 +78,9 @@ enum query_type {
 /* Max value for media_file_info->rating (valid range is from 0 to 100) */
 #define DB_FILES_RATING_MAX 100
 
+/* Magic id for media_file_info objects that are not stored in the files database table */
+#define DB_MEDIA_FILE_NON_PERSISTENT_ID 9999999
+
 struct query_params {
   /* Query parameters, filled in by caller */
   enum query_type type;

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -143,7 +143,7 @@ static int seek_target;
 /* If an item is removed from the library while in the queue, we replace it with this */
 static struct media_file_info dummy_mfi =
 {
-  .id = 9999999,
+  .id = DB_MEDIA_FILE_NON_PERSISTENT_ID,
   .title = "(unknown title)",
   .artist = "(unknown artist)",
   .album = "(unknown album)",
@@ -151,7 +151,7 @@ static struct media_file_info dummy_mfi =
 };
 static struct db_queue_item dummy_queue_item =
 {
-  .file_id = 9999999,
+  .file_id = DB_MEDIA_FILE_NON_PERSISTENT_ID,
   .title = "(unknown title)",
   .artist = "(unknown artist)",
   .album = "(unknown album)",

--- a/src/library.h
+++ b/src/library.h
@@ -67,11 +67,6 @@ struct library_source
   int (*fullrescan)(void);
 
   /*
-   * Scans metadata for the media file with the given path into the given mfi
-   */
-  int (*scan_metadata)(const char *path, struct media_file_info *mfi);
-
-  /*
    * Save queue as a new playlist under the given virtual path
    */
   int (*playlist_add)(const char *vp_playlist, const char *vp_item);
@@ -85,8 +80,12 @@ struct library_source
    * Save queue as a new playlist under the given virtual path
    */
   int (*queue_save)(const char *virtual_path);
-};
 
+  /*
+   * Add item for the given path to the current queue
+   */
+  int (*queue_add)(const char *path);
+};
 
 void
 library_add_media(struct media_file_info *mfi);
@@ -95,10 +94,7 @@ int
 library_add_playlist_info(const char *path, const char *title, const char *virtual_path, enum pl_type type, int parent_pl_id, int dir_id);
 
 int
-library_scan_media(const char *path, struct media_file_info *mfi);
-
-int
-library_add_queue_item(struct media_file_info *mfi);
+library_queue_add(const char *path);
 
 void
 library_rescan();

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -11,6 +11,9 @@ int
 scan_metadata_ffmpeg(const char *file, struct media_file_info *mfi);
 
 void
+scan_metadata_stream(const char *path, struct media_file_info *mfi);
+
+void
 scan_playlist(const char *file, time_t mtime, int dir_id);
 
 void

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1685,7 +1685,6 @@ mpd_queue_add(char *path, bool exact_match)
 static int
 mpd_command_add(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, struct mpd_client_ctx *ctx)
 {
-  struct media_file_info mfi;
   int ret;
 
   ret = mpd_queue_add(argv[1], false);
@@ -1699,15 +1698,12 @@ mpd_command_add(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, st
   if (ret == 0)
     {
       // Given path is not in the library, check if it is possible to add as a non-library queue item
-      ret = library_scan_media(argv[1], &mfi);
+      ret = library_queue_add(argv[1]);
       if (ret != LIBRARY_OK)
 	{
 	  *errmsg = safe_asprintf("Failed to add song '%s' to playlist (unkown path)", argv[1]);
 	  return ACK_ERROR_UNKNOWN;
 	}
-
-      library_add_queue_item(&mfi);
-      free_mfi(&mfi, 1);
     }
 
   return 0;
@@ -1722,7 +1718,6 @@ mpd_command_add(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, st
 static int
 mpd_command_addid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, struct mpd_client_ctx *ctx)
 {
-  struct media_file_info mfi;
   int to_pos = -1;
   int ret;
 
@@ -1741,15 +1736,12 @@ mpd_command_addid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, 
   if (ret == 0)
     {
       // Given path is not in the library, directly add it as a new queue item
-      ret = library_scan_media(argv[1], &mfi);
+      ret = library_queue_add(argv[1]);
       if (ret != LIBRARY_OK)
 	{
 	  *errmsg = safe_asprintf("Failed to add song '%s' to playlist (unkown path)", argv[1]);
 	  return ACK_ERROR_UNKNOWN;
 	}
-
-      ret = library_add_queue_item(&mfi);
-      free_mfi(&mfi, 1);
     }
 
   if (ret < 0)

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2510,7 +2510,7 @@ mpd_command_playlistadd(struct evbuffer *evbuf, int argc, char **argv, char **er
   free(vp_item);
   if (ret < 0)
     {
-      *errmsg = safe_asprintf("Error saving queue to file '%s'", argv[1]);
+      *errmsg = safe_asprintf("Error adding item to file '%s'", argv[1]);
       return ACK_ERROR_ARG;
     }
 


### PR DESCRIPTION
This refactors how paths, that are not in the library, are added to the queue (currently only supports internet radio urls). Before, the client protocol implementation (mpd.c) had to first scan the url into a media_file_info and than add this media_file_info to the queue. This is simplified by this pr by adding a "queue_add" function to the library source implementations. In mpd.c it is now enough to pass the url to queue_add and queue_add takes care of creating and adding the queue items.

This is an intermediate step towards support for adding spotify uris to the queue that are not in a saved playlist or album. It opens the possibility that a given path/uri translates to more than one queue item (e. g. a spotify album uri).

It also addresses the issue that @wolfmanx  reported and worked on in #451 by making sure that a stream is in the library before it is added to a playlist file. 