### PR TITLE
Fix error logs for non persistent queue items

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -818,9 +818,8 @@ source_check(void)
 #ifdef LASTFM
 	  worker_execute(scrobble_cb, &id, sizeof(int), 8);
 #endif
+	  history_add(cur_playing->id, cur_playing->item_id);
 	}
-
-      history_add(cur_playing->id, cur_playing->item_id);
 
       if (consume)
 	db_queue_delete_byitemid(cur_playing->item_id);

--- a/src/player.c
+++ b/src/player.c
@@ -811,10 +811,15 @@ source_check(void)
       i++;
 
       id = (int)cur_playing->id;
-      worker_execute(playcount_inc_cb, &id, sizeof(int), 5);
+
+      if (id != DB_MEDIA_FILE_NON_PERSISTENT_ID)
+	{
+	  worker_execute(playcount_inc_cb, &id, sizeof(int), 5);
 #ifdef LASTFM
-      worker_execute(scrobble_cb, &id, sizeof(int), 8);
+	  worker_execute(scrobble_cb, &id, sizeof(int), 8);
 #endif
+	}
+
       history_add(cur_playing->id, cur_playing->item_id);
 
       if (consume)


### PR DESCRIPTION
Incrementing playcount and trying to scrobble non persistent queue items is not necessary and produces error log messages.

Non persistent items are also not correctly shown in the queue history (only shown in dacp clients). It would be nice to display them correctly, but this is a bigger change (for imo little gain). The second commit just avoids adding them to the history.