### PR TITLE
[db,web-src] support links to album,artist from queue item modal like others modals

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -264,6 +264,7 @@ static const struct col_type_map qi_cols_map[] =
     { "artwork_url",        qi_offsetof(artwork_url),         DB_TYPE_STRING, DB_FIXUP_NO_SANITIZE },
     { "queue_version",      qi_offsetof(queue_version),       DB_TYPE_INT },
     { "composer",           qi_offsetof(composer),            DB_TYPE_STRING, DB_FIXUP_COMPOSER },
+    { "songartistid",       qi_offsetof(songartistid),        DB_TYPE_INT64 },
   };
 
 /* This list must be kept in sync with
@@ -4748,13 +4749,13 @@ queue_add_file(struct db_media_file_info *dbmfi, int pos, int shuffle_pos, int q
 #define Q_TMPL "INSERT INTO queue "							\
 		    "(id, file_id, song_length, data_kind, media_kind, "		\
 		    "pos, shuffle_pos, path, virtual_path, title, "			\
-		    "artist, composer, album_artist, album, genre, songalbumid, "	\
+		    "artist, composer, album_artist, album, genre, songalbumid, songartistid,"	\
 		    "time_modified, artist_sort, album_sort, album_artist_sort, year, "	\
 		    "track, disc, queue_version)" 					\
 		"VALUES"                                           			\
 		    "(NULL, %s, %s, %s, %s, "						\
 		    "%d, %d, %Q, %Q, %Q, "						\
-		    "%Q, %Q, %Q, %Q, %Q, %s, "						\
+		    "%Q, %Q, %Q, %Q, %Q, %s, %s,"					\
 		    "%s, %Q, %Q, %Q, %s, "						\
 		    "%s, %s, %d);"
 
@@ -4764,7 +4765,7 @@ queue_add_file(struct db_media_file_info *dbmfi, int pos, int shuffle_pos, int q
   query = sqlite3_mprintf(Q_TMPL,
 			  dbmfi->id, dbmfi->song_length, dbmfi->data_kind, dbmfi->media_kind,
 			  pos, shuffle_pos, dbmfi->path, dbmfi->virtual_path, dbmfi->title,
-			  dbmfi->artist, dbmfi->composer, dbmfi->album_artist, dbmfi->album, dbmfi->genre, dbmfi->songalbumid,
+			  dbmfi->artist, dbmfi->composer, dbmfi->album_artist, dbmfi->album, dbmfi->genre, dbmfi->songalbumid, dbmfi->songartistid,
 			  dbmfi->time_modified, dbmfi->artist_sort, dbmfi->album_sort, dbmfi->album_artist_sort, dbmfi->year,
 			  dbmfi->track, dbmfi->disc, queue_version);
   ret = db_query_run(query, 1, 0);
@@ -4780,13 +4781,13 @@ queue_add_item(struct db_queue_item *item, int pos, int shuffle_pos, int queue_v
 #define Q_TMPL "INSERT INTO queue "							\
 		    "(id, file_id, song_length, data_kind, media_kind, "		\
 		    "pos, shuffle_pos, path, virtual_path, title, "			\
-		    "artist, composer, album_artist, album, genre, songalbumid, "       \
+		    "artist, composer, album_artist, album, genre, songalbumid, songartistid, "	\
 		    "time_modified, artist_sort, album_sort, album_artist_sort, year, "	\
 		    "track, disc, artwork_url, queue_version)" 				\
 		"VALUES"                                           			\
 		    "(NULL, %d, %d, %d, %d, "						\
 		    "%d, %d, %Q, %Q, %Q, "						\
-		    "%Q, %Q, %Q, %Q, %Q, %" PRIi64 ", "					\
+		    "%Q, %Q, %Q, %Q, %Q, %" PRIi64 ", %" PRIi64 ","			\
 		    "%d, %Q, %Q, %Q, %d, "						\
 		    "%d, %d, %Q, %d);"
 
@@ -4796,7 +4797,7 @@ queue_add_item(struct db_queue_item *item, int pos, int shuffle_pos, int queue_v
   query = sqlite3_mprintf(Q_TMPL,
 			  item->file_id, item->song_length, item->data_kind, item->media_kind,
 			  pos, shuffle_pos, item->path, item->virtual_path, item->title,
-			  item->artist, item->composer, item->album_artist, item->album, item->genre, item->songalbumid,
+			  item->artist, item->composer, item->album_artist, item->album, item->genre, item->songalbumid, item->songartistid,
 			  item->time_modified, item->artist_sort, item->album_sort, item->album_artist_sort, item->year,
 			  item->track, item->disc, item->artwork_url, queue_version);
   ret = db_query_run(query, 1, 0);
@@ -4814,7 +4815,8 @@ db_queue_update_item(struct db_queue_item *qi)
 		    "pos = %d, shuffle_pos = %d, path = '%q', virtual_path = %Q, "	\
 		    "title = %Q, artist = %Q, album_artist = %Q, album = %Q, "		\
 		    "composer = %Q,"                                                    \
-		    "genre = %Q, songalbumid = %" PRIi64 ", time_modified = %d, "	\
+		    "genre = %Q, time_modified = %d, "					\
+		    "songalbumid = %" PRIi64 ", songartistid = %" PRIi64 ", "		\
 		    "artist_sort = %Q, album_sort = %Q, album_artist_sort = %Q, "	\
 		    "year = %d, track = %d, disc = %d, artwork_url = %Q, "		\
 		    "queue_version = %d "						\
@@ -4831,7 +4833,8 @@ db_queue_update_item(struct db_queue_item *qi)
 			  qi->pos, qi->shuffle_pos, qi->path, qi->virtual_path,
 			  qi->title, qi->artist, qi->album_artist, qi->album,
                           qi->composer,
-			  qi->genre, qi->songalbumid, qi->time_modified,
+			  qi->genre, qi->time_modified,
+			  qi->songalbumid, qi->songartistid,
 			  qi->artist_sort, qi->album_sort, qi->album_artist_sort,
 			  qi->year, qi->track, qi->disc, qi->artwork_url, queue_version,
 			  qi->id);
@@ -5223,6 +5226,7 @@ queue_enum_fetch(struct query_params *qp, struct db_queue_item *queue_item, int 
   queue_item->disc = sqlite3_column_int(qp->stmt, 21);
   queue_item->artwork_url = strdup_if((char *)sqlite3_column_text(qp->stmt, 22), keep_item);
   queue_item->composer = strdup_if((char *)sqlite3_column_text(qp->stmt, 24), keep_item);
+  queue_item->songartistid = sqlite3_column_int64(qp->stmt, 25);
 
   return 0;
 }

--- a/src/db.h
+++ b/src/db.h
@@ -469,6 +469,8 @@ struct db_queue_item {
 
   char *composer;
 
+  int64_t songartistid;
+
   /* Not saved in queue table */
   uint32_t seek;
 };

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -191,7 +191,8 @@
   "   disc                INTEGER DEFAULT 0,"				\
   "   artwork_url         VARCHAR(4096) DEFAULT NULL,"			\
   "   queue_version       INTEGER DEFAULT 0,"				\
