### PR TITLE
[db] Add support to add items to the queue at a specified position

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -778,13 +778,13 @@ int
 db_queue_add_by_queryafteritemid(struct query_params *qp, uint32_t item_id);
 
 int
-db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id);
+db_queue_add_by_query(struct query_params *qp, char reshuffle, uint32_t item_id, int position, int *count, int *new_item_id);
 
 int
-db_queue_add_by_playlistid(int plid, char reshuffle, uint32_t item_id);
+db_queue_add_by_playlistid(int plid, char reshuffle, uint32_t item_id, int position, int *count, int *new_item_id);
 
 int
-db_queue_add_by_fileid(int id, char reshuffle, uint32_t item_id);
+db_queue_add_by_fileid(int id, char reshuffle, uint32_t item_id, int position, int *count, int *new_item_id);
 
 int
 db_queue_add_start(struct db_queue_add_info *queue_add_info);

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -414,7 +414,7 @@ dacp_queueitem_add(const char *query, const char *queuefilter, const char *sort,
   if (mode == 3)
     ret = db_queue_add_by_queryafteritemid(&qp, status.item_id);
   else
-    ret = db_queue_add_by_query(&qp, status.shuffle, status.item_id);
+    ret = db_queue_add_by_query(&qp, status.shuffle, status.item_id, -1, NULL, NULL);
 
   if (qp.filter)
     free(qp.filter);
@@ -1446,9 +1446,9 @@ dacp_reply_playspec(struct httpd_request *hreq)
   db_queue_clear(0);
 
   if (plid > 0)
-    ret = db_queue_add_by_playlistid(plid, status.shuffle, status.item_id);
+    ret = db_queue_add_by_playlistid(plid, status.shuffle, status.item_id, -1, NULL, NULL);
   else if (id > 0)
-    ret = db_queue_add_by_fileid(id, status.shuffle, status.item_id);
+    ret = db_queue_add_by_fileid(id, status.shuffle, status.item_id, -1, NULL, NULL);
 
   if (ret < 0)
     {

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1559,7 +1559,7 @@ queue_tracks_add_artist(const char *id)
 
   player_get_status(&status);
 
-  ret = db_queue_add_by_query(&query_params, status.shuffle, status.item_id);
+  ret = db_queue_add_by_query(&query_params, status.shuffle, status.item_id, -1, NULL, NULL);
 
   free(query_params.filter);
 
@@ -1582,7 +1582,7 @@ queue_tracks_add_album(const char *id)
 
   player_get_status(&status);
 
-  ret = db_queue_add_by_query(&query_params, status.shuffle, status.item_id);
+  ret = db_queue_add_by_query(&query_params, status.shuffle, status.item_id, -1, NULL, NULL);
 
   free(query_params.filter);
 
@@ -1605,7 +1605,7 @@ queue_tracks_add_track(const char *id)
 
   player_get_status(&status);
 
-  ret = db_queue_add_by_query(&query_params, status.shuffle, status.item_id);
+  ret = db_queue_add_by_query(&query_params, status.shuffle, status.item_id, -1, NULL, NULL);
 
   free(query_params.filter);
 
@@ -1629,7 +1629,7 @@ queue_tracks_add_playlist(const char *id)
 
   player_get_status(&status);
 
-  ret = db_queue_add_by_playlistid(playlist_id, status.shuffle, status.item_id);
+  ret = db_queue_add_by_playlistid(playlist_id, status.shuffle, status.item_id, -1, NULL, NULL);
 
   return ret;
 }

--- a/src/player.c
+++ b/src/player.c
@@ -2111,7 +2111,7 @@ playback_start_id(void *arg, int *retval)
     {
       db_queue_clear(0);
 
-      ret = db_queue_add_by_fileid(cmdarg->id, 0, 0);
+      ret = db_queue_add_by_fileid(cmdarg->id, 0, 0, -1, NULL, NULL);
       if (ret < 0)
 	return COMMAND_END;
 


### PR DESCRIPTION
As a prerequisite for #581, this pr adds the functions to add new queue items into the middle of the queue.
It also adds to new output parameters to the queue add function, count and item-id. This is a preparation to add these information to the JSON API. This information would allow clients to append to the queue and start playback at the first inserted item. The count value is useful to display the number of items added to the queue, e. g. after adding an album.