### PR TITLE
[mdns] Fix compile warning "directive output may be truncated" (provided

### DIFF
--- a/src/mdns_avahi.c
+++ b/src/mdns_avahi.c
@@ -555,7 +555,7 @@ static int
 address_check(AvahiProtocol proto, const char *hostname, const AvahiAddress *addr, int port)
 {
   char address[AVAHI_ADDRESS_STR_MAX];
-  char address_log[AVAHI_ADDRESS_STR_MAX];
+  char address_log[AVAHI_ADDRESS_STR_MAX + 2];
   int family;
   int ret;
 


### PR DESCRIPTION
string length might not be big enough for ipv6 addresses)