### PR TITLE
[systemd] add MemoryMax to service

### DIFF
--- a/forked-daapd.service.in
+++ b/forked-daapd.service.in
@@ -6,6 +6,21 @@ After=network.target sound.target remote-fs.target pulseaudio.service avahi-daem
 [Service]
 ExecStart=@sbindir@/forked-daapd -f
 
+# Constrain the upper limit of memory/swap that can be used; this prevents 
+# forked-daapd from consuming all system memory (in event of bug/malformed user
+# curl/SMARTPL query etc) that would hang/freeze low resource and headless (ie 
+# RPi) machines
+#
+# systemd will kill the process in such an event but would be auto-restarted as
+# per 'Restart' directive below
+#
+# Values derived from obersvations on rpi3 under load - limits are >50% above
+# seen high watermarks 
+# 
+# https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
+MemoryMax=256M
+MemorySwapMax=32M
+
 # Restart, but not more than once every 10 minutes
 Restart=on-failure
 StartLimitBurst=2


### PR DESCRIPTION
This simple PR adds `MemoryMax` limit to the control group that the server runs, enforcing an upper limit of memory.

This helps to prevent **malformed user generated** `SMARTPL` queries (initiated by `curl`)  (see https://github.com/ejurgensen/forked-daapd/issues/570) from putting the server into a infinite loop and causes process to consume all ram / freeze the system until OOM killer finds it.

In the event that `forked-daapd` starts to eat memory, `cgroup` handling will kill it once it reaches the set memory threshold (which is beyond normal usage scenarios from what I've seen) - the restart logic/settings in the same service file will bring the server back.


I've had this running on my main production machine (Raspberry Pi) and development boxes for a while and works well.