### PR TITLE
[jsonapi] Allow adding items by query language to the queue (plus some small fixes)

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -582,9 +582,12 @@ POST /api/queue/items/add
 
 | Parameter       | Value                                                       |
 | --------------- | ----------------------------------------------------------- |
-| uris            | Comma seperated list of resource identifiers (`track`, `playlist`, `artist` or `album` object `uri`) |
-| expression      | A smart playlist query expression identifying the tracks that will be added to the queue.                |
-| position        | *(Optional)* If a position is given, new items are inserted starting from this position into the queue.  |
+| uris            | Comma seperated list of resource identifiers (`track`, `playlist`, `artist` or `album` object `uri`)           |
+| expression      | A smart playlist query expression identifying the tracks that will be added to the queue.                          |
+| position        | *(Optional)* If a position is given, new items are inserted starting from this position into the queue.            |
+| playback        | *(Optional)* If the `playback` parameter is set to `start`, playback will be started after adding the new items. |
+| clear           | *(Optional)* If the `clear` parameter is set to `true`, the queue will be cleared before adding the new items.    |
+| shuffle         | *(Optional)* If the `shuffle` parameter is set to `true`, the shuffle mode is activated. If it is set to something else, the shuffle mode is deactivated. To leave the shuffle mode untouched the parameter should be ommited.    |
 
 Either the `uris` or the `expression` parameter must be set. If both are set the `uris` parameter takes presedence and the `expression` parameter will be ignored.
 

--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -583,7 +583,10 @@ POST /api/queue/items/add
 | Parameter       | Value                                                       |
 | --------------- | ----------------------------------------------------------- |
 | uris            | Comma seperated list of resource identifiers (`track`, `playlist`, `artist` or `album` object `uri`) |
+| expression      | A smart playlist query expression identifying the tracks that will be added to the queue.                |
 | position        | *(Optional)* If a position is given, new items are inserted starting from this position into the queue.  |
+
+Either the `uris` or the `expression` parameter must be set. If both are set the `uris` parameter takes presedence and the `expression` parameter will be ignored.
 
 **Response**
 
@@ -596,8 +599,22 @@ On success returns the HTTP `200 OK` success status response code.
 
 **Example**
 
