### PR TITLE
[jsonapi] Artwork url for non library items and streams

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -1724,6 +1724,7 @@ curl --include \
 | data_kind          | string   | Data type of this track: `file`, `url`, `spotify`, `pipe` |
 | path               | string   | Path                                      |
 | uri                | string   | Resource identifier                       |
+| artwork_url        | string   | *(optional)* [Artwork url](#artwork-urls) |
 
 
 ### `playlist` object
@@ -1748,6 +1749,7 @@ curl --include \
 | track_count     | integer  | Number of tracks                          |
 | length_ms       | integer  | Total length of tracks in milliseconds    |
 | uri             | string   | Resource identifier                       |
+| artwork_url     | string   | *(optional)* [Artwork url](#artwork-urls) |
 
 
 ### `album` object
@@ -1762,6 +1764,7 @@ curl --include \
 | track_count     | integer  | Number of tracks                          |
 | length_ms       | integer  | Total length of tracks in milliseconds    |
 | uri             | string   | Resource identifier                       |
+| artwork_url     | string   | *(optional)* [Artwork url](#artwork-urls) |
 
 
 ### `track` object
@@ -1792,6 +1795,7 @@ curl --include \
 | data_kind          | string   | Data type of this track: `file`, `stream`, `spotify`, `pipe` |
 | path               | string   | Path                                      |
 | uri                | string   | Resource identifier                       |
+| artwork_url        | string   | *(optional)* [Artwork url](#artwork-urls) |
 
 
 ### `paging` object
@@ -1810,3 +1814,13 @@ curl --include \
 | --------------- | -------- | ----------------------------------------- |
 | name            | string   | Name of genre                             |
 
+
+
+### Artwork urls
+
+Artwork urls in `queue item`, `artist`, `album` and `track` objects can be either relative urls or absolute urls to the artwork image.
+Absolute artwork urls are pointing to external artwork images (e. g. for radio streams that provide artwork metadata), while relative artwork urls are served from forked-daapd. 
+
+It is possible to add the query parameters `maxwidth` and/or `maxheight` to relative artwork urls, in order to get a smaller image (forked-daapd only scales down never up).
+
+Note that even if a relative artwork url attribute is present, it is not guaranteed to exist.

--- a/src/artwork.h
+++ b/src/artwork.h
@@ -5,6 +5,9 @@
 #define ART_FMT_PNG     1
 #define ART_FMT_JPEG    2
 
+#define ART_DEFAULT_HEIGHT 600
+#define ART_DEFAULT_WIDTH  600
+
 #include <event2/buffer.h>
 
 /*

--- a/src/db.c
+++ b/src/db.c
@@ -4665,13 +4665,13 @@ queue_add_item(struct db_queue_item *item, int pos, int shuffle_pos, int queue_v
 		    "pos, shuffle_pos, path, virtual_path, title, "			\
 		    "artist, album_artist, album, genre, songalbumid, "			\
 		    "time_modified, artist_sort, album_sort, album_artist_sort, year, "	\
-		    "track, disc, queue_version)" 					\
+		    "track, disc, artwork_url, queue_version)" 				\
 		"VALUES"                                           			\
 		    "(NULL, %d, %d, %d, %d, "						\
 		    "%d, %d, %Q, %Q, %Q, "						\
 		    "%Q, %Q, %Q, %Q, %" PRIi64 ", "					\
 		    "%d, %Q, %Q, %Q, %d, "						\
-		    "%d, %d, %d);"
+		    "%d, %d, %Q, %d);"
 
   char *query;
   int ret;
@@ -4681,7 +4681,7 @@ queue_add_item(struct db_queue_item *item, int pos, int shuffle_pos, int queue_v
 			  pos, shuffle_pos, item->path, item->virtual_path, item->title,
 			  item->artist, item->album_artist, item->album, item->genre, item->songalbumid,
 			  item->time_modified, item->artist_sort, item->album_sort, item->album_artist_sort, item->year,
-			  item->track, item->disc, queue_version);
+			  item->track, item->disc, item->artwork_url, queue_version);
   ret = db_query_run(query, 1, 0);
 
   return ret;

--- a/src/http.c
+++ b/src/http.c
@@ -639,7 +639,7 @@ metadata_packet_get(struct http_icy_metadata *metadata, AVFormatContext *fmtctx)
 	  else
 	    metadata->title = strdup(metadata->title);
 	}
-      else if ((strncmp(icy_token, "StreamUrl", strlen("StreamUrl")) == 0) && !metadata->artwork_url)
+      else if ((strncmp(icy_token, "StreamUrl", strlen("StreamUrl")) == 0) && !metadata->artwork_url && strlen(ptr) > 0)
 	{
 	  metadata->artwork_url = strdup(ptr);
 	}

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1525,7 +1525,8 @@ queue_item_to_json(struct db_queue_item *queue_item, char shuffle)
   else
     json_object_object_add(item, "position", json_object_new_int(queue_item->pos));
 
-  json_object_object_add(item, "track_id", json_object_new_int(queue_item->file_id));
+  if (queue_item->file_id > 0 && queue_item->file_id != DB_MEDIA_FILE_NON_PERSISTENT_ID)
+    json_object_object_add(item, "track_id", json_object_new_int(queue_item->file_id));
 
   safe_json_add_string(item, "title", queue_item->title);
   safe_json_add_string(item, "artist", queue_item->artist);
@@ -1546,20 +1547,26 @@ queue_item_to_json(struct db_queue_item *queue_item, char shuffle)
 
   safe_json_add_string(item, "path", queue_item->path);
 
-  if (queue_item->file_id > 0)
+  if (queue_item->file_id > 0 && queue_item->file_id != DB_MEDIA_FILE_NON_PERSISTENT_ID)
     {
       ret = snprintf(uri, sizeof(uri), "%s:%s:%d", "library", "track", queue_item->file_id);
       if (ret < sizeof(uri))
 	json_object_object_add(item, "uri", json_object_new_string(uri));
-
-      ret = snprintf(artwork_url, sizeof(artwork_url), "/artwork/item/%d", queue_item->file_id);
-      if (ret < sizeof(artwork_url))
-	json_object_object_add(item, "artwork_url", json_object_new_string(artwork_url));
     }
   else
     {
       safe_json_add_string(item, "uri", queue_item->path);
+    }
+
+  if (queue_item->artwork_url)
+    {
       safe_json_add_string(item, "artwork_url", queue_item->artwork_url);
+    }
+  else if (queue_item->file_id > 0 && queue_item->file_id != DB_MEDIA_FILE_NON_PERSISTENT_ID)
+    {
+      ret = snprintf(artwork_url, sizeof(artwork_url), "/artwork/item/%d", queue_item->file_id);
+      if (ret < sizeof(artwork_url))
+	json_object_object_add(item, "artwork_url", json_object_new_string(artwork_url));
     }
 
   return item;

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4702,7 +4702,7 @@ artwork_cb(struct evhttp_request *req, void *arg)
       return;
     }
 
-  format = artwork_get_item(evbuffer, itemid, 600, 600);
+  format = artwork_get_item(evbuffer, itemid, ART_DEFAULT_WIDTH, ART_DEFAULT_HEIGHT);
   if (format < 0)
     {
       httpd_send_error(req, HTTP_NOTFOUND, "Document was not found");

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -879,7 +879,7 @@ raop_metadata_prepare(int id)
       goto skip_artwork;
     }
 
-  ret = artwork_get_item(rmd->artwork, queue_item->file_id, 600, 600);
+  ret = artwork_get_item(rmd->artwork, queue_item->file_id, ART_DEFAULT_WIDTH, ART_DEFAULT_HEIGHT);
   if (ret < 0)
     {
       DPRINTF(E_INFO, L_RAOP, "Failed to retrieve artwork for file id %d; no artwork will be sent\n", id);


### PR DESCRIPTION
This pr fixes wrong artwork urls for items in the queue, that are not in the local library or are streams that support artwork as metadata. The later is an assumption based on the code and not (yet) tested. @ejurgensen could you point me to a radio stream that supports artwork? The ones in my library do not seem to provide artwork metadata.

Another change included in this pr is, that spotify queue items, that are not part of the library, now provide an artwork url (taken from the spotify web api).