### PR TITLE
genre search functionality

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -1257,10 +1257,10 @@ GET api/search?type=albums&expression=genre+is+\"{genre name}\""
 **Example**
 
 ```
-curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"Pop\"
-curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"Rock%2FPop\"            # Rock/Pop
-curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"Drum%20%26%20Bass\"     # Drum & Bass
-curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"%2790s%20Alternative\"  # '90 Alternative
+curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"Pop\""
+curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"Rock%2FPop\""            # Rock/Pop
+curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"Drum%20%26%20Bass\""     # Drum & Bass
+curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"%2790s%20Alternative\""  # '90 Alternative
 ```
 
 ```

--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -669,6 +669,7 @@ curl -X PUT "http://localhost:3689/api/queue/items/2"
 | GET       | [/api/library/albums](#list-albums)                         | Get a list of albums                 |
 | GET       | [/api/library/albums/{id}](#get-an-album)                   | Get an album                         |
 | GET       | [/api/library/albums/{id}/tracks](#list-album-tracks)       | Get list of tracks for an album      |
+| GET       | [/api/library/genres](#list-genres)                         | Get list of genres                   |
 | GET       | [/api/library/count](#get-count-of-tracks-artists-and-albums) | Get count of tracks, artists and albums |
 
 
@@ -1159,6 +1160,151 @@ curl -X GET "http://localhost:3689/api/library/albums/1/tracks"
 ```
 
 
