### PR TITLE
[artwork] Missing playlist image for radio streams without icy artwork in the web interface

### DIFF
--- a/src/artwork.c
+++ b/src/artwork.c
@@ -954,9 +954,6 @@ process_items(struct artwork_ctx *ctx, int item_mode)
       if (!ctx->persistentid)
 	safe_atoi64(dbmfi.songalbumid, &ctx->persistentid);
 
-      if (item_mode && !ctx->individual)
-	goto no_artwork;
-
       ret = (safe_atoi32(dbmfi.id, &ctx->id) < 0) ||
             (safe_atou32(dbmfi.data_kind, &data_kind) < 0) ||
             (data_kind > 30);
@@ -965,6 +962,9 @@ process_items(struct artwork_ctx *ctx, int item_mode)
 	  DPRINTF(E_LOG, L_ART, "Error converting dbmfi id or data_kind to number\n");
 	  continue;
 	}
+
+      if (item_mode && !ctx->individual && data_kind != DATA_KIND_HTTP)
+	goto no_artwork;
 
       for (i = 0; artwork_item_source[i].handler; i++)
 	{


### PR DESCRIPTION
I am not sure if this is the right way to fix it. The problem is, that the artwork url for the queue item does not return the playlist artwork file for radio streams.

It feels a bit hacky to just override the "individual artwork" config value for streams and maybe the better way would be to add a `artwork_group_source`?