### PR TITLE
Fix setting speaker volume from mpd/json

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -31,6 +31,7 @@
 #endif
 
 #include <regex.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>

--- a/src/player.c
+++ b/src/player.c
@@ -2631,6 +2631,23 @@ volume_set(void *arg, int *retval)
   return COMMAND_END;
 }
 
+#ifdef DEBUG_RELVOL
+static void debug_print_speaker()
+{
+  struct output_device *device;
+
+  DPRINTF(E_DBG, L_PLAYER, "*** Master: %d\n", master_volume);
+
+  for (device = dev_list; device; device = device->next)
+    {
+      if (!device->selected)
+	continue;
+
+      DPRINTF(E_DBG, L_PLAYER, "*** %s: abs %d rel %d\n", device->name, device->volume, device->relvol);
+    }
+}
+#endif
+
 static enum command_state
 volume_setrel_speaker(void *arg, int *retval)
 {
@@ -2667,6 +2684,9 @@ volume_setrel_speaker(void *arg, int *retval)
       break;
     }
 
+#ifdef DEBUG_RELVOL
+  debug_print_speaker();
+#endif
   listener_notify(LISTENER_VOLUME);
 
   if (*retval > 0)
@@ -2717,6 +2737,9 @@ volume_setabs_speaker(void *arg, int *retval)
 	}
     }
 
+#ifdef DEBUG_RELVOL
+  debug_print_speaker();
+#endif
   listener_notify(LISTENER_VOLUME);
 
   if (*retval > 0)

--- a/src/player.c
+++ b/src/player.c
@@ -2684,6 +2684,8 @@ volume_setrel_speaker(void *arg, int *retval)
       break;
     }
 
+  volume_master_find();
+
 #ifdef DEBUG_RELVOL
   debug_print_speaker();
 #endif
@@ -2737,9 +2739,12 @@ volume_setabs_speaker(void *arg, int *retval)
 	}
     }
 
+  volume_master_find();
+
 #ifdef DEBUG_RELVOL
   debug_print_speaker();
 #endif
+
   listener_notify(LISTENER_VOLUME);
 
   if (*retval > 0)


### PR DESCRIPTION
I noticed that setting volume for an individual speaker from mpd or json does not always result in a correct update of the master volume. The problem occurs if the volume of the speaker is changed that defines the master volume and after the change another speaker would define the new master volume.

For DACP clients this is working because in that case they send two requests to forked-daapd. The first one for the speaker the volume should change and the second for the new "master" speaker.

To avoid having to send two requests in mpd.c and httpd_jsonapi.c, i added an option to force a master volume update in volume_setabs_speaker and volume_setrel_speaker.