### PR TITLE
Small fixes/adjustments to the queue item model

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -1961,8 +1961,10 @@ curl --include \
 | artist_sort        | string   | Track artist sort name                    |
 | album              | string   | Album name                                |
 | album_sort         | string   | Album sort name                           |
+| album_id           | string   | Album id                                  |
 | album_artist       | string   | Album artist name                         |
 | album_artist_sort  | string   | Album artist sort name                    |
+| album_artist_id    | string   | Album artist id                           |
 | composer           | string   | Composer (optional)                       |
 | genre              | string   | Genre                                     |
 | year               | integer  | Release year                              |

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -67,6 +67,20 @@ safe_json_add_string(json_object *obj, const char *key, const char *value)
 }
 
 static inline void
+safe_json_add_string_from_int64(json_object *obj, const char *key, int64_t value)
+{
+  char tmp[100];
+  int ret;
+
+  if (value > 0)
+    {
+      ret = snprintf(tmp, sizeof(tmp), "%" PRIi64, value);
+      if (ret < sizeof(tmp))
+	json_object_object_add(obj, key, json_object_new_string(tmp));
+    }
+}
+
+static inline void
 safe_json_add_int_from_string(json_object *obj, const char *key, const char *value)
 {
   int intval;
@@ -1649,23 +1663,12 @@ queue_item_to_json(struct db_queue_item *queue_item, char shuffle)
   safe_json_add_string(item, "artist_sort", queue_item->artist_sort);
   safe_json_add_string(item, "album", queue_item->album);
   safe_json_add_string(item, "album_sort", queue_item->album_sort);
+  safe_json_add_string_from_int64(item, "album_id", queue_item->songalbumid);
   safe_json_add_string(item, "album_artist", queue_item->album_artist);
   safe_json_add_string(item, "album_artist_sort", queue_item->album_artist_sort);
+  safe_json_add_string_from_int64(item, "album_artist_id", queue_item->songartistid);
   safe_json_add_string(item, "composer", queue_item->composer);
   safe_json_add_string(item, "genre", queue_item->genre);
-
-  if (queue_item->songartistid > 0)
-    {
-      ret = snprintf(uri, sizeof(uri), "%" PRIi64, queue_item->songartistid);
-      if (ret < sizeof(uri))
-        json_object_object_add(item, "albumartist_id", json_object_new_string(uri));
-    }
-  if (queue_item->songalbumid > 0)
-    {
-      ret = snprintf(uri, sizeof(uri), "%" PRIi64, queue_item->songalbumid);
-      if (ret < sizeof(uri))
-        json_object_object_add(item, "album_id", json_object_new_string(uri));
-    }
 
   json_object_object_add(item, "year", json_object_new_int(queue_item->year));
   json_object_object_add(item, "track_number", json_object_new_int(queue_item->track));

--- a/web-src/src/components/ModalDialogQueueItem.vue
+++ b/web-src/src/components/ModalDialogQueueItem.vue
@@ -15,11 +15,13 @@
               <div class="content is-small">
                 <p>
                   <span class="heading">Album</span>
-                  <a class="title is-6 has-text-link" @click="open_album">{{ item.album }}</a>
+                  <a v-if="item.album_id" class="title is-6 has-text-link" @click="open_album">{{ item.album }}</a>
+                  <span v-else class="title is-6">{{ item.album }}</span>
                 </p>
                 <p v-if="item.album_artist">
                   <span class="heading">Album artist</span>
-                  <a class="title is-6 has-text-link" @click="open_album_artist">{{ item.album_artist }}</a>
+                  <a v-if="item.album_artist_id" class="title is-6 has-text-link" @click="open_album_artist">{{ item.album_artist }}</a>
+                  <span v-else class="title is-6">{{ item.album_artist }}</span>
                 </p>
                 <p v-if="item.composer">
                   <span class="heading">Composer</span>
@@ -29,7 +31,7 @@
                   <span class="heading">Year</span>
                   <span class="title is-6">{{ item.year }}</span>
                 </p>
-                <p>
+                <p v-if="item.genre">
                   <span class="heading">Genre</span>
                   <a class="title is-6 has-text-link" @click="open_genre">{{ item.genre }}</a>
                 </p>
@@ -92,7 +94,7 @@ export default {
     },
 
     open_album_artist: function () {
-      this.$router.push({ path: '/music/artists/' + this.item.albumartist_id })
+      this.$router.push({ path: '/music/artists/' + this.item.album_artist_id })
     },
 
     open_genre: function () {


### PR DESCRIPTION
Small fixes/adjustments to the queue item details dialog:

- Only link to album/artist if there is a valid id
- Rename `albumartist_id` to `album_artist_id` (keep naming between queue item and track in sync)

