### PR TITLE
JSON API endpoints to get a track and modify rating, play count

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -716,9 +716,11 @@ curl -X PUT "http://localhost:3689/api/queue/items/2"
 | GET       | [/api/library/albums](#list-albums)                         | Get a list of albums                 |
 | GET       | [/api/library/albums/{id}](#get-an-album)                   | Get an album                         |
 | GET       | [/api/library/albums/{id}/tracks](#list-album-tracks)       | Get list of tracks for an album      |
+| GET       | [/api/library/tracks/{id}](#get-a-track)                    | Get a track                          |
+| PUT       | [/api/library/tracks/{id}](#update-track-properties)        | Update a tracks properties (rating, play_count) |
 | GET       | [/api/library/genres](#list-genres)                         | Get list of genres                   |
 | GET       | [/api/library/count](#get-count-of-tracks-artists-and-albums) | Get count of tracks, artists and albums |
-| GET       | [/api/library/files](#list-local-directories)               | Get list of directories in the local library  |
+| GET       | [/api/library/files](#list-local-directories)               | Get list of directories in the local library    |
 | GET       | [/api/update](#trigger-rescan)                              | Trigger a library rescan             |
 
 
@@ -1248,6 +1250,106 @@ curl -X GET "http://localhost:3689/api/library/albums/1/tracks"
   "offset": 0,
   "limit": -1
 }
+```
+
+
+### Get a track
+
+Get a specific track in your library
+
+**Endpoint**
+
+```http
+GET /api/library/tracks/{id}
+```
+
+**Path parameters**
+
+| Parameter       | Value                |
+| --------------- | -------------------- |
+| id              | Track id             |
+
+**Response**
+
+On success returns the HTTP `200 OK` success status response code. With the response body holding the **[`track`](#track-object) object**.
+
+
+**Example**
+
+```shell
+curl -X GET "http://localhost:3689/api/library/track/1"
+```
+
+```json
+{
+  "id": 1,
+  "title": "Pardon Me",
+  "title_sort": "Pardon Me",
+  "artist": "Incubus",
+  "artist_sort": "Incubus",
+  "album": "Make Yourself",
+  "album_sort": "Make Yourself",
+  "album_id": "6683985628074308431",
+  "album_artist": "Incubus",
+  "album_artist_sort": "Incubus",
+  "album_artist_id": "4833612337650426236",
+  "composer": "Alex Katunich/Brandon Boyd/Chris Kilmore/Jose Antonio Pasillas II/Mike Einziger",
+  "genre": "Alternative Rock",
+  "year": 2001,
+  "track_number": 12,
+  "disc_number": 1,
+  "length_ms": 223170,
+  "rating": 0,
+  "play_count": 0,
+  "skip_count": 0,
+  "time_added": "2019-01-20T11:58:29Z",
+  "date_released": "2001-05-27",
+  "seek_ms": 0,
+  "media_kind": "music",
+  "data_kind": "file",
+  "path": "/music/srv/Incubus/Make Yourself/12 Pardon Me.mp3",
+  "uri": "library:track:1",
+  "artwork_url": "/artwork/item/1"
+}
+```
+
+
+### Update track properties
+
+Change properties of a specific track (supported properties are "rating" and "play_count")
+
+**Endpoint**
+
+```http
+PUT /api/library/tracks/{id}
+```
+
+**Path parameters**
+
+| Parameter       | Value                |
+| --------------- | -------------------- |
+| id              | Track id             |
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| rating          | The new rating (0 - 100)                                    |
+| play_count      | Either `increment` or `reset`. `increment` will increment `play_count` and update `time_played`, `reset` will set `play_count` and `skip_count` to zero and delete `time_played` and `time_skipped` |
+
+
+**Response**
+
+On success returns the HTTP `204 No Content` success status response code.
+
+**Example**
+
+```shell
+curl -X PUT "http://localhost:3689/api/library/tracks/1?rating=100"
+```
+
+```shell
+curl -X PUT "http://localhost:3689/api/library/tracks/1?play_count=increment"
 ```
 
 

--- a/src/db.c
+++ b/src/db.c
@@ -2543,6 +2543,7 @@ db_file_inc_playcount(int id)
 	       "     rating = CAST(((play_count + 1.0) / (play_count + skip_count + 2.0) * 100 * 0.75) + ((rating + ((100.0 - rating) / 2.0)) * 0.25) AS INT)" \
                " WHERE id = %d;"
   char *query;
+  int ret;
 
   if (db_rating_updates)
     query = sqlite3_mprintf(Q_TMPL_WITH_RATING, (int64_t)time(NULL), id);
@@ -2555,7 +2556,9 @@ db_file_inc_playcount(int id)
       return;
     }
 
-  db_query_run(query, 1, 0);
+  ret = db_query_run(query, 1, 0);
+  if (ret == 0)
+    db_admin_setint64(DB_ADMIN_DB_MODIFIED, (int64_t) time(NULL));
 #undef Q_TMPL
 #undef Q_TMPL_WITH_RATING
 }
@@ -2571,6 +2574,7 @@ db_file_inc_skipcount(int id)
 	       "     rating = CAST(((play_count + 1.0) / (play_count + skip_count + 2.0) * 100 * 0.75) + ((rating - (rating / 2.0)) * 0.25) AS INT)" \
                " WHERE id = %d;"
   char *query;
+  int ret;
 
   if (db_rating_updates)
     query = sqlite3_mprintf(Q_TMPL_WITH_RATING, (int64_t)time(NULL), id);
@@ -2583,7 +2587,9 @@ db_file_inc_skipcount(int id)
       return;
     }
 
-  db_query_run(query, 1, 0);
+  ret = db_query_run(query, 1, 0);
+  if (ret == 0)
+    db_admin_setint64(DB_ADMIN_DB_MODIFIED, (int64_t) time(NULL));
 #undef Q_TMPL
 #undef Q_TMPL_WITH_RATING
 }
@@ -2593,6 +2599,7 @@ db_file_reset_playskip_count(int id)
 {
 #define Q_TMPL "UPDATE files SET play_count = 0, skip_count = 0, time_played = 0, time_skipped = 0 WHERE id = %d;"
   char *query;
+  int ret;
 
   query = sqlite3_mprintf(Q_TMPL, id);
   if (!query)
@@ -2602,7 +2609,9 @@ db_file_reset_playskip_count(int id)
       return;
     }
 
-  db_query_run(query, 1, 0);
+  ret = db_query_run(query, 1, 0);
+  if (ret == 0)
+    db_admin_setint64(DB_ADMIN_DB_MODIFIED, (int64_t) time(NULL));
 #undef Q_TMPL
 }
 
@@ -3067,6 +3076,7 @@ db_file_seek_update(int id, uint32_t seek)
 {
 #define Q_TMPL "UPDATE files SET seek = %d WHERE id = %d;"
   char *query;
+  int ret;
 
   if (id == 0)
     return;
@@ -3079,8 +3089,26 @@ db_file_seek_update(int id, uint32_t seek)
       return;
     }
 
-  db_query_run(query, 1, 0);
+  ret = db_query_run(query, 1, 0);
+  if (ret == 0)
+    db_admin_setint64(DB_ADMIN_DB_MODIFIED, (int64_t) time(NULL));
 #undef Q_TMPL
+}
+
+static int
+db_file_rating_update(char *query)
+{
+  int ret;
+
+  ret = db_query_run(query, 1, 0);
+
+  if (ret == 0)
+    {
+      db_admin_setint64(DB_ADMIN_DB_MODIFIED, (int64_t) time(NULL));
+      listener_notify(LISTENER_RATING);
+    }
+
+  return ((ret < 0) ? -1 : sqlite3_changes(hdl));
 }
 
 int
@@ -3088,16 +3116,10 @@ db_file_rating_update_byid(uint32_t id, uint32_t rating)
 {
 #define Q_TMPL "UPDATE files SET rating = %d WHERE id = %d;"
   char *query;
-  int ret;
 
   query = sqlite3_mprintf(Q_TMPL, rating, id);
 
-  ret = db_query_run(query, 1, 0);
-
-  if (ret == 0)
-    listener_notify(LISTENER_RATING);
-
-  return ((ret < 0) ? -1 : sqlite3_changes(hdl));
+  return db_file_rating_update(query);
 #undef Q_TMPL
 }
 
@@ -3106,16 +3128,10 @@ db_file_rating_update_byvirtualpath(const char *virtual_path, uint32_t rating)
 {
 #define Q_TMPL "UPDATE files SET rating = %d WHERE virtual_path = %Q;"
   char *query;
-  int ret;
 
   query = sqlite3_mprintf(Q_TMPL, rating, virtual_path);
 
-  ret = db_query_run(query, 1, 0);
-
-  if (ret == 0)
-    listener_notify(LISTENER_RATING);
-
-  return ((ret < 0) ? -1 : sqlite3_changes(hdl));
+  return db_file_rating_update(query);
 #undef Q_TMPL
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -2589,6 +2589,24 @@ db_file_inc_skipcount(int id)
 }
 
 void
+db_file_reset_playskip_count(int id)
+{
+#define Q_TMPL "UPDATE files SET play_count = 0, skip_count = 0, time_played = 0, time_skipped = 0 WHERE id = %d;"
+  char *query;
+
+  query = sqlite3_mprintf(Q_TMPL, id);
+  if (!query)
+    {
+      DPRINTF(E_LOG, L_DB, "Out of memory for query string\n");
+
+      return;
+    }
+
+  db_query_run(query, 1, 0);
+#undef Q_TMPL
+}
+
+void
 db_file_ping(int id)
 {
 #define Q_TMPL "UPDATE files SET db_timestamp = %" PRIi64 ", disabled = 0 WHERE id = %d;"

--- a/src/db.h
+++ b/src/db.h
@@ -71,6 +71,7 @@ enum query_type {
 #define DB_ADMIN_SCHEMA_VERSION "schema_version"
 #define DB_ADMIN_QUEUE_VERSION "queue_version"
 #define DB_ADMIN_DB_UPDATE "db_update"
+#define DB_ADMIN_DB_MODIFIED "db_modified"
 #define DB_ADMIN_START_TIME "start_time"
 #define DB_ADMIN_LASTFM_SESSION_KEY "lastfm_sk"
 #define DB_ADMIN_SPOTIFY_REFRESH_TOKEN "spotify_refresh_token"

--- a/src/db.h
+++ b/src/db.h
@@ -567,6 +567,9 @@ void
 db_file_inc_skipcount(int id);
 
 void
+db_file_reset_playskip_count(int id);
+
+void
 db_file_ping(int id);
 
 int

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -2590,7 +2590,7 @@ jsonapi_reply_library_album_tracks(struct httpd_request *hreq)
   int total;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_MODIFIED);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -2644,7 +2644,7 @@ jsonapi_reply_library_tracks_get_byid(struct httpd_request *hreq)
   json_object *reply = NULL;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_MODIFIED);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 
@@ -2836,7 +2836,7 @@ jsonapi_reply_library_playlist_tracks(struct httpd_request *hreq)
   int total;
   int ret = 0;
 
-  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_UPDATE);
+  db_update = (time_t) db_admin_getint64(DB_ADMIN_DB_MODIFIED);
   if (db_update && httpd_request_not_modified_since(hreq->req, &db_update))
     return HTTP_NOTMODIFIED;
 

--- a/src/library.c
+++ b/src/library.c
@@ -98,6 +98,7 @@ static short deferred_update_events;
 static bool
 handle_deferred_update_notifications(void)
 {
+  time_t update_time;
   bool ret = (deferred_update_notifications > 0);
 
   if (ret)
@@ -105,7 +106,9 @@ handle_deferred_update_notifications(void)
       DPRINTF(E_DBG, L_LIB, "Database changed (%d changes)\n", deferred_update_notifications);
 
       deferred_update_notifications = 0;
-      db_admin_setint64(DB_ADMIN_DB_UPDATE, (int64_t) time(NULL));
+      update_time = time(NULL);
+      db_admin_setint64(DB_ADMIN_DB_UPDATE, (int64_t) update_time);
+      db_admin_setint64(DB_ADMIN_DB_MODIFIED, (int64_t) update_time);
     }
 
   return ret;


### PR DESCRIPTION
I started using forked-daapd to listen to podcasts and therefor am looking into improving the podcast section in the web interface. One thing missing in the JSON API is, that it is not possible to mark a podcast episode as already played. 

The new endpoints are:

- GET api/library/tracks/{id}: get metadata for a single track
- PUT api/library/tracks/{id}: update play count and/or rating for a single track