### PR TITLE
configurable options to show composer on web `Now Playing` page

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -1870,6 +1870,7 @@ GET /api/config
 | version         | string   | forked-daapd server version               |
 | websocket_port  | integer  | Port number for the [websocket](#push-notifications) (or `0` if websocket is disabled) |
 | buildoptions    | array    | Array of strings indicating which features are supported by the forked-daapd server |
+| show_composer   | array    | Array of genres (in lowercase) that indicating which genres should display composer if available|
 
 
 **Example**
@@ -1891,6 +1892,10 @@ curl -X GET "http://localhost:3689/api/config"
     "Device verification",
     "Websockets",
     "ALSA"
+  ],
+  "show_composer": [
+    "classical",
+    "soundtrack"
   ]
 }
 ```

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -191,6 +191,11 @@ library {
 	# (played or skipped). Both results are combined with a mix-factor of 0.75:
 	# new rating = 0.75 * stable rating + 0.25 * rolling rating)
 #	rating_updates = false
+
+	# which genres to display composer on webui's Now Playing screen
+	# empty list to disable or "*" to display all
+	# entries are case insensitive
+	show_composer = { }
 }
 
 # Local audio output

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -101,6 +101,7 @@ static cfg_opt_t sec_library[] =
     CFG_STR_LIST("force_decode", NULL, CFGF_NONE),
     CFG_BOOL("pipe_autostart", cfg_true, CFGF_NONE),
     CFG_BOOL("rating_updates", cfg_false, CFGF_NONE),
+    CFG_STR_LIST("show_composer", "{ }", CFGF_NONE),
     CFG_END()
   };
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -714,8 +714,9 @@ jsonapi_reply_config(struct httpd_request *hreq)
 
   n = cfg_size(lib, "show_composer");
   show_composer = json_object_new_array();
-  buf = NULL;
-  bufsz = 0;
+  bufsz = 32;
+  buf = malloc(bufsz+1);
+  memset(buf, 0, bufsz+1);
   for (i = 0; i < n; i++)
     {
       ptr = cfg_getnstr(lib, "show_composer", i);

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -4,7 +4,7 @@
       <div class="container has-text-centered fd-has-margin-top">
         <h1 class="title is-4">
           {{ now_playing.title }}
-          <div class="subtitle is-6" v-show="composer_visible">
+          <div class="subtitle has-text-grey is-7" v-show="composer_visible">
             {{ composer() }}
           </div>
         </h1>

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -4,6 +4,9 @@
       <div class="container has-text-centered fd-has-margin-top">
         <h1 class="title is-4">
           {{ now_playing.title }}
+          <div class="subtitle is-6" v-show="composer_visible">
+            {{ composer() }}
+          </div>
         </h1>
         <h2 class="title is-6">
           {{ now_playing.artist }}
@@ -75,6 +78,7 @@ export default {
       item_progress_ms: 0,
       interval_id: 0,
       artwork_visible: false,
+      composer_visible: false,
 
       show_details_modal: false,
       selected_item: {}
@@ -131,6 +135,19 @@ export default {
 
     artwork_error: function () {
       this.artwork_visible = false
+    },
+
+    composer: function () {
+      if (this.now_playing.composer === undefined || this.now_playing.composer === null || this.now_playing.genre === undefined || this.now_playing.genre === null) {
+        this.composer_visible = false
+      } else {
+        if (this.$store.state.config.show_composer.includes('*')) {
+          this.composer_visible = true
+        } else {
+          this.composer_visible = (this.$store.state.config.show_composer.includes(this.now_playing.genre.toLowerCase()))
+        }
+      }
+      return this.now_playing.composer
     },
 
     open_dialog: function (item) {

--- a/web-src/src/store/index.js
+++ b/web-src/src/store/index.js
@@ -9,7 +9,8 @@ export default new Vuex.Store({
     config: {
       'websocket_port': 0,
       'version': '',
-      'buildoptions': [ ]
+      'buildoptions': [ ],
+      'show_composer': [ ]
     },
     library: {
       'artists': 0,


### PR DESCRIPTION
Closes https://github.com/ejurgensen/forked-daapd/issues/631

Composer was exposed on jsonapi in commit cfadcc184faa9fc19ecebca43adaceba33fe0ef4.  This PR has server side configuration to determine which genres the `Now Playing` should attempt to display.

![before-after](https://user-images.githubusercontent.com/18466811/51863410-d8907f80-2338-11e9-8c2d-98c8e825207a.png)
Composer is displayed under title (in non bold) on the screenshot on the right.

@chme previously had reservations about hardcoding logic (in websrc code) to display when `genre == classical` - this PR allows user/server config to determine list of `genres`that the user wants to display composer.