### PR TITLE
Add automatic calculation of ratings based on played/skipped

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -178,6 +178,17 @@ library {
 	# there is data to be read. To exclude specific pipes from watching,
 	# consider using the above _ignore options.
 #	pipe_autostart = true
+
+	# Enable automatic rating updates
+	# If enabled, rating is automatically updated after a song has either been
+	# played or skipped (only skipping to the next song is taken into account).
+	# The calculation is taken from the beets plugin "mpdstats" (see 
+	# https://beets.readthedocs.io/en/latest/plugins/mpdstats.html).
+	# It consist of calculating a stable rating based only on the play- and 
+	# skipcount and a rolling rating based on the current rating and the action
+	# (played or skipped). Both results are combined with a mix-factor of 0.75:
+	# new rating = 0.75 * stable rating + 0.25 * rolling rating)
+#	rating_updates = false
 }
 
 # Local audio output

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -100,6 +100,7 @@ static cfg_opt_t sec_library[] =
     CFG_STR_LIST("no_decode", NULL, CFGF_NONE),
     CFG_STR_LIST("force_decode", NULL, CFGF_NONE),
     CFG_BOOL("pipe_autostart", cfg_true, CFGF_NONE),
+    CFG_BOOL("rating_updates", cfg_false, CFGF_NONE),
     CFG_END()
   };
 


### PR DESCRIPTION
If i have done it right, this will implement the logic for calculating ratings like it is done in the beets mpdstats plugin (https://beets.readthedocs.io/en/latest/plugins/mpdstats.html).

For lazy people like me, that do not manually set ratings, this adds an easy way to get ratings based on how often a song is played and skipped. 

Ref: #249