+Add new items by uri:
+
 ```shell
 curl -X POST "http://localhost:3689/api/queue/items/add?uris=library:playlist:68,library:artist:2932599850102967727"
+```
+
+```json
+{
+  "count": 42
+}
+```
+
+Add new items by query language:
+
+```shell
+curl -X POST "http://localhost:3689/api/queue/items/add?expression=media_kind+is+music"
 ```
 
 ```json

--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -1795,6 +1795,7 @@ will send a message each time one of the events occurred.
 | Type            | Description                               |
 | --------------- | ----------------------------------------- |
 | update          | Library update started or finished        |
+| database        | Library database changed (new/modified/deleted tracks)  |
 | outputs         | An output was enabled or disabled         |
 | player          | Player state changes                      |
 | options         | Playback option changes (shuffle, repeat, consume mode) |

--- a/src/http.c
+++ b/src/http.c
@@ -597,6 +597,7 @@ metadata_packet_get(struct http_icy_metadata *metadata, AVFormatContext *fmtctx)
 {
   uint8_t *buffer;
   char *icy_token;
+  char *save_pr;
   char *ptr;
   char *end;
 
@@ -604,13 +605,13 @@ metadata_packet_get(struct http_icy_metadata *metadata, AVFormatContext *fmtctx)
   if (!buffer)
     return -1;
 
-  icy_token = strtok((char *)buffer, ";");
+  icy_token = strtok_r((char *)buffer, ";", &save_pr);
   while (icy_token != NULL)
     {
       ptr = strchr(icy_token, '=');
       if (!ptr || (ptr[1] == '\0'))
 	{
-	  icy_token = strtok(NULL, ";");
+	  icy_token = strtok_r(NULL, ";", &save_pr);
 	  continue;
 	}
 
@@ -647,7 +648,7 @@ metadata_packet_get(struct http_icy_metadata *metadata, AVFormatContext *fmtctx)
       if (end)
 	*end = '\'';
 
-      icy_token = strtok(NULL, ";");
+      icy_token = strtok_r(NULL, ";", &save_pr);
     }
   av_free(buffer);
 
@@ -663,6 +664,7 @@ metadata_header_get(struct http_icy_metadata *metadata, AVFormatContext *fmtctx)
   uint8_t *buffer;
   uint8_t *utf;
   char *icy_token;
+  char *save_pr;
   char *ptr;
 
   av_opt_get(fmtctx, "icy_metadata_headers", AV_OPT_SEARCH_CHILDREN, &buffer);
@@ -677,13 +679,13 @@ metadata_header_get(struct http_icy_metadata *metadata, AVFormatContext *fmtctx)
   if (!utf)
     return -1;
 
-  icy_token = strtok((char *)utf, "\r\n");
+  icy_token = strtok_r((char *)utf, "\r\n", &save_pr);
   while (icy_token != NULL)
     {
       ptr = strchr(icy_token, ':');
       if (!ptr || (ptr[1] == '\0'))
 	{
-	  icy_token = strtok(NULL, "\r\n");
+	  icy_token = strtok_r(NULL, "\r\n", &save_pr);
 	  continue;
 	}
 
@@ -698,7 +700,7 @@ metadata_header_get(struct http_icy_metadata *metadata, AVFormatContext *fmtctx)
       else if ((strncmp(icy_token, "icy-genre", strlen("icy-genre")) == 0) && !metadata->genre)
 	metadata->genre = strdup(ptr);
 
-      icy_token = strtok(NULL, "\r\n");
+      icy_token = strtok_r(NULL, "\r\n", &save_pr);
     }
   free(utf);
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1762,6 +1762,12 @@ queue_tracks_add_byuris(const char *param, int pos, int *total_count)
 
   *total_count = 0;
 
+  if (strlen(param) == 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "Empty query parameter 'uris'\n");
+      return -1;
+    }
+
   uris = strdup(param);
   uri = strtok(uris, ",");
 
@@ -3254,6 +3260,9 @@ jsonapi_request(struct evhttp_request *req, struct httpd_uri_parsed *uri_parsed)
   CHECK_NULL(L_WEB, hreq->reply = evbuffer_new());
 
   status_code = hreq->handler(hreq);
+
+  if (status_code >= 400)
+    DPRINTF(E_LOG, L_WEB, "JSON api request failed with error code %d (%s)\n", status_code, uri_parsed->uri);
 
   switch (status_code)
     {

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1335,6 +1335,13 @@ play_item_with_id(const char *param)
   ret = player_playback_start_byitem(queue_item);
   free_queue_item(queue_item, 0);
 
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "Failed to start playback from item with id '%d'\n", item_id);
+
+      return HTTP_INTERNAL;
+    }
+
   return HTTP_NOCONTENT;
 }
 
@@ -1367,6 +1374,13 @@ play_item_at_position(const char *param)
   player_playback_stop();
   ret = player_playback_start_byitem(queue_item);
   free_queue_item(queue_item, 0);
+
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_WEB, "Failed to start playback from position '%d'\n", position);
+
+      return HTTP_INTERNAL;
+    }
 
   return HTTP_NOCONTENT;
 }

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1756,20 +1756,22 @@ queue_tracks_add_byuris(const char *param, int pos, int *total_count)
 {
   char *uris;
   char *uri;
+  char *ptr;
   const char *id;
   int count = 0;
   int ret = 0;
 
   *total_count = 0;
 
-  if (strlen(param) == 0)
+  CHECK_NULL(L_WEB, uris = strdup(param));
+  uri = strtok_r(uris, ",", &ptr);
+
+  if (!uri)
     {
       DPRINTF(E_LOG, L_WEB, "Empty query parameter 'uris'\n");
+      free(uris);
       return -1;
     }
-
-  uris = strdup(param);
-  uri = strtok(uris, ",");
 
   do
     {
@@ -1811,7 +1813,7 @@ queue_tracks_add_byuris(const char *param, int pos, int *total_count)
 
       *total_count += count;
     }
-  while ((uri = strtok(NULL, ",")));
+  while ((uri = strtok_r(NULL, ",", &ptr)));
 
   free(uris);
 

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -129,6 +129,10 @@ process_notify_request(struct ws_session_data_notify *session_data, void *in, si
 		{
 		  session_data->events |= LISTENER_UPDATE;
 		}
+	      else if (0 == strcmp(event_type, "database"))
+		{
+		  session_data->events |= LISTENER_DATABASE;
+		}
 	      else if (0 == strcmp(event_type, "pairing"))
 		{
 		  session_data->events |= LISTENER_PAIRING;
@@ -192,6 +196,10 @@ send_notify_reply(short events, struct lws* wsi)
   if (events & LISTENER_UPDATE)
     {
       json_object_array_add(notify, json_object_new_string("update"));
+    }
+  if (events & LISTENER_DATABASE)
+    {
+      json_object_array_add(notify, json_object_new_string("database"));
     }
   if (events & LISTENER_PAIRING)
     {
@@ -306,7 +314,7 @@ static struct lws_protocols protocols[] =
 static void *
 websocket(void *arg)
 {
-  listener_add(listener_cb, LISTENER_UPDATE | LISTENER_PAIRING | LISTENER_SPOTIFY | LISTENER_LASTFM | LISTENER_SPEAKER
+  listener_add(listener_cb, LISTENER_UPDATE | LISTENER_DATABASE | LISTENER_PAIRING | LISTENER_SPOTIFY | LISTENER_LASTFM | LISTENER_SPEAKER
 	       | LISTENER_PLAYER | LISTENER_OPTIONS | LISTENER_VOLUME | LISTENER_QUEUE);
 
   while(!ws_exit)


### PR DESCRIPTION
- Allow adding new items to the queue by query language, add new optional parameters to start playback after adding new items (closes #641)
- Fix ordering of tracks in `library/files` endpoint
- Fix segfault if an empty `uris` parameter is passed to `queue/items/add` endpoint
- Include configured library directories in `config` endpoint
- Add missing "database" notification to `websocket.c`