### PR TITLE
wip! Add support for artist images

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -134,6 +134,10 @@ library {
 	# default to reduce cache size.
 #	artwork_individual = false
 
+	# Artwork file names for artist images (without file type extension)
+	# forked-daapd will look for jpg and png files with these base names
+#	artwork_artist_basenames = { "artist" }
+
 	# File types the scanner should ignore
 	# Non-audio files will never be added to the database, but here you
 	# can prevent the scanner from even probing them. This might improve

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -101,6 +101,9 @@ struct artwork_group_source {
   // The handler
   int (*handler)(struct evbuffer *evbuf, char *artwork_path, struct group_info *group_info, int max_w, int max_h);
 
+  // What group_type the handler can work with
+  int group_types;
+
   // When should results from the source be cached?
   enum artwork_cache cache;
 };
@@ -135,16 +138,19 @@ static struct artwork_group_source artwork_group_source[] =
     {
       .name = "directory",
       .handler = source_group_dir_get,
+      .group_types = G_ARTISTS | G_ALBUMS,
       .cache = ON_SUCCESS | ON_FAILURE,
     },
     {
       .name = "embedded",
       .handler = source_group_embedded_get,
+      .group_types = G_ARTISTS | G_ALBUMS,
       .cache = ON_SUCCESS | ON_FAILURE,
     },
     {
       .name = "Spotify web api",
       .handler = source_group_spotifywebapi_get,
+      .group_types = G_ARTISTS | G_ALBUMS,
       .cache = ON_SUCCESS | ON_FAILURE,
     },
     {
@@ -1047,6 +1053,9 @@ artwork_get_groupinfo(struct evbuffer *evbuf, struct group_info *gri, int max_w,
 
   for (i = 0; artwork_group_source[i].handler; i++)
     {
+      if ((artwork_group_source[i].group_types & gri->type) == 0)
+	continue;
+
       // If just one handler says we should not cache a negative result then we obey that
       if ((artwork_group_source[i].cache & ON_FAILURE) == 0)
 	cache_result = NEVER;

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -92,6 +92,7 @@ static cfg_opt_t sec_library[] =
     CFG_STR("name_radio", "Radio", CFGF_NONE),
     CFG_STR_LIST("artwork_basenames", "{artwork,cover,Folder}", CFGF_NONE),
     CFG_BOOL("artwork_individual", cfg_false, CFGF_NONE),
+    CFG_STR_LIST("artwork_artist_basenames", "{artist}", CFGF_NONE),
     CFG_STR_LIST("filetypes_ignore", "{.db,.ini,.db-journal,.pdf,.metadata}", CFGF_NONE),
     CFG_STR_LIST("filepath_ignore", NULL, CFGF_NONE),
     CFG_BOOL("filescan_disable", cfg_false, CFGF_NONE),

--- a/src/db.h
+++ b/src/db.h
@@ -140,6 +140,11 @@ enum data_kind {
 const char *
 db_data_kind_label(enum data_kind data_kind);
 
+enum group_type {
+  G_ALBUMS = 1,
+  G_ARTISTS = 2,
+};
+
 /* Note that fields marked as integers in the metadata map in filescanner_ffmpeg must be uint32_t here */
 struct media_file_info {
   uint32_t id;
@@ -286,6 +291,7 @@ struct group_info {
   char *songalbumartist; /* song album artist (asaa) */
   uint64_t songartistid; /* song artist id (asri) */
   uint32_t song_length;
+  enum group_type type;
 };
 
 #define gri_offsetof(field) offsetof(struct group_info, field)
@@ -300,6 +306,7 @@ struct db_group_info {
   char *songalbumartist;
   char *songartistid;
   char *song_length;
+  char *type;
 };
 
 #define dbgri_offsetof(field) offsetof(struct db_group_info, field)

--- a/src/db.h
+++ b/src/db.h
@@ -506,6 +506,9 @@ void
 free_pli(struct playlist_info *pli, int content_only);
 
 void
+free_gri(struct group_info *gri, int content_only);
+
+void
 free_di(struct directory_info *di, int content_only);
 
 void
@@ -697,6 +700,11 @@ db_groups_cleanup();
 int
 db_group_persistentid_byid(int id, int64_t *persistentid);
 
+struct group_info *
+db_group_fetch_byid(int id);
+
+struct group_info *
+db_group_fetch_bypersistentid(int64_t persistentid);
 
 /* Directories */
 int

--- a/src/spotify_webapi.h
+++ b/src/spotify_webapi.h
@@ -55,6 +55,8 @@ void
 spotifywebapi_pl_remove(const char *uri);
 char *
 spotifywebapi_artwork_url_get(const char *uri, int max_w, int max_h);
+char *
+spotifywebapi_artist_artwork_url_get(const char *uri, int max_w, int max_h);
 
 void
 spotifywebapi_status_info_get(struct spotifywebapi_status_info *info);


### PR DESCRIPTION
The pr adds support for artist images. The JSON API as well as the DAAP protocol already support loading artwork for artists, but the returned image is the first album artwork found for this artist.

With the changes in this pr, an artwork request for an artist first tries to find an artist image and if none is found, falls back to the album artwork.

Supported artist images are artist.{jpg/png} (the basenames can be configured in the configuration file. Similar to the album artwork logic, the tracks for an artist are iterated and checked whether an artist image is found in the same directory or the parent directory.

The directory structures i have in mind are:

- music/[artist]/[album]
  - music/[artist]/artist.jpg
- music/[artist] - [album]
  - music/[artist] - [album]/artist.jpg

I changed a lot in `artwork.c`, but i think, it is now a bit easier to understand. It should now also be easier to add online sources for artwork, as the artwork retrieval functions now have access to the track/album/artist object.

This needs a lot more testing and is still work in progress (it should work and in my test Retune did show the artist images correctly). I hope to get some feedback, if the general approach is ok (especially the refactoring done in `artwork.c`), if there should be more configuration options (e. g. disable artist artwork completely) or if a different directory structure should be supported.