### PR TITLE
Support for shairport-meta artwork

### DIFF
--- a/src/artwork_legacy.c
+++ b/src/artwork_legacy.c
@@ -183,6 +183,12 @@ static struct artwork_source artwork_item_source[] =
       .cache = ON_FAILURE,
     },
     {
+      .name = "pipe",
+      .handler = source_item_own_get,
+      .data_kinds = (1 << DATA_KIND_PIPE),
+      .cache = NEVER,
+    },
+    {
       .name = "embedded",
       .handler = source_item_embedded_get,
       .data_kinds = (1 << DATA_KIND_FILE),


### PR DESCRIPTION
Not sure if this is the best implementation of this, but it works. I have not spent a huge amount of time getting into the internals of forked-daapd. Relates to #456