### PR TITLE
[mpd] Fix segfault

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -56,10 +56,10 @@ char *
 safe_strdup(const char *str);
 
 char *
-safe_asprintf(const char *fmt, ...);
+safe_asprintf(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 int
-safe_snprintf_cat(char *dst, size_t n, const char *fmt, ...);
+safe_snprintf_cat(char *dst, size_t n, const char *fmt, ...) __attribute__ ((format (printf, 3, 4)));
 
 
 /* Key/value functions */

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -2267,7 +2267,7 @@ mpd_command_listplaylist(struct evbuffer *evbuf, int argc, char **argv, char **e
   else
     {
       // Argument is a playlist name, prepend default playlist directory
-      path = safe_asprintf("%s/%s%s", default_pl_dir, argv[1]);
+      path = safe_asprintf("%s/%s", default_pl_dir, argv[1]);
     }
 
   pli = db_pl_fetch_byvirtualpath(path);
@@ -2330,7 +2330,7 @@ mpd_command_listplaylistinfo(struct evbuffer *evbuf, int argc, char **argv, char
   else
     {
       // Argument is a playlist name, prepend default playlist directory
-      path = safe_asprintf("%s/%s%s", default_pl_dir, argv[1]);
+      path = safe_asprintf("%s/%s", default_pl_dir, argv[1]);
     }
 
   pli = db_pl_fetch_byvirtualpath(path);
@@ -2449,7 +2449,7 @@ mpd_command_load(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, s
   else
     {
       // Argument is a playlist name, prepend default playlist directory
-      path = safe_asprintf("%s/%s%s", default_pl_dir, argv[1]);
+      path = safe_asprintf("%s/%s", default_pl_dir, argv[1]);
     }
 
   pli = db_pl_fetch_byvirtualpath(path);
@@ -3260,7 +3260,7 @@ mpd_sticker_set(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, co
   rating *= MPD_RATING_FACTOR;
   if (rating > DB_FILES_RATING_MAX)
     {
-      *errmsg = safe_asprintf("rating '%s' is greater than maximum value allowed", argv[5], (DB_FILES_RATING_MAX / MPD_RATING_FACTOR));
+      *errmsg = safe_asprintf("rating '%s' is greater than maximum value allowed", argv[5]);
       return ACK_ERROR_ARG;
     }
 


### PR DESCRIPTION
Fixes a segfault i encountered with the `listplaylistinfo` command in combination with setting a default playlist directory (forked-daapd.conf) due to a mistake in the creation of the virtual path (wrong format string used for asprintf).

@ejurgensen Could you take a quick look at the change in `misc.h`? To avoid this mistake in the future i added a compiler function attribute that will spit out compiler warnings in case format string and/or format parameters do not match.