### PR TITLE
[smartpl] support 'songartistid' for searching

### DIFF
--- a/README_SMARTPL.md
+++ b/README_SMARTPL.md
@@ -26,6 +26,7 @@ field-name operator operand
 Where valid field-names (with their types) are:
 * `artist` (string)
 * `album_artist` (string)
+* `songartistid` (string)
 * `album` (string)
 * `title` (string)
 * `genre` (string)

--- a/src/SMARTPL.g
+++ b/src/SMARTPL.g
@@ -82,6 +82,7 @@ STRTAG		:	'artist'
 			|	'path'
 			|	'type'
 			|	'grouping'
+			|	'songartistid'
 			;
 
 INTTAG		:	'play_count'


### PR DESCRIPTION
Use case: https://github.com/ejurgensen/forked-daapd/issues/584

Support additional SMARTPL token `songartistid` that can be used for listing tracks belonging to artist:
`'/api/search?type=tracks&expression=songartistid+is+"3234450040256965254"'`
as partner to
`'/api/search?type=tracks&expression=artist+is+"Foo"'`

Useful on webui where we already have the `artist id` (ie `/music/artists/3234450040256965254`) and require to search based on known `artist_id` instead of using artist name again.
