### PR TITLE
Add count endpoint to JSON API and fix cache-control headers for library endpoints

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -669,6 +669,7 @@ curl -X PUT "http://localhost:3689/api/queue/items/2"
 | GET       | [/api/library/albums](#list-albums)                         | Get a list of albums                 |
 | GET       | [/api/library/albums/{id}](#get-an-album)                   | Get an album                         |
 | GET       | [/api/library/albums/{id}/tracks](#list-album-tracks)       | Get list of tracks for an album      |
+| GET       | [/api/library/count](#get-count-of-tracks-artists-and-albums) | Get count of tracks, artists and albums |
 
 
 
@@ -1157,6 +1158,48 @@ curl -X GET "http://localhost:3689/api/library/albums/1/tracks"
 ```
 
 
+### Get count of tracks, artists and albums
+
+Get information about the number of tracks, artists and albums and the total playtime
+
+**Endpoint**
+
+```
+GET /api/library/count
+```
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| expression      | *(Optional)* The smart playlist query expression, if this parameter is omitted returns the information for the whole library |
+
+**Response**
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| tracks          | integer  | Number of tracks matching the expression  |
+| artists         | integer  | Number of artists matching the expression |
+| albums          | integer  | Number of albums matching the expression  |
+| db_playtime     | integer  | Total playtime in milliseconds of all tracks matching the expression |
+
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/library/count?expression=data_kind+is+file"
+```
+
+```
+{
+  "tracks": 6811,
+  "artists": 355,
+  "albums": 646,
+  "db_playtime": 1590767
+}
+```
+
+
 
 ## Search
 
@@ -1182,7 +1225,8 @@ GET /api/search
 | Parameter       | Value                                                       |
 | --------------- | ----------------------------------------------------------- |
 | query           | The search keyword                                          |
-| type            | Comma separated list of the result types (`playlist`, `artist`, `album`, `track` |
+| type            | Comma separated list of the result types (`playlist`, `artist`, `album`, `track`) |
+| media_kind      | *(Optional)* Filter results by media kind (`music`, `movie`, `podcast`, `audiobook`, `musicvideo`, `tvshow`). Filter only applies to artist, album and track result types. |
 | offset          | *(Optional)* Offset of the first item to return for each type |
 | limit           | *(Optional)* Maximum number of items to return for each type  |
 
@@ -1530,7 +1574,10 @@ curl --include \
 | disc_number        | integer  | Disc number                               |
 | length_ms          | integer  | Track length in milliseconds              |
 | play_count         | integer  | How many times the track was played       |
-| time_played        | string   | The timestamp in `ISO 8601` format      |
+| time_played        | string   | Timestamp in `ISO 8601` format           |
+| time_added         | string   | Timestamp in `ISO 8601` format           |
+| date_released      | string   | Date in the format `yyyy-mm-dd`         |
+| seek_ms            | integer  | Resume point in milliseconds (available only for podcasts and audiobooks) |
 | media_kind         | string   | Media type of this track: `music`, `movie`, `podcast`, `audiobook`, `musicvideo`, `tvshow` |
 | data_kind          | string   | Data type of this track: `file`, `stream`, `spotify`, `pipe` |
 | path               | string   | Path                                      |

--- a/src/db.c
+++ b/src/db.c
@@ -1834,7 +1834,7 @@ db_build_query_count_items(struct query_params *qp)
 
   qp->results = 1;
 
-  query = sqlite3_mprintf("SELECT COUNT(*), SUM(song_length), COUNT(distinct songartistid), COUNT(distinct songalbumid) FROM files f %s;", qc->where);
+  query = sqlite3_mprintf("SELECT COUNT(*), SUM(song_length), COUNT(DISTINCT songartistid), COUNT(DISTINCT songalbumid) FROM files f %s;", qc->where);
   if (!query)
     DPRINTF(E_LOG, L_DB, "Out of memory for query string\n");
 

--- a/src/db.c
+++ b/src/db.c
@@ -1834,7 +1834,7 @@ db_build_query_count_items(struct query_params *qp)
 
   qp->results = 1;
 
-  query = sqlite3_mprintf("SELECT COUNT(*), SUM(song_length) FROM files f %s;", qc->where);
+  query = sqlite3_mprintf("SELECT COUNT(*), SUM(song_length), COUNT(distinct songartistid), COUNT(distinct songalbumid) FROM files f %s;", qc->where);
   if (!query)
     DPRINTF(E_LOG, L_DB, "Out of memory for query string\n");
 
@@ -2218,6 +2218,8 @@ db_query_fetch_count(struct query_params *qp, struct filecount_info *fci)
 
   fci->count = sqlite3_column_int(qp->stmt, 0);
   fci->length = sqlite3_column_int64(qp->stmt, 1);
+  fci->artist_count = sqlite3_column_int(qp->stmt, 2);
+  fci->album_count = sqlite3_column_int(qp->stmt, 3);
 
   return 0;
 }
@@ -2322,18 +2324,6 @@ int
 db_files_get_count(void)
 {
   return db_get_one_int("SELECT COUNT(*) FROM files f WHERE f.disabled = 0;");
-}
-
-int
-db_files_get_artist_count(void)
-{
-  return db_get_one_int("SELECT COUNT(DISTINCT songartistid) FROM files f WHERE f.disabled = 0;");
-}
-
-int
-db_files_get_album_count(void)
-{
-  return db_get_one_int("SELECT COUNT(DISTINCT songalbumid) FROM files f WHERE f.disabled = 0;");
 }
 
 void

--- a/src/db.h
+++ b/src/db.h
@@ -391,6 +391,8 @@ struct watch_enum {
 struct filecount_info {
   uint32_t count;
   uint64_t length;
+  uint32_t artist_count;
+  uint32_t album_count;
 };
 
 /* Directory ids must be in sync with the ids in Q_DIR* in db_init.c */
@@ -551,12 +553,6 @@ db_query_fetch_string_sort(struct query_params *qp, char **string, char **sortst
 /* Files */
 int
 db_files_get_count(void);
-
-int
-db_files_get_artist_count(void);
-
-int
-db_files_get_album_count(void);
 
 void
 db_file_inc_playcount(int id);

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -31,7 +31,6 @@
 #endif
 
 #include <regex.h>
-#include <sqlite3.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -1895,7 +1894,7 @@ jsonapi_reply_library_artists(struct httpd_request *hreq)
   int total;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -1957,7 +1956,7 @@ jsonapi_reply_library_artist(struct httpd_request *hreq)
   json_object *reply;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -1995,7 +1994,7 @@ jsonapi_reply_library_artist_albums(struct httpd_request *hreq)
   int total;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -2051,7 +2050,7 @@ jsonapi_reply_library_albums(struct httpd_request *hreq)
   int total;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -2113,7 +2112,7 @@ jsonapi_reply_library_album(struct httpd_request *hreq)
   json_object *reply;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -2151,7 +2150,7 @@ jsonapi_reply_library_album_tracks(struct httpd_request *hreq)
   int total;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -2205,7 +2204,7 @@ jsonapi_reply_library_playlists(struct httpd_request *hreq)
   int total;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -2255,7 +2254,7 @@ jsonapi_reply_library_playlist(struct httpd_request *hreq)
   json_object *reply;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -2293,7 +2292,7 @@ jsonapi_reply_library_playlist_tracks(struct httpd_request *hreq)
   int total;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -2343,6 +2342,7 @@ jsonapi_reply_library_playlist_tracks(struct httpd_request *hreq)
 static int
 jsonapi_reply_library_count(struct httpd_request *hreq)
 {
+  time_t db_update;
   const char *param_expression;
   char *expression;
   struct smartpl smartpl_expression;
@@ -2351,6 +2351,10 @@ jsonapi_reply_library_count(struct httpd_request *hreq)
   json_object *jreply;
   int ret;
 
+
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
+  if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
+    return HTTP_NOTMODIFIED;
 
   memset(&qp, 0, sizeof(struct query_params));
   qp.type = Q_COUNT_ITEMS;

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1053,8 +1053,6 @@ mpd_command_stats(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, 
 {
   struct query_params qp;
   struct filecount_info fci;
-  int artists;
-  int albums;
   time_t start_time;
   double uptime;
   int64_t db_update;
@@ -1070,9 +1068,6 @@ mpd_command_stats(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, 
       return ACK_ERROR_UNKNOWN;
     }
 
-  artists = db_files_get_artist_count();
-  albums = db_files_get_album_count();
-
   start_time = (time_t) db_admin_getint64(DB_ADMIN_START_TIME);
   uptime = difftime(time(NULL), start_time);
   db_update = db_admin_getint64(DB_ADMIN_DB_UPDATE);
@@ -1086,8 +1081,8 @@ mpd_command_stats(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, 
       "db_playtime: %" PRIi64 "\n"
       "db_update: %" PRIi64 "\n"
       "playtime: %d\n",
-      artists,
-      albums,
+      fci.artist_count,
+      fci.album_count,
       fci.count,
       uptime,
       (fci.length / 1000),


### PR DESCRIPTION
Some additions to the JSON API:
- new count endpoint
- additional metadata in track object (time added/played, date released, resume point)
- a fix for the cache-control headers (check if a resource was modified was done on the startup time but should be done on the db update time)

The one change that also affects mpd is adding artist and album count to the filecount_info struct. This allows to get rid of the count artist and album functions.