### PR TITLE
[player] Fix segfault when getting single speaker/output by id

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -3166,6 +3166,7 @@ player_speaker_get_byid(uint64_t id, struct player_speaker_info *spk)
   int ret;
 
   param.spk_id = id;
+  param.spk_info = spk;
 
   ret = commands_exec_sync(cmdbase, speaker_get_byid, NULL, &param);
   return ret;


### PR DESCRIPTION
Fixes #674. The segfault was introduced in #668 (i was sure, that i did test the last version i submitted. But that was obviously not the case ...)