-  "   composer            VARCHAR(1024) DEFAULT NULL"			\
+  "   composer            VARCHAR(1024) DEFAULT NULL,"			\
+  "   songartistid        INTEGER NOT NULL"				\
   ");"
 
 #define Q_PL1								\

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * forked-daapd after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 20
-#define SCHEMA_VERSION_MINOR 00
+#define SCHEMA_VERSION_MINOR 01
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -972,6 +972,17 @@ static const struct db_upgrade_query db_upgrade_v2000_queries[] =
     { U_V2000_SCVER_MINOR,    "set schema_version_minor to 00" },
   };
 
+#define U_V2001_ALTER_QUEUE_ADD_SONGARTISTID \
+  "ALTER TABLE queue ADD COLUMN songartistid INTEGER NOT NULL default 0;"
+#define U_V2001_SCVER_MINOR \
+  "UPDATE admin SET value = '01' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v2001_queries[] =
+  {
+    { U_V2001_ALTER_QUEUE_ADD_SONGARTISTID, "add songartistid to queue" },
+    { U_V2001_SCVER_MINOR,    "set schema_version_minor to 01" },
+  };
+
 
 int
 db_upgrade(sqlite3 *hdl, int db_ver)
@@ -1103,6 +1114,13 @@ db_upgrade(sqlite3 *hdl, int db_ver)
 	return -1;
 
       ret = db_generic_upgrade(hdl, db_upgrade_v2000_queries, ARRAY_SIZE(db_upgrade_v2000_queries));
+      if (ret < 0)
+	return -1;
+
+      /* FALLTHROUGH */
+
+    case 2000:
+      ret = db_generic_upgrade(hdl, db_upgrade_v2001_queries, ARRAY_SIZE(db_upgrade_v2001_queries));
       if (ret < 0)
 	return -1;
 

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1654,6 +1654,19 @@ queue_item_to_json(struct db_queue_item *queue_item, char shuffle)
   safe_json_add_string(item, "composer", queue_item->composer);
   safe_json_add_string(item, "genre", queue_item->genre);
 
+  if (queue_item->songartistid > 0)
+    {
+      ret = snprintf(uri, sizeof(uri), "%" PRIi64, queue_item->songartistid);
+      if (ret < sizeof(uri))
+        json_object_object_add(item, "albumartist_id", json_object_new_string(uri));
+    }
+  if (queue_item->songalbumid > 0)
+    {
+      ret = snprintf(uri, sizeof(uri), "%" PRIi64, queue_item->songalbumid);
+      if (ret < sizeof(uri))
+        json_object_object_add(item, "album_id", json_object_new_string(uri));
+    }
+
   json_object_object_add(item, "year", json_object_new_int(queue_item->year));
   json_object_object_add(item, "track_number", json_object_new_int(queue_item->track));
   json_object_object_add(item, "disc_number", json_object_new_int(queue_item->disc));

--- a/web-src/src/components/ModalDialogQueueItem.vue
+++ b/web-src/src/components/ModalDialogQueueItem.vue
@@ -15,11 +15,11 @@
               <div class="content is-small">
                 <p>
                   <span class="heading">Album</span>
-                  <span class="title is-6">{{ item.album }}</span>
+                  <a class="title is-6 has-text-link" @click="open_album">{{ item.album }}</a>
                 </p>
                 <p v-if="item.album_artist">
                   <span class="heading">Album artist</span>
-                  <span class="title is-6">{{ item.album_artist }}</span>
+                  <a class="title is-6 has-text-link" @click="open_album_artist">{{ item.album_artist }}</a>
                 </p>
                 <p v-if="item.composer">
                   <span class="heading">Composer</span>
@@ -31,7 +31,7 @@
                 </p>
                 <p>
                   <span class="heading">Genre</span>
-                  <span class="title is-6">{{ item.genre }}</span>
+                  <a class="title is-6 has-text-link" @click="open_genre">{{ item.genre }}</a>
                 </p>
                 <p>
                   <span class="heading">Track / Disc</span>
@@ -79,6 +79,24 @@ export default {
     play: function () {
       this.$emit('close')
       webapi.player_play({ 'item_id': this.item.id })
+    },
+
+    open_album: function () {
+      if (this.media_kind === 'podcast') {
+        this.$router.push({ path: '/podcasts/' + this.item.album_id })
+      } else if (this.media_kind === 'audiobook') {
+        this.$router.push({ path: '/audiobooks/' + this.item.album_id })
+      } else {
+        this.$router.push({ path: '/music/albums/' + this.item.album_id })
+      }
+    },
+
+    open_album_artist: function () {
+      this.$router.push({ path: '/music/artists/' + this.item.albumartist_id })
+    },
+
+    open_genre: function () {
+      this.$router.push({ path: '/music/genres/' + this.item.genre })
     }
   }
 }


### PR DESCRIPTION
The web ui's `queue item` modal is inconsistent with other modal's (such as Artist modal) which has clickable links to album and atrist
![album](https://user-images.githubusercontent.com/18466811/52139177-44c7f780-2647-11e9-8e48-0c9d381a8691.png)
This PR makes adds the same clickable links for the `queue item` modal.

Requires the `queue` table to be extended to carry `songartistid` - it was already carrying the `songalbumid`; both these are exposed by the `jsonapi`'s `/api/queue` endpoint as new elements for each `queue item`
![now playing](https://user-images.githubusercontent.com/18466811/52139362-dafc1d80-2647-11e9-9894-5036a1913ff7.png)