+### list genres
+
+Get list of genres
+
+**Endpoint**
+
+```
+GET /api/library/genres
+```
+**Response**
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| items           | array    | Array of [`genre`](#genre-object) objects |
+| total           | integer  | Total number of genres in the library     |
+| offset          | integer  | Requested offset of the first genre       |
+| limit           | integer  | Requested maximum number of genres        |
+
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/library/genres"
+```
+
+```
+{
+  "items": [
+    {
+      "name": "Classical",
+      "album_count": 3,
+      "artist_count": 2,
+      "track_count": 4
+    },
+    {
+      "name": "Drum & Bass",
+      "album_count": 1,
+      "artist_count": 1,
+      "track_count": 1
+    },
+    {
+      "name": "Pop",
+      "album_count": 3,
+      "artist_count": 3,
+      "track_count": 4
+    },
+    {
+      "name": "Rock/Pop",
+      "album_count": 1,
+      "artist_count": 1,
+      "track_count": 1
+    },
+    {
+      "name": "'90s Alternative",
+      "album_count": 1,
+      "artist_count": 1,
+      "track_count": 1
+    }
+  ],
+  "total": 4,
+  "offset": 0,
+  "limit": -1
+}
+
+```
+
+### List albums for genre
+
+Lists the albums in a genre
+
+**Endpoint**
+
+```
+GET api/search?type=albums&expression=genre+is+\"{genre name}\""
+```
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| genre           | genre name (uri encoded and html esc seq for chars: '/&)    |
+| offset          | *(Optional)* Offset of the first album to return            |
+| limit           | *(Optional)* Maximum number of albums to return             |
+
+**Response**
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| items           | array    | Array of [`album`](#album-object) objects |
+| total           | integer  | Total number of albums in the library     |
+| offset          | integer  | Requested offset of the first albums      |
+| limit           | integer  | Requested maximum number of albums        |
+
+
+**Example**
+
+```
+curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"Pop\"
+curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"Rock%2FPop\"            # Rock/Pop
+curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"Drum%20%26%20Bass\"     # Drum & Bass
+curl -X GET "http://localhost:3689/api/search?type=albums&expression=genre+is+\"%2790s%20Alternative\"  # '90 Alternative
+```
+
+```
+{
+  "albums": {
+    "items": [
+      {
+        "id": "320189328729146437",
+        "name": "Best Ever",
+        "name_sort": "Best Ever",
+        "artist": "ABC",
+        "artist_id": "8760559201889050080",
+        "track_count": 1,
+        "length_ms": 3631,
+        "uri": "library:album:320189328729146437"
+      },
+      {
+        "id": "7964595866631625723",
+        "name": "Greatest Hits",
+        "name_sort": "Greatest Hits",
+        "artist": "Marvin Gaye",
+        "artist_id": "5261930703203735930",
+        "track_count": 2,
+        "length_ms": 7262,
+        "uri": "library:album:7964595866631625723"
+      },
+      {
+        "id": "3844610748145176456",
+        "name": "The Very Best of Etta",
+        "name_sort": "Very Best of Etta",
+        "artist": "Etta James",
+        "artist_id": "2627182178555864595",
+        "track_count": 1,
+        "length_ms": 177926,
+        "uri": "library:album:3844610748145176456"
+      }
+    ],
+    "total": 3,
+    "offset": 0,
+    "limit": -1
+  }
+}
+```
+
 ### Get count of tracks, artists and albums
 
 Get information about the number of tracks, artists and albums and the total playtime
@@ -1206,14 +1352,14 @@ curl -X GET "http://localhost:3689/api/library/count?expression=data_kind+is+fil
 
 | Method    | Endpoint                                                    | Description                          |
 | --------- | ----------------------------------------------------------- | ------------------------------------ |
-| GET       | [/api/search](#search-by-search-term)                       | Search for playlists, artists, albums, tracks by a simple search term |
+| GET       | [/api/search](#search-by-search-term)                       | Search for playlists, artists, albums, tracks,genres by a simple search term |
 | GET       | [/api/search](#search-by-query-language)                    | Search by complex query expression   |
 
 
 
 ### Search by search term
 
-Search for playlists, artists, albums, tracks that include the given query in their title (case insensitive matching).
+Search for playlists, artists, albums, tracks, genres that include the given query in their title (case insensitive matching).
 
 **Endpoint**
 
@@ -1226,7 +1372,7 @@ GET /api/search
 | Parameter       | Value                                                       |
 | --------------- | ----------------------------------------------------------- |
 | query           | The search keyword                                          |
-| type            | Comma separated list of the result types (`playlist`, `artist`, `album`, `track`) |
+| type            | Comma separated list of the result types (`playlist`, `artist`, `album`, `track`, `genre`) |
 | media_kind      | *(Optional)* Filter results by media kind (`music`, `movie`, `podcast`, `audiobook`, `musicvideo`, `tvshow`). Filter only applies to artist, album and track result types. |
 | offset          | *(Optional)* Offset of the first item to return for each type |
 | limit           | *(Optional)* Maximum number of items to return for each type  |
@@ -1239,6 +1385,7 @@ GET /api/search
 | artists         | object   | [`paging`](#paging-object) object containing [`artist`](#artist-object) objects that matches the `query` |
 | albums          | object   | [`paging`](#paging-object) object containing [`album`](#album-object) objects that matches the `query` |
 | playlists       | object   | [`paging`](#paging-object) object containing [`playlist`](#playlist-object) objects that matches the `query` |
+| genres          | object   | [`paging`](#paging-object) object containing [`genre`](#genre-object) objects that matches the `query` |
 
 
 **Example**
@@ -1593,4 +1740,14 @@ curl --include \
 | total           | integer  | Total number of items                     |
 | offset          | integer  | Requested offset of the first item        |
 | limit           | integer  | Requested maximum number of items         |
+
+
+### `genre` object
+
+| Key             | Type     | Value                                     |
+| --------------- | -------- | ----------------------------------------- |
+| name            | string   | Name of genre                             |
+| album_count     | integer  | Total number of albums for genre          |
+| artist_count    | integer  | Total number of arists for genre          |
+| track_count     | integer  | Total number of tracks for genre          |
 

--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -1189,37 +1189,22 @@ curl -X GET "http://localhost:3689/api/library/genres"
 {
   "items": [
     {
-      "name": "Classical",
-      "album_count": 3,
-      "artist_count": 2,
-      "track_count": 4
+      "name": "Classical"
     },
     {
-      "name": "Drum & Bass",
-      "album_count": 1,
-      "artist_count": 1,
-      "track_count": 1
+      "name": "Drum & Bass"
     },
     {
-      "name": "Pop",
-      "album_count": 3,
-      "artist_count": 3,
-      "track_count": 4
+      "name": "Pop"
     },
     {
-      "name": "Rock/Pop",
-      "album_count": 1,
-      "artist_count": 1,
-      "track_count": 1
+      "name": "Rock/Pop"
     },
     {
-      "name": "'90s Alternative",
-      "album_count": 1,
-      "artist_count": 1,
-      "track_count": 1
+      "name": "'90s Alternative"
     }
   ],
-  "total": 4,
+  "total": 5,
   "offset": 0,
   "limit": -1
 }
@@ -1385,7 +1370,6 @@ GET /api/search
 | artists         | object   | [`paging`](#paging-object) object containing [`artist`](#artist-object) objects that matches the `query` |
 | albums          | object   | [`paging`](#paging-object) object containing [`album`](#album-object) objects that matches the `query` |
 | playlists       | object   | [`paging`](#paging-object) object containing [`playlist`](#playlist-object) objects that matches the `query` |
-| genres          | object   | [`paging`](#paging-object) object containing [`genre`](#genre-object) objects that matches the `query` |
 
 
 **Example**
@@ -1747,7 +1731,4 @@ curl --include \
 | Key             | Type     | Value                                     |
 | --------------- | -------- | ----------------------------------------- |
 | name            | string   | Name of genre                             |
-| album_count     | integer  | Total number of albums for genre          |
-| artist_count    | integer  | Total number of arists for genre          |
-| track_count     | integer  | Total number of tracks for genre          |
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -2473,9 +2473,11 @@ jsonapi_reply_library_genres(struct httpd_request *hreq)
   if (media_kind)
     query_params.filter = db_mprintf("(f.media_kind = %d)", media_kind);
 
-  ret = fetch_genres(&query_params, items, &total);
+  ret = fetch_genres(&query_params, items, NULL);
   if (ret < 0)
     goto error;
+  else
+    total = json_object_array_length(items);
 
   json_object_object_add(reply, "total", json_object_new_int(total));
   json_object_object_add(reply, "offset", json_object_new_int(query_params.offset));
@@ -2796,7 +2798,6 @@ search_genres(json_object *reply, struct httpd_request *hreq, const char *param_
   json_object_object_add(type, "items", items);
 
   query_params.type = Q_BROWSE_GENRES;
-  query_params.sort = S_GENRE;
   query_params.idx_type = I_NONE;
 
   if (param_query)
@@ -2820,7 +2821,7 @@ search_genres(json_object *reply, struct httpd_request *hreq, const char *param_
 	}
     }
 
-  ret = fetch_genres(&query_params, items, &total);
+  ret = fetch_genres(&query_params, items, NULL);
   if (ret < 0) 
     {
       /* browse seems to expect to find rows; if it can't it returns NULL to
@@ -2828,7 +2829,10 @@ search_genres(json_object *reply, struct httpd_request *hreq, const char *param_
        */
       total = 0;
       ret = 0;
+      DPRINTF(E_DBG, L_WEB, "reseting fetch_genre() return\n");
     }
+  else
+    total = json_object_array_length(items);
 
   json_object_object_add(type, "total", json_object_new_int(total));
   json_object_object_add(type, "offset", json_object_new_int(query_params.offset));

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -2816,8 +2816,14 @@ search_genres(json_object *reply, struct httpd_request *hreq, const char *param_
     }
 
   ret = fetch_genres(&query_params, items, &total);
-  if (ret < 0)
-    goto out;
+  if (ret < 0) 
+    {
+      /* browse seems to expect to find rows; if it can't it returns NULL to
+       * db_build_query_check() .. db_get_one_int() leading to this to case
+       */
+      total = 0;
+      ret = 0;
+    }
 
   json_object_object_add(type, "total", json_object_new_int(total));
   json_object_object_add(type, "offset", json_object_new_int(query_params.offset));

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -348,6 +348,7 @@ fetch_artist(const char *artist_id)
 
  error:
   db_query_end(&query_params);
+  free(query_params.filter);
 
   return artist;
 }
@@ -414,6 +415,7 @@ fetch_album(const char *album_id)
 
  error:
   db_query_end(&query_params);
+  free(query_params.filter);
 
   return album;
 }
@@ -476,6 +478,7 @@ fetch_playlist(const char *playlist_id)
 
  error:
   db_query_end(&query_params);
+  free(query_params.filter);
 
   return playlist;
 }
@@ -639,6 +642,7 @@ jsonapi_reply_library(struct httpd_request *hreq)
   struct filecount_info fci;
   json_object *jreply;
   int ret;
+  char *s;
 
 
   CHECK_NULL(L_WEB, jreply = json_object_new_object());
@@ -658,8 +662,10 @@ jsonapi_reply_library(struct httpd_request *hreq)
       DPRINTF(E_LOG, L_WEB, "library: failed to get file count info\n");
     }
 
-  safe_json_add_time_from_string(jreply, "started_at", db_admin_get(DB_ADMIN_START_TIME), true);
-  safe_json_add_time_from_string(jreply, "updated_at", db_admin_get(DB_ADMIN_DB_UPDATE), true);
+  safe_json_add_time_from_string(jreply, "started_at", (s = db_admin_get(DB_ADMIN_START_TIME)), true);
+  free(s);
+  safe_json_add_time_from_string(jreply, "updated_at", (s = db_admin_get(DB_ADMIN_DB_UPDATE)), true);
+  free(s);
 
   json_object_object_add(jreply, "updating", json_object_new_boolean(library_is_scanning()));
 


### PR DESCRIPTION
Add endpoints to:
* list all `genres` known to server
* search by `genres`, returning all albums matching a `genre`

modeled heavily on existing `album` code.

Functionality would be coupled with update to UI that would allow users to queue music by a given genre, such as classical.  Currently, users need to locate and queue individual songs/artists/albums.

~~Missing updates to web ui for which an issue https://github.com/ejurgensen/forked-daapd/issues/558 is logged~~  Web ui (generated/drop-in `htdocs` files) updates on a fork:
~~https://github.com/whatdoineed2do/forked-daapd-web/files/2258629/dist-0cd890b3128c50510c776d455adb0c61a9b3b376.tar.gz~~
~~[dist-search-genre-98ce8de37dfda03a766e5745e5e1219be764545b.tar.gz](https://github.com/ejurgensen/forked-daapd/files/2288253/dist-search-genre-98ce8de37dfda03a766e5745e5e1219be764545b.tar.gz)~~

**EDIT: 2018-08-24**
* branch updated: https://github.com/whatdoineed2do/forked-daapd/tree/search-genre (includes a temporary workaround for https://github.com/ejurgensen/forked-daapd/issues/570)
* webui [dist-search-genre-7d5becba4a8cee675eadbdbadec194dba3386651.tar.gz](https://github.com/ejurgensen/forked-daapd/files/2318320/dist-search-genre-7d5becba4a8cee675eadbdbadec194dba3386651.tar.gz)
* pending to squash commits
* `Q_BROWSE_GENRE`
* adds agreed endpoint, `api/library/genres`
* searches for albums for genres via `api/search`

Please use in conjunction with this build to see intended use cases - web ui code NOT incl in PR)

Upon server functionality is merge, I will submit PR to https://github.com/chme/forked-daapd-web.

comments / feedback?  @chme , @ejurgensen 
Thanks