### PR TITLE
[player] CD-like player behavior: first track + previous == last track

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1363,6 +1363,11 @@ jsonapi_reply_player_next(struct httpd_request *hreq)
   ret = player_playback_next();
   if (ret < 0)
     {
+      struct player_status status;
+      player_get_status(&status);
+      if (status.status == PLAY_STOPPED)
+        return HTTP_NOCONTENT;
+
       DPRINTF(E_LOG, L_WEB, "Error switching to next item.\n");
       return HTTP_INTERNAL;
     }
@@ -1385,6 +1390,11 @@ jsonapi_reply_player_previous(struct httpd_request *hreq)
   ret = player_playback_prev();
   if (ret < 0)
     {
+      struct player_status status;
+      player_get_status(&status);
+      if (status.status == PLAY_STOPPED)
+        return HTTP_NOCONTENT;
+
       DPRINTF(E_LOG, L_WEB, "Error switching to previous item.\n");
       return HTTP_INTERNAL;
     }

--- a/src/player.c
+++ b/src/player.c
@@ -923,7 +923,22 @@ source_prev()
 
   queue_item = db_queue_fetch_prev(cur_streaming->item_id, shuffle);
   if (!queue_item)
-    return NULL;
+    {
+      int queue_count;
+      int pos = db_queue_get_pos(cur_streaming->item_id, 0);
+
+      // do we have no prev item because we're the first item?
+      if ( pos != 0)
+        return NULL;
+
+      queue_count = db_queue_get_count();
+      if (queue_count < 0)
+        return NULL;
+
+      queue_item = db_queue_fetch_bypos(queue_count-1, shuffle);
+      if (!queue_item)
+        return NULL;
+    }
 
   ps = source_new(queue_item);
   free_queue_item(queue_item, 0);

--- a/src/player.c
+++ b/src/player.c
@@ -925,7 +925,7 @@ source_prev()
   if (!queue_item)
     {
       int queue_count;
-      int pos = db_queue_get_pos(cur_streaming->item_id, 0);
+      int pos = db_queue_get_pos(cur_streaming->item_id, shuffle);
 
       // do we have no prev item because we're the first item?
       if ( pos != 0)


### PR DESCRIPTION
Player interface will report `internal error` when the queue item is _first track_ and user selects _previous_.

In nearly all CD/DVD/... interfaces, when on _track1_ and _previous_ is requested, the player skips to the _last track_ (wraps it around) of the disk.  Similar comment for when on the _last track_: _next_ skips to _first track_.  Behavior is irrelevant of _repeat all_ status.

This PR implements this behavior for when player is in _paused_ state.


The behavior in player is subtly different when player is _stopped_ vs _paused_: when _stopped_ the track is NOT skipped.  The `command_exec_sync` with the _top half_ and _bottom half_ functions split the actual work; the _top half_ function checks state of player and if stopped it kicks out which means the jsonapi needs to also check if a non-success is because the play state == STOPPED.  This will allow the jsonapi to not return HTTP_INTERNAL error.