### PR TITLE
Fixes for shuffle mode in player web interface

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -4788,7 +4788,7 @@ db_queue_add_start(struct db_queue_add_info *queue_add_info, int pos)
 }
 
 int
-db_queue_add_end(struct db_queue_add_info *queue_add_info, int ret)
+db_queue_add_end(struct db_queue_add_info *queue_add_info, char reshuffle, uint32_t item_id, int ret)
 {
   char *query;
 
@@ -4798,6 +4798,12 @@ db_queue_add_end(struct db_queue_add_info *queue_add_info, int ret)
       query = sqlite3_mprintf("UPDATE queue SET pos = pos + %d, queue_version = %d WHERE pos >= %d AND queue_version < %d;",
 			      queue_add_info->count, queue_add_info->queue_version, queue_add_info->start_pos, queue_add_info->queue_version);
       ret = db_query_run(query, 1, 0);
+    }
+
+  // Reshuffle after adding new items
+  if (ret == 0 && reshuffle)
+    {
+      ret = queue_reshuffle(item_id, queue_add_info->queue_version);
     }
 
   queue_transaction_end(ret, queue_add_info->queue_version);

--- a/src/db.c
+++ b/src/db.c
@@ -5963,6 +5963,20 @@ db_queue_reshuffle(uint32_t item_id)
   return ret;
 }
 
+/*
+ * Increment queue version (triggers queue change event)
+ */
+int
+db_queue_inc_version()
+{
+  int queue_version;
+
+  queue_version = queue_transaction_begin();
+  queue_transaction_end(0, queue_version);
+
+  return 0;
+}
+
 int
 db_queue_get_count()
 {

--- a/src/db.h
+++ b/src/db.h
@@ -854,6 +854,9 @@ int
 db_queue_reshuffle(uint32_t item_id);
 
 int
+db_queue_inc_version(void);
+
+int
 db_queue_get_count();
 
 int

--- a/src/db.h
+++ b/src/db.h
@@ -794,7 +794,7 @@ int
 db_queue_add_start(struct db_queue_add_info *queue_add_info, int pos);
 
 int
-db_queue_add_end(struct db_queue_add_info *queue_add_info, int ret);
+db_queue_add_end(struct db_queue_add_info *queue_add_info, char reshuffle, uint32_t item_id, int ret);
 
 int
 db_queue_add_item(struct db_queue_add_info *queue_add_info, struct db_queue_item *item);

--- a/src/library.c
+++ b/src/library.c
@@ -145,10 +145,13 @@ library_add_media(struct media_file_info *mfi)
 int
 library_queue_add(const char *path, int position, int *count, int *new_item_id)
 {
+  struct player_status status;
   int i;
   int ret;
 
   DPRINTF(E_DBG, L_LIB, "Add items for path '%s' to the queue\n", path);
+
+  player_get_status(&status);
 
   ret = LIBRARY_PATH_INVALID;
   for (i = 0; sources[i] && ret == LIBRARY_PATH_INVALID; i++)
@@ -159,7 +162,7 @@ library_queue_add(const char *path, int position, int *count, int *new_item_id)
 	  continue;
 	}
 
-      ret = sources[i]->queue_add(path, position, count, new_item_id);
+      ret = sources[i]->queue_add(path, position, status.shuffle, status.item_id, count, new_item_id);
 
       if (ret == LIBRARY_OK)
 	{

--- a/src/library.h
+++ b/src/library.h
@@ -84,7 +84,7 @@ struct library_source
   /*
    * Add item for the given path to the current queue
    */
-  int (*queue_add)(const char *path, int position, int *count, int *new_item_id);
+  int (*queue_add)(const char *path, int position, char reshuffle, uint32_t item_id, int *count, int *new_item_id);
 };
 
 void

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -1676,7 +1676,7 @@ map_media_file_to_queue_item(struct db_queue_item *queue_item, struct media_file
 }
 
 static int
-queue_add_stream(const char *path, int position, int *count, int *new_item_id)
+queue_add_stream(const char *path, int position, char reshuffle, uint32_t item_id, int *count, int *new_item_id)
 {
   struct media_file_info mfi;
   struct db_queue_item item;
@@ -1694,7 +1694,7 @@ queue_add_stream(const char *path, int position, int *count, int *new_item_id)
   if (ret == 0)
     {
       ret = db_queue_add_item(&queue_add_info, &item);
-      ret = db_queue_add_end(&queue_add_info, ret);
+      ret = db_queue_add_end(&queue_add_info, reshuffle, item_id, ret);
       if (ret == 0)
 	{
 	  if (count)
@@ -1711,11 +1711,11 @@ queue_add_stream(const char *path, int position, int *count, int *new_item_id)
 }
 
 static int
-queue_add(const char *uri, int position, int *count, int *new_item_id)
+queue_add(const char *uri, int position, char reshuffle, uint32_t item_id, int *count, int *new_item_id)
 {
   if (strncasecmp(uri, "http://", strlen("http://")) == 0)
     {
-      queue_add_stream(uri, position, count, new_item_id);
+      queue_add_stream(uri, position, reshuffle, item_id, count, new_item_id);
       return LIBRARY_OK;
     }
 

--- a/src/spotify_webapi.c
+++ b/src/spotify_webapi.c
@@ -997,7 +997,7 @@ map_track_to_queueitem(struct db_queue_item *item, const struct spotify_track *t
 }
 
 static int
-queue_add_track(const char *uri, int position, int *count, int *new_item_id)
+queue_add_track(const char *uri, int position, char reshuffle, uint32_t item_id, int *count, int *new_item_id)
 {
   json_object *response;
   struct spotify_track track;
@@ -1019,7 +1019,7 @@ queue_add_track(const char *uri, int position, int *count, int *new_item_id)
   if (ret == 0)
     {
       ret = db_queue_add_item(&queue_add_info, &item);
-      ret = db_queue_add_end(&queue_add_info, ret);
+      ret = db_queue_add_end(&queue_add_info, reshuffle, item_id, ret);
       if (ret == 0)
 	{
 	  if (count)
@@ -1068,7 +1068,7 @@ queue_add_album_tracks(json_object *item, int index, int total, void *arg)
 }
 
 static int
-queue_add_album(const char *uri, int position, int *count, int *new_item_id)
+queue_add_album(const char *uri, int position, char reshuffle, uint32_t item_id, int *count, int *new_item_id)
 {
   char *album_endpoint_uri = NULL;
   char *endpoint_uri = NULL;
@@ -1088,7 +1088,7 @@ queue_add_album(const char *uri, int position, int *count, int *new_item_id)
 
   ret = request_pagingobject_endpoint(endpoint_uri, queue_add_album_tracks, NULL, NULL, true, &param);
 
-  ret = db_queue_add_end(&param.queue_add_info, ret);
+  ret = db_queue_add_end(&param.queue_add_info, reshuffle, item_id, ret);
   if (ret == 0 && count)
     *count = param.queue_add_info.count;
 
@@ -1137,7 +1137,7 @@ queue_add_playlist_tracks(json_object *item, int index, int total, void *arg)
 }
 
 static int
-queue_add_playlist(const char *uri, int position, int *count, int *new_item_id)
+queue_add_playlist(const char *uri, int position, char reshuffle, uint32_t item_id, int *count, int *new_item_id)
 {
   char *endpoint_uri;
   struct db_queue_add_info queue_add_info;
@@ -1151,7 +1151,7 @@ queue_add_playlist(const char *uri, int position, int *count, int *new_item_id)
 
   ret = request_pagingobject_endpoint(endpoint_uri, queue_add_playlist_tracks, NULL, NULL, true, &queue_add_info);
 
-  ret = db_queue_add_end(&queue_add_info, ret);
+  ret = db_queue_add_end(&queue_add_info, reshuffle, item_id, ret);
   if (ret == 0 && count)
     *count = queue_add_info.count;
 
@@ -1161,21 +1161,21 @@ queue_add_playlist(const char *uri, int position, int *count, int *new_item_id)
 }
 
 static int
-queue_add(const char *uri, int position, int *count, int *new_item_id)
+queue_add(const char *uri, int position, char reshuffle, uint32_t item_id, int *count, int *new_item_id)
 {
   if (strncasecmp(uri, "spotify:track:", strlen("spotify:track:")) == 0)
     {
-      queue_add_track(uri, position, count, new_item_id);
+      queue_add_track(uri, position, reshuffle, item_id, count, new_item_id);
       return LIBRARY_OK;
     }
   else if (strncasecmp(uri, "spotify:album:", strlen("spotify:album:")) == 0)
     {
-      queue_add_album(uri, position, count, new_item_id);
+      queue_add_album(uri, position, reshuffle, item_id, count, new_item_id);
       return LIBRARY_OK;
     }
   else if (strncasecmp(uri, "spotify:", strlen("spotify:")) == 0)
     {
-      queue_add_playlist(uri, position, count, new_item_id);
+      queue_add_playlist(uri, position, reshuffle, item_id, count, new_item_id);
       return LIBRARY_OK;
     }
 


### PR DESCRIPTION
Two fixes for errors i noticed in the player web interface (might also affect mpd clients):

- Turning shuffle mode off did not update the queue in the player web interface
- Adding non library items to the queue with shuffle mode on, does not reshuffle the queue