### PR TITLE
Display composer on Now Playing page

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -1715,6 +1715,7 @@ curl --include \
 | album_sort         | string   | Album sort name                           |
 | album_artist       | string   | Album artist name                         |
 | album_artist_sort  | string   | Album artist sort name                    |
+| composer           | string   | Composer (optional)                       |
 | genre              | string   | Genre                                     |
 | year               | integer  | Release year                              |
 | track_number       | integer  | Track number                              |
@@ -1778,6 +1779,7 @@ curl --include \
 | album_artist       | string   | Album artist name                         |
 | album_artist_sort  | string   | Album artist sort name                    |
 | album_artist_id    | string   | Album artist id                           |
+| composer           | string   | Track composer                            |
 | genre              | string   | Genre                                     |
 | year               | integer  | Release year                              |
 | track_number       | integer  | Track number                              |

--- a/src/db.c
+++ b/src/db.c
@@ -610,6 +610,7 @@ free_queue_item(struct db_queue_item *queue_item, int content_only)
   free(queue_item->title);
   free(queue_item->artist);
   free(queue_item->album_artist);
+  free(queue_item->composer);
   free(queue_item->album);
   free(queue_item->genre);
   free(queue_item->artist_sort);
@@ -4631,13 +4632,13 @@ queue_add_file(struct db_media_file_info *dbmfi, int pos, int shuffle_pos, int q
 #define Q_TMPL "INSERT INTO queue "							\
 		    "(id, file_id, song_length, data_kind, media_kind, "		\
 		    "pos, shuffle_pos, path, virtual_path, title, "			\
-		    "artist, album_artist, album, genre, songalbumid, "			\
+		    "artist, composer, album_artist, album, genre, songalbumid, "	\
 		    "time_modified, artist_sort, album_sort, album_artist_sort, year, "	\
 		    "track, disc, queue_version)" 					\
 		"VALUES"                                           			\
 		    "(NULL, %s, %s, %s, %s, "						\
 		    "%d, %d, %Q, %Q, %Q, "						\
-		    "%Q, %Q, %Q, %Q, %s, "						\
+		    "%Q, %Q, %Q, %Q, %Q, %s, "						\
 		    "%s, %Q, %Q, %Q, %s, "						\
 		    "%s, %s, %d);"
 
@@ -4647,7 +4648,7 @@ queue_add_file(struct db_media_file_info *dbmfi, int pos, int shuffle_pos, int q
   query = sqlite3_mprintf(Q_TMPL,
 			  dbmfi->id, dbmfi->song_length, dbmfi->data_kind, dbmfi->media_kind,
 			  pos, shuffle_pos, dbmfi->path, dbmfi->virtual_path, dbmfi->title,
-			  dbmfi->artist, dbmfi->album_artist, dbmfi->album, dbmfi->genre, dbmfi->songalbumid,
+			  dbmfi->artist, dbmfi->composer, dbmfi->album_artist, dbmfi->album, dbmfi->genre, dbmfi->songalbumid,
 			  dbmfi->time_modified, dbmfi->artist_sort, dbmfi->album_sort, dbmfi->album_artist_sort, dbmfi->year,
 			  dbmfi->track, dbmfi->disc, queue_version);
   ret = db_query_run(query, 1, 0);
@@ -4663,13 +4664,13 @@ queue_add_item(struct db_queue_item *item, int pos, int shuffle_pos, int queue_v
 #define Q_TMPL "INSERT INTO queue "							\
 		    "(id, file_id, song_length, data_kind, media_kind, "		\
 		    "pos, shuffle_pos, path, virtual_path, title, "			\
-		    "artist, album_artist, album, genre, songalbumid, "			\
+		    "artist, composer, album_artist, album, genre, songalbumid, "       \
 		    "time_modified, artist_sort, album_sort, album_artist_sort, year, "	\
 		    "track, disc, queue_version)" 					\
 		"VALUES"                                           			\
 		    "(NULL, %d, %d, %d, %d, "						\
 		    "%d, %d, %Q, %Q, %Q, "						\
-		    "%Q, %Q, %Q, %Q, %" PRIi64 ", "					\
+		    "%Q, %Q, %Q, %Q, %Q, %" PRIi64 ", "					\
 		    "%d, %Q, %Q, %Q, %d, "						\
 		    "%d, %d, %d);"
 
@@ -4679,7 +4680,7 @@ queue_add_item(struct db_queue_item *item, int pos, int shuffle_pos, int queue_v
   query = sqlite3_mprintf(Q_TMPL,
 			  item->file_id, item->song_length, item->data_kind, item->media_kind,
 			  pos, shuffle_pos, item->path, item->virtual_path, item->title,
-			  item->artist, item->album_artist, item->album, item->genre, item->songalbumid,
+			  item->artist, item->composer, item->album_artist, item->album, item->genre, item->songalbumid,
 			  item->time_modified, item->artist_sort, item->album_sort, item->album_artist_sort, item->year,
 			  item->track, item->disc, queue_version);
   ret = db_query_run(query, 1, 0);
@@ -4696,6 +4697,7 @@ db_queue_update_item(struct db_queue_item *qi)
 		    "file_id = %d, song_length = %d, data_kind = %d, media_kind = %d, "	\
 		    "pos = %d, shuffle_pos = %d, path = '%q', virtual_path = %Q, "	\
 		    "title = %Q, artist = %Q, album_artist = %Q, album = %Q, "		\
+		    "composer = %Q,"                                                    \
 		    "genre = %Q, songalbumid = %" PRIi64 ", time_modified = %d, "	\
 		    "artist_sort = %Q, album_sort = %Q, album_artist_sort = %Q, "	\
 		    "year = %d, track = %d, disc = %d, artwork_url = %Q, "		\
@@ -4712,6 +4714,7 @@ db_queue_update_item(struct db_queue_item *qi)
 			  qi->file_id, qi->song_length, qi->data_kind, qi->media_kind,
 			  qi->pos, qi->shuffle_pos, qi->path, qi->virtual_path,
 			  qi->title, qi->artist, qi->album_artist, qi->album,
+                          qi->composer,
 			  qi->genre, qi->songalbumid, qi->time_modified,
 			  qi->artist_sort, qi->album_sort, qi->album_artist_sort,
 			  qi->year, qi->track, qi->disc, qi->artwork_url, queue_version,
@@ -5103,6 +5106,7 @@ queue_enum_fetch(struct query_params *qp, struct db_queue_item *queue_item, int 
   queue_item->track = sqlite3_column_int(qp->stmt, 20);
   queue_item->disc = sqlite3_column_int(qp->stmt, 21);
   queue_item->artwork_url = strdup_if((char *)sqlite3_column_text(qp->stmt, 22), keep_item);
+  queue_item->composer = strdup_if((char *)sqlite3_column_text(qp->stmt, 24), keep_item);
 
   return 0;
 }

--- a/src/db.h
+++ b/src/db.h
@@ -452,6 +452,7 @@ struct db_queue_item
   char *title;
   char *artist;
   char *album_artist;
+  char *composer;
   char *album;
   char *genre;
 

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -189,7 +189,8 @@
   "   track               INTEGER DEFAULT 0,"				\
   "   disc                INTEGER DEFAULT 0,"				\
   "   artwork_url         VARCHAR(4096) DEFAULT NULL,"			\
-  "   queue_version       INTEGER DEFAULT 0"				\
+  "   queue_version       INTEGER DEFAULT 0,"				\
+  "   composer            VARCHAR(1024) DEFAULT NULL"			\
   ");"
 
 #define TRG_GROUPS_INSERT_FILES						\

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * forked-daapd after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 19
-#define SCHEMA_VERSION_MINOR 10
+#define SCHEMA_VERSION_MINOR 11
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1681,6 +1681,22 @@ static const struct db_upgrade_query db_upgrade_v1910_queries[] =
     { U_V1910_SCVER_MINOR,    "set schema_version_minor to 10" },
   };
 
+#define U_v1911_ALTER_QUEUE_ADD_COMPOSER \
+  "ALTER TABLE queue ADD COLUMN composer VARCHAR(1024) DEFAULT NULL;"
+
+#define U_v1911_SCVER_MAJOR			\
+  "UPDATE admin SET value = '19' WHERE key = 'schema_version_major';"
+#define U_v1911_SCVER_MINOR			\
+  "UPDATE admin SET value = '11' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v1911_queries[] =
+  {
+    { U_v1911_ALTER_QUEUE_ADD_COMPOSER,   "alter table queue add column composer" },
+
+    { U_v1911_SCVER_MAJOR,    "set schema_version_major to 19" },
+    { U_v1911_SCVER_MINOR,    "set schema_version_minor to 11" },
+  };
+
 
 int
 db_upgrade(sqlite3 *hdl, int db_ver)
@@ -1859,6 +1875,13 @@ db_upgrade(sqlite3 *hdl, int db_ver)
 
     case 1909:
       ret = db_generic_upgrade(hdl, db_upgrade_v1910_queries, ARRAY_SIZE(db_upgrade_v1910_queries));
+      if (ret < 0)
+	return -1;
+
+      /* FALLTHROUGH */
+
+    case 1910:
+      ret = db_generic_upgrade(hdl, db_upgrade_v1911_queries, ARRAY_SIZE(db_upgrade_v1911_queries));
       if (ret < 0)
 	return -1;
       break;

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -190,6 +190,7 @@ track_to_json(struct db_media_file_info *dbmfi)
   safe_json_add_string(item, "album_artist", dbmfi->album_artist);
   safe_json_add_string(item, "album_artist_sort", dbmfi->album_artist_sort);
   safe_json_add_string(item, "album_artist_id", dbmfi->songartistid);
+  safe_json_add_string(item, "composer", dbmfi->composer);
   safe_json_add_string(item, "genre", dbmfi->genre);
   safe_json_add_int_from_string(item, "year", dbmfi->year);
   safe_json_add_int_from_string(item, "track_number", dbmfi->track);
@@ -1534,6 +1535,7 @@ queue_item_to_json(struct db_queue_item *queue_item, char shuffle)
   safe_json_add_string(item, "album_sort", queue_item->album_sort);
   safe_json_add_string(item, "album_artist", queue_item->album_artist);
   safe_json_add_string(item, "album_artist_sort", queue_item->album_artist_sort);
+  safe_json_add_string(item, "composer", queue_item->composer);
   safe_json_add_string(item, "genre", queue_item->genre);
 
   json_object_object_add(item, "year", json_object_new_int(queue_item->year));


### PR DESCRIPTION
Feature request: https://github.com/ejurgensen/forked-daapd/issues/614

Add `composer`to `queue` table and displaying on `Now Playing` page if `composer` is exposed by `httpd_jsonapi`

![composer](https://user-images.githubusercontent.com/18466811/48305113-e47c5a80-e51c-11e8-8a02-8c9ef99b026c.png)