### PR TITLE
[travis-ci] Update build environment to Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 sudo: required
-dist: trusty
+dist: xenial
 env:
   matrix:
     - CFG="--disable-verification"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: required
 dist: trusty
 env:
   matrix:
-    - CFG="--disable-websocket --disable-webinterface --disable-verification"
-    - CFG="--disable-websocket --disable-webinterface --enable-lastfm --disable-verification"
-    - CFG="--disable-websocket --disable-webinterface --enable-spotify --disable-verification"
-    - CFG="--disable-websocket --disable-webinterface --enable-chromecast --disable-verification"
-    - CFG="--disable-websocket --disable-webinterface --with-pulseaudio --disable-verification"
+    - CFG="--disable-verification"
+    - CFG="--enable-lastfm --disable-verification"
+    - CFG="--enable-spotify --disable-verification"
+    - CFG="--enable-chromecast --disable-verification"
+    - CFG="--with-pulseaudio --disable-verification"
 
 script:
   - autoreconf -fi
@@ -20,7 +20,14 @@ before_install:
   - wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
   - sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/jessie.list
   - sudo apt-get -qq update
-  - sudo apt-get install -y build-essential clang git autotools-dev autoconf libtool gettext gawk gperf antlr3 libantlr3c-dev libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libmxml-dev libgcrypt11-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libcurl4-openssl-dev libjson-c-dev libspotify-dev libgnutls-dev libprotobuf-c0-dev libpulse-dev
+  - sudo apt-get install -y build-essential clang git autotools-dev autoconf libtool gettext gawk gperf antlr3 libantlr3c-dev libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libmxml-dev libgcrypt11-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libcurl4-openssl-dev libjson-c-dev libspotify-dev libgnutls-dev libprotobuf-c0-dev libpulse-dev cmake
+  - wget -q -O - https://github.com/warmcat/libwebsockets/archive/v2.0.3.tar.gz | tar -xvzf -
+  - mkdir ./libwebsockets-2.0.3/build
+  - cd ./libwebsockets-2.0.3/build
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
+  - make
+  - sudo make install
+  - cd ../..
   
 # Disable email notification
 notifications:

--- a/src/db.c
+++ b/src/db.c
@@ -970,7 +970,7 @@ fixup_tags_queue_item(struct db_queue_item *queue_item)
       queue_item->album_artist = strdup(queue_item->artist);
     }
 
-  if (!queue_item->album_artist_sort && (strcmp(queue_item->album_artist, queue_item->artist) == 0))
+  if (!queue_item->album_artist_sort && queue_item->artist_sort && (strcmp(queue_item->album_artist, queue_item->artist) == 0))
     queue_item->album_artist_sort = strdup(queue_item->artist_sort);
   else
     sort_tag_create(&queue_item->album_artist_sort, queue_item->album_artist);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -72,7 +72,9 @@ db_drop_indices(sqlite3 *hdl)
       DPRINTF(E_LOG, L_DB, "Could not step: %s\n", sqlite3_errmsg(hdl));
 
       sqlite3_finalize(stmt);
-      return -1;
+
+      ret = -1;
+      goto out;
     }
 
   sqlite3_finalize(stmt);
@@ -80,7 +82,6 @@ db_drop_indices(sqlite3 *hdl)
   for (i = 0; i < n; i++)
     {
       query = sqlite3_mprintf(Q_TMPL, index[i]);
-      free(index[i]);
 
       DPRINTF(E_DBG, L_DB, "Running query '%s'\n", query);
 
@@ -90,13 +91,19 @@ db_drop_indices(sqlite3 *hdl)
 	  DPRINTF(E_LOG, L_DB, "DB error while running '%s': %s\n", query, errmsg);
 
 	  sqlite3_free(errmsg);
-	  return -1;
+	  sqlite3_free(query);
+
+	  ret = -1;
+	  goto out;
 	}
 
       sqlite3_free(query);
     }
 
-  return 0;
+ out:
+  for (i = 0; i < n; i++)
+    free(index[i]);
+  return ret;
 #undef Q_TMPL
 #undef Q_INDEX
 }

--- a/src/evrtsp/rtsp.c
+++ b/src/evrtsp/rtsp.c
@@ -1319,6 +1319,7 @@ evrtsp_connection_get_local_address(struct evrtsp_connection *evcon,
 
   *address = NULL;
   *port = 0;
+  memset(&addr, 0, sizeof(addr));
 
   if (!evrtsp_connected(evcon))
     return;
@@ -1333,7 +1334,7 @@ evrtsp_connection_get_local_address(struct evrtsp_connection *evcon,
   if (!*address)
     return;
 
-  *family = addr.ss.ss_family;
+  *family = addr.sa.sa_family;
 
   switch (*family)
     {

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -1707,6 +1707,9 @@ daap_reply_groups(struct httpd_request *hreq)
       for (i = 0; i < nmeta; i++)
 	{
 	  df = meta[i];
+	  if (!df)
+	    continue;
+
 	  dfm = df->dfm;
 
 	  /* dmap.itemcount - always added */

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -417,7 +417,7 @@ parse_item(struct input_metadata *m, const char *item)
       if (data != &progress && data != &volume)
 	free(*data);
 
-      *data = b64_decode(s);
+      CHECK_NULL(L_PLAYER, *data = b64_decode(s));
 
       DPRINTF(E_DBG, L_PLAYER, "Read Shairport metadata (type=%8x, code=%8x): '%s'\n", type, code, *data);
 

--- a/src/library/filescanner_ffmpeg.c
+++ b/src/library/filescanner_ffmpeg.c
@@ -388,16 +388,17 @@ scan_metadata_ffmpeg(const char *file, struct media_file_info *mfi)
       return -1;
     }
 
-  free(path);
-
   ret = avformat_find_stream_info(ctx, NULL);
   if (ret < 0)
     {
       DPRINTF(E_WARN, L_SCAN, "Cannot get stream info of '%s': %s\n", path, err2str(ret));
 
       avformat_close_input(&ctx);
+      free(path);
       return -1;
     }
+
+  free(path);
 
 #if 0
   /* Dump input format as determined by ffmpeg */

--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -622,7 +622,7 @@ buffer_write(struct alsa_session *as, uint8_t *buf, snd_pcm_sframes_t *avail, in
 
   nsamp = AIRTUNES_V2_PACKET_SAMPLES;
 
-  if (prebuffering || !prebuf_empty || *avail < AIRTUNES_V2_PACKET_SAMPLES)
+  if (as->prebuf && (prebuffering || !prebuf_empty || *avail < AIRTUNES_V2_PACKET_SAMPLES))
     {
       pkt = &as->prebuf[as->prebuf_head * PACKET_SIZE];
 

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -4730,7 +4730,7 @@ raop_device_cb(const char *name, const char *type, const char *domain, const cha
   p = keyval_get(txt, "et");
   if (p)
     {
-      et = strdup(p);
+      CHECK_NULL(L_RAOP, et = strdup(p));
       token = strtok_r(et, ",", &ptr);
       while (token)
 	{

--- a/src/player.c
+++ b/src/player.c
@@ -2033,6 +2033,7 @@ playback_start_item(void *arg, int *retval)
       if (ret < 0)
 	{
 	  playback_abort();
+	  source_free(ps);
 	  *retval = -1;
 	  return COMMAND_END;
 	}


### PR DESCRIPTION
The xenial build environment is available in travis-ci (https://blog.travis-ci.com/2018-11-08-xenial-release).
Unfortunately the libwebsocket-dev version in xenial is still to old to build with websockets enabled. 
But the new scanbuild version finds some new issues. I fixed 3 of them and i think the others might be false positives. @ejurgensen it would be good if you too can take a look at them.