### PR TITLE
[dacp] Only return requested number of queue item (fixes #556)

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1749,8 +1749,7 @@ dacp_reply_playqueuecontents(struct httpd_request *hreq)
       if (ret < 0)
 	goto error;
 
-      //FIXME [queue] Check count value
-      while ((db_queue_enum_fetch(&qp, &queue_item) == 0) && (queue_item.id > 0))
+      while ((db_queue_enum_fetch(&qp, &queue_item) == 0) && (queue_item.id > 0) && (count < span))
 	{
 	  if (status.item_id == 0 || status.item_id == queue_item.id)
 	    {


### PR DESCRIPTION
Since the change to store the queue in the db, the span parameter from dacp clients was not taken into account (and the client always got the whole queue instead of the requested number of items). This should fix #556.