### PR TITLE
Player refactor - WIP

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -218,11 +218,11 @@ audio {
 #	mixer_device = ""
 
 	# Synchronization
-	# If your local audio is out of sync with AirPlay, you can adjust this
-	# value. Positive values correspond to moving local audio ahead,
-	# negative correspond to delaying it. The unit is samples, where is
-	# 44100 = 1 second. The offset must be between -44100 and 44100.
-#	offset = 0
+	# If your local audio is out of sync with other speakers, e.g. Airplay,
+	# adjust this value. Negative values correspond to moving local audio
+	# ahead, positive correspond to delaying it. The unit is milliseconds.
+	# The offset must be between -1000 and 1000 (+/- 1 sec).
+#	offset_ms = 0
 
 	# How often to check and correct for drift between ALSA and AirPlay.
 	# The value is an integer expressed in seconds.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -131,6 +131,7 @@ forked_daapd_SOURCES = main.c \
 	input.h input.c \
 	inputs/file_http.c inputs/pipe.c \
 	outputs.h outputs.c \
+	outputs/rtp_common.h outputs/rtp_common.c \
 	outputs/raop.c $(RAOP_VERIFICATION_SRC) \
 	outputs/streaming.c outputs/dummy.c outputs/fifo.c \
 	$(ALSA_SRC) $(PULSEAUDIO_SRC) $(CHROMECAST_SRC) \

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -115,7 +115,8 @@ static cfg_opt_t sec_audio[] =
     CFG_STR("card", "default", CFGF_NONE),
     CFG_STR("mixer", NULL, CFGF_NONE),
     CFG_STR("mixer_device", NULL, CFGF_NONE),
-    CFG_INT("offset", 0, CFGF_NONE),
+    CFG_INT("offset", 0, CFGF_NONE), // deprecated
+    CFG_INT("offset_ms", 0, CFGF_NONE),
     CFG_INT("adjust_period_seconds", 10, CFGF_NONE),
     CFG_END()
   };

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -100,6 +100,8 @@ static cfg_opt_t sec_library[] =
     CFG_STR_LIST("no_decode", NULL, CFGF_NONE),
     CFG_STR_LIST("force_decode", NULL, CFGF_NONE),
     CFG_BOOL("pipe_autostart", cfg_true, CFGF_NONE),
+    CFG_INT("pipe_sample_rate", 44100, CFGF_NONE),
+    CFG_INT("pipe_bits_per_sample", 16, CFGF_NONE),
     CFG_BOOL("rating_updates", cfg_false, CFGF_NONE),
     CFG_END()
   };

--- a/src/httpd_artworkapi.c
+++ b/src/httpd_artworkapi.c
@@ -88,7 +88,7 @@ artworkapi_reply_nowplaying(struct httpd_request *hreq)
   if (ret != 0)
     return ret;
 
-  ret = player_now_playing(&id);
+  ret = player_playing_now(&id);
   if (ret != 0)
     return HTTP_NOTFOUND;
 

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -1083,7 +1083,7 @@ dacp_propset_userrating(const char *value, struct httpd_request *hreq)
     {
       DPRINTF(E_WARN, L_DACP, "Invalid id %d for rating, defaulting to player id\n", itemid);
 
-      ret = player_now_playing(&itemid);
+      ret = player_playing_now(&itemid);
       if (ret < 0)
 	{
 	  DPRINTF(E_WARN, L_DACP, "Could not find an id for rating\n");
@@ -2277,7 +2277,7 @@ dacp_reply_nowplayingartwork(struct httpd_request *hreq)
       goto error;
     }
 
-  ret = player_now_playing(&id);
+  ret = player_playing_now(&id);
   if (ret < 0)
     goto no_artwork;
 

--- a/src/httpd_streaming.c
+++ b/src/httpd_streaming.c
@@ -290,9 +290,9 @@ streaming_write(struct output_buffer *obuf)
   if (!streaming_sessions)
     return;
 
-  if (!quality_is_equal(&obuf->frames[0].quality, &streaming_quality))
+  if (!quality_is_equal(&obuf->data[0].quality, &streaming_quality))
     {
-      ret = write(streaming_meta[1], &obuf->frames[0].quality, sizeof(struct media_quality));
+      ret = write(streaming_meta[1], &obuf->data[0].quality, sizeof(struct media_quality));
       if (ret < 0)
 	{
 	  DPRINTF(E_LOG, L_STREAMING, "Error writing to streaming pipe: %s\n", strerror(errno));
@@ -300,7 +300,7 @@ streaming_write(struct output_buffer *obuf)
 	}
     }
 
-  ret = write(streaming_pipe[1], obuf->frames[0].buffer, obuf->frames[0].bufsize);
+  ret = write(streaming_pipe[1], obuf->data[0].buffer, obuf->data[0].bufsize);
   if (ret < 0)
     {
       if (errno == EAGAIN)

--- a/src/httpd_streaming.h
+++ b/src/httpd_streaming.h
@@ -3,6 +3,7 @@
 #define __HTTPD_STREAMING_H__
 
 #include "httpd.h"
+#include "outputs.h"
 
 /* httpd_streaming takes care of incoming requests to /stream.mp3
  * It will receive decoded audio from the player, and encode it, and
@@ -11,7 +12,7 @@
  */
 
 void
-streaming_write(uint8_t *buf, uint64_t rtptime);
+streaming_write(struct output_buffer *obuf);
 
 int
 streaming_request(struct evhttp_request *req, struct httpd_uri_parsed *uri_parsed);

--- a/src/input.c
+++ b/src/input.c
@@ -267,9 +267,6 @@ input_write(struct evbuffer *evbuf, struct media_quality *quality, short flags)
       return 0;
     }
 
-  // Change of quality. Note, the marker is placed at the last position of the
-  // last byte we wrote, even though that of course doesn't have the new quality
-  // yet. Not intuitive, but input_read() will understand.
   if (quality && !quality_is_equal(quality, &input_buffer.cur_write_quality))
     {
       input_buffer.cur_write_quality = *quality;

--- a/src/input.c
+++ b/src/input.c
@@ -477,6 +477,12 @@ input_wait(void)
   // Is the buffer full?
   if (evbuffer_get_length(input_buffer.evbuf) > INPUT_BUFFER_THRESHOLD)
     {
+      if (input_buffer.full_cb)
+	{
+	  input_buffer.full_cb();
+	  input_buffer.full_cb = NULL;
+	}
+
       pthread_mutex_unlock(&input_buffer.mutex);
       return -1;
     }

--- a/src/input.c
+++ b/src/input.c
@@ -215,7 +215,7 @@ playback(void *arg)
   // Loops until input_loop_break is set or no more input, e.g. EOF
   ret = inputs[type]->start(ps);
   if (ret < 0)
-    input_write(NULL, INPUT_FLAG_ERROR);
+    input_write(NULL, 0, 0, INPUT_FLAG_ERROR);
 
 #ifdef DEBUG
   DPRINTF(E_DBG, L_PLAYER, "Playback loop stopped (break is %d, ret %d)\n", input_loop_break, ret);
@@ -240,7 +240,7 @@ input_wait(void)
 
 // Called by input modules from within the playback loop
 int
-input_write(struct evbuffer *evbuf, short flags)
+input_write(struct evbuffer *evbuf, int sample_rate, int bits_per_sample, short flags)
 {
   struct timespec ts;
   int ret;

--- a/src/input.c
+++ b/src/input.c
@@ -41,9 +41,9 @@
 #include "commands.h"
 #include "input.h"
 
-// Disallow further writes to the buffer when its size is larger than this threshold
-// TODO untie from 44100
-#define INPUT_BUFFER_THRESHOLD STOB(88200, 16, 2)
+// Disallow further writes to the buffer when its size exceeds this threshold.
+// The below gives us room to buffer 2 seconds of 48000/16/2 audio.
+#define INPUT_BUFFER_THRESHOLD STOB(96000, 16, 2)
 // How long (in sec) to wait for player read before looping in playback thread
 #define INPUT_LOOP_TIMEOUT 1
 
@@ -359,65 +359,6 @@ stop_cmd(void *arg, int *retval)
   *retval = 0;
   return COMMAND_END;
 }
-
-/*
-static enum command_state
-next(void *arg, int *retval)
-{
-  struct player_status status;
-  struct db_queue_item *queue_item;
-  uint32_t item_id;
-  int type;
-  int ret;
-
-  // We may have finished reading source way before end of playback, and we
-  // don't want to proceed prematurely. So we wait until the input buffer is
-  // below the write threshold.
-  ret = input_wait();
-  if (ret < 0)
-    {
-      input_next(); // Async call to ourselves
-      return;
-    }
-
-  item_id = input_now_reading.item_id;
-
-  // Cleans up the source that has ended/failed and clears input_now_reading
-  stop(NULL, NULL);
-
-  player_get_status(&status);
-
-  // TODO what about repeat/repeat_all? Maybe move next() to player that can
-  // just call input_start()
-
-  // Get the next queue_item from the db
-  queue_item = db_queue_fetch_next(item_id, status.shuffle);
-  if (!queue_item)
-    {
-      DPRINTF(E_DBG, L_PLAYER, "Reached end of playback queue\n");
-      *retval = 0;
-      return COMMAND_END;
-    }
-
-  ret = setup(&input_now_reading, queue_item, 0);
-  free_queue_item(queue_item, 0);
-  if (ret < 0)
-    goto error;
-
-  DPRINTF(E_DBG, L_PLAYER, "Continuing input read loop for item '%s' (item id %" PRIu32 ")\n", input_now_reading.path, input_now_reading.item_id);
-
-  event_active(inputev, 0, 0);
-
-  *retval = 0;
-  return COMMAND_END;
-
- error:
-  input_write(NULL, NULL, INPUT_FLAG_ERROR);
-  clear(&input_now_reading);
-  *retval = -1;
-  return COMMAND_END;
-}
-*/
 
 static enum command_state
 metadata_get(void *arg, int *retval)

--- a/src/input.c
+++ b/src/input.c
@@ -323,7 +323,7 @@ input_read(void *data, size_t size, short *flags)
   // with multiple markers, and we don't return data that contains mixed sample
   // rates, bits per sample or an EOF in the middle.
   marker = input_buffer.marker_tail;
-  if (marker && marker->pos < input_buffer.bytes_read + size)
+  if (marker && marker->pos <= input_buffer.bytes_read + size)
     {
       *flags = marker->flags;
       if (*flags & INPUT_FLAG_QUALITY)

--- a/src/input.h
+++ b/src/input.h
@@ -140,18 +140,20 @@ struct input_definition
 int input_loop_break;
 
 /*
- * Transfer stream data to the player's input buffer. The input evbuf will be
- * drained on succesful write. This is to avoid copying memory. If the player's
- * input buffer is full the function will block until the write can be made
- * (unless INPUT_FILE_NONBLOCK is set).
+ * Transfer stream data to the player's input buffer. Data must be PCM-LE
+ * samples. The input evbuf will be drained on succesful write. This is to avoid
+ * copying memory. If the player's input buffer is full the function will block
+ * until the write can be made (unless INPUT_FILE_NONBLOCK is set).
  *
- * @in  evbuf    Raw audio data to write
+ * @in  evbuf    Raw PCM_LE audio data to write
+ * @in  evbuf    Sample rate of the data
+ * @in  evbuf    Bits per sample (typically 16 or 24)
  * @in  flags    One or more INPUT_FLAG_*
  * @return       0 on success, EAGAIN if buffer was full (and _NONBLOCK is set),
  *               -1 on error
  */
 int
-input_write(struct evbuffer *evbuf, short flags);
+input_write(struct evbuffer *evbuf, int sample_rate, int bits_per_sample, short flags);
 
 /*
  * Input modules can use this to wait in the playback loop (like input_write()

--- a/src/input.h
+++ b/src/input.h
@@ -6,8 +6,8 @@
 # include <config.h>
 #endif
 #include <event2/buffer.h>
+#include "db.h"
 #include "misc.h"
-#include "transcode.h"
 
 // Must be in sync with inputs[] in input.c
 enum input_types
@@ -22,64 +22,49 @@ enum input_types
 
 enum input_flags
 {
-  // Write to input buffer must not block
-  INPUT_FLAG_NONBLOCK = (1 << 0),
+  // Flags that input is closing current source
+  INPUT_FLAG_START_NEXT = (1 << 0),
   // Flags end of file
-  INPUT_FLAG_EOF      = (1 << 1),
+  INPUT_FLAG_EOF        = (1 << 1),
   // Flags error reading file
-  INPUT_FLAG_ERROR    = (1 << 2),
+  INPUT_FLAG_ERROR      = (1 << 2),
   // Flags possible new stream metadata
-  INPUT_FLAG_METADATA = (1 << 3),
+  INPUT_FLAG_METADATA   = (1 << 3),
   // Flags new stream quality
-  INPUT_FLAG_QUALITY  = (1 << 4),
+  INPUT_FLAG_QUALITY    = (1 << 4),
 };
 
-struct player_source
+struct input_source
 {
-  /* Id of the file/item in the files database */
-  uint32_t id;
+  // Type of input
+  enum input_types type;
 
-  /* Item-Id of the file/item in the queue */
+  // Item-Id of the file/item in the queue
   uint32_t item_id;
 
-  /* Length of the file/item in milliseconds */
+  // Id of the file/item in the files database
+  uint32_t id;
+
+  // Length of the file/item in milliseconds
   uint32_t len_ms;
 
   enum data_kind data_kind;
   enum media_kind media_kind;
   char *path;
 
-  /* Start time of the media item as rtp-time
-     The stream-start is the rtp-time the media item did or would have
-     started playing (after seek or pause), therefor the elapsed time of the
-     media item is always:
-     elapsed time = current rtptime - stream-start */
-  uint64_t stream_start;
+  // Flags that the input has been opened (i.e. needs to be closed)
+  bool open;
 
-  /* Output start time of the media item as rtp-time
-     The output start time is the rtp-time of the first audio packet send
-     to the audio outputs.
-     It differs from stream-start especially after a seek, where the first audio
-     packet has the next rtp-time as output start and stream start becomes the
-     rtp-time the media item would have been started playing if the seek did
-     not happen. */
-  uint64_t output_start;
-
-  /* End time of media item as rtp-time
-     The end time is set if the reading (source_read) of the media item reached
-     end of file, until then it is 0. */
-  uint64_t end;
-
-  /* Opaque pointer to data that the input sets up when called with setup(), and
-   * which is cleaned up by the input with stop()
-   */
+  // The below is private data for the input backend. It is optional for the
+  // backend to use, so nothing in the input or player should depend on it!
+  //
+  // Opaque pointer to data that the input backend sets up when start() is
+  // called, and that is cleaned up by the backend when stop() is called
   void *input_ctx;
-
-  /* Input has completed setup of the source
-   */
-  int setup_done;
-
-  struct player_source *play_next;
+  // Private evbuf. Alloc'ed by backend at start() and free'd at stop()
+  struct evbuffer *evbuf;
+  // Private source quality storage
+  struct media_quality quality;
 };
 
 typedef int (*input_cb)(void);
@@ -90,6 +75,7 @@ struct input_metadata
 
   int startup;
 
+  uint64_t start;
   uint64_t rtptime;
   uint64_t offset;
 
@@ -115,54 +101,62 @@ struct input_definition
   char disabled;
 
   // Prepare a playback session
-  int (*setup)(struct player_source *ps);
+  int (*setup)(struct input_source *source);
 
-  // Starts playback loop (must be defined)
-  int (*start)(struct player_source *ps);
+  // One iteration of the playback loop (= a read operation from source)
+  int (*play)(struct input_source *source);
 
-  // Cleans up when playback loop has ended
-  int (*stop)(struct player_source *ps);
+  // Cleans up (only required when stopping source before it ends itself)
+  int (*stop)(struct input_source *source);
 
   // Changes the playback position
-  int (*seek)(struct player_source *ps, int seek_ms);
+  int (*seek)(struct input_source *source, int seek_ms);
 
   // Return metadata
-  int (*metadata_get)(struct input_metadata *metadata, struct player_source *ps, uint64_t rtptime);
+  int (*metadata_get)(struct input_metadata *metadata, struct input_source *source);
 
   // Initialization function called during startup
   int (*init)(void);
 
   // Deinitialization function called at shutdown
   void (*deinit)(void);
-
 };
 
-/*
- * Input modules should use this to test if playback should end
- */
-int input_loop_break;
+
+/* ---------------------- Interface towards input backends ------------------ */
+/*                           Thread: input and spotify                        */
 
 /*
  * Transfer stream data to the player's input buffer. Data must be PCM-LE
  * samples. The input evbuf will be drained on succesful write. This is to avoid
- * copying memory. If the player's input buffer is full the function will block
- * until the write can be made (unless INPUT_FILE_NONBLOCK is set).
+ * copying memory.
  *
  * @in  evbuf    Raw PCM_LE audio data to write
  * @in  evbuf    Quality of the PCM (sample rate etc.)
  * @in  flags    One or more INPUT_FLAG_*
- * @return       0 on success, EAGAIN if buffer was full (and _NONBLOCK is set),
- *               -1 on error
+ * @return       0 on success, EAGAIN if buffer was full, -1 on error
  */
 int
 input_write(struct evbuffer *evbuf, struct media_quality *quality, short flags);
 
 /*
- * Input modules can use this to wait in the playback loop (like input_write()
- * would have done)
+ * Input modules can use this to wait for the input_buffer to be ready for 
+ * writing. The wait is max INPUT_LOOP_TIMEOUT, which allows the event base to
+ * loop and process pending commands once in a while.
  */
-void
+int
 input_wait(void);
+
+/*
+ * Async switch to the next song in the queue. Mostly for internal use, but
+ * might be relevant some day externally?
+ */
+//void
+//input_next(void);
+
+
+/* ---------------------- Interface towards player thread ------------------- */
+/*                                Thread: player                              */
 
 /*
  * Move a chunk of stream data from the player's input buffer to an output
@@ -186,39 +180,31 @@ void
 input_buffer_full_cb(input_cb cb);
 
 /*
- * Initializes the given player source for playback
+ * Tells the input to start, i.e. after calling this function the input buffer
+ * will begin to fill up, and should be read periodically with input_read(). If
+ * called while another item is still open, it will be closed and the input
+ * buffer will be flushed. This operation blocks.
+ *
+ * @in  item_id  Queue item id to start playing
+ * @in  seek_ms  Position to start playing
+ * @return       Actual seek position if seekable, 0 otherwise, -1 on error
  */
 int
-input_setup(struct player_source *ps);
+input_seek(uint32_t item_id, int seek_ms);
 
 /*
- * Tells the input to start or resume playback, i.e. after calling this function
- * the input buffer will begin to fill up, and should be read periodically with
- * input_read(). Before calling this input_setup() must have been called.
+ * Same as input_seek(), just non-blocking and does not offer seek.
+ *
+ * @in  item_id  Queue item id to start playing
  */
-int
-input_start(struct player_source *ps);
+void
+input_start(uint32_t item_id);
 
 /*
- * Pauses playback of the given player source (stops playback loop) and flushes
- * the input buffer
+ * Stops the input and clears everything. Flushes the input buffer.
  */
-int
-input_pause(struct player_source *ps);
-
-/*
- * Stops playback loop (if running), flushes input buffer and cleans up the
- * player source
- */
-int
-input_stop(struct player_source *ps);
-
-/*
- * Seeks playback position to seek_ms. Returns actual seek position, 0 on
- * unseekable, -1 on error. May block.
- */
-int
-input_seek(struct player_source *ps, int seek_ms);
+void
+input_stop(void);
 
 /*
  * Flush input buffer. Output flags will be the same as input_read().
@@ -236,7 +222,7 @@ input_quality_get(struct media_quality *quality);
  * Gets metadata from the input, returns 0 if metadata is set, otherwise -1
  */
 int
-input_metadata_get(struct input_metadata *metadata, struct player_source *ps, int startup, uint64_t rtptime);
+input_metadata_get(struct input_metadata *metadata);
 
 /*
  * Free the entire struct

--- a/src/input.h
+++ b/src/input.h
@@ -6,6 +6,7 @@
 # include <config.h>
 #endif
 #include <event2/buffer.h>
+#include "misc.h"
 #include "transcode.h"
 
 // Must be in sync with inputs[] in input.c
@@ -83,13 +84,6 @@ struct player_source
 
 typedef int (*input_cb)(void);
 
-struct input_quality
-{
-  int sample_rate;
-  int bits_per_sample;
-  // Maybe some day also add channels here
-};
-
 struct input_metadata
 {
   uint32_t item_id;
@@ -161,7 +155,7 @@ int input_loop_break;
  *               -1 on error
  */
 int
-input_write(struct evbuffer *evbuf, struct input_quality *quality, short flags);
+input_write(struct evbuffer *evbuf, struct media_quality *quality, short flags);
 
 /*
  * Input modules can use this to wait in the playback loop (like input_write()
@@ -236,7 +230,7 @@ input_flush(short *flags);
  * Returns the current quality of data returned by intput_read().
  */
 int
-input_quality_get(struct input_quality *quality);
+input_quality_get(struct media_quality *quality);
 
 /*
  * Gets metadata from the input, returns 0 if metadata is set, otherwise -1

--- a/src/input.h
+++ b/src/input.h
@@ -29,6 +29,8 @@ enum input_flags
   INPUT_FLAG_ERROR    = (1 << 2),
   // Flags possible new stream metadata
   INPUT_FLAG_METADATA = (1 << 3),
+  // Flags new stream quality
+  INPUT_FLAG_QUALITY  = (1 << 4),
 };
 
 struct player_source
@@ -80,6 +82,13 @@ struct player_source
 };
 
 typedef int (*input_cb)(void);
+
+struct input_quality
+{
+  int sample_rate;
+  int bits_per_sample;
+  // Maybe some day also add channels here
+};
 
 struct input_metadata
 {
@@ -146,14 +155,13 @@ int input_loop_break;
  * until the write can be made (unless INPUT_FILE_NONBLOCK is set).
  *
  * @in  evbuf    Raw PCM_LE audio data to write
- * @in  evbuf    Sample rate of the data
- * @in  evbuf    Bits per sample (typically 16 or 24)
+ * @in  evbuf    Quality of the PCM (sample rate etc.)
  * @in  flags    One or more INPUT_FLAG_*
  * @return       0 on success, EAGAIN if buffer was full (and _NONBLOCK is set),
  *               -1 on error
  */
 int
-input_write(struct evbuffer *evbuf, int sample_rate, int bits_per_sample, short flags);
+input_write(struct evbuffer *evbuf, struct input_quality *quality, short flags);
 
 /*
  * Input modules can use this to wait in the playback loop (like input_write()
@@ -223,6 +231,12 @@ input_seek(struct player_source *ps, int seek_ms);
  */
 void
 input_flush(short *flags);
+
+/*
+ * Returns the current quality of data returned by intput_read().
+ */
+int
+input_quality_get(struct input_quality *quality);
 
 /*
  * Gets metadata from the input, returns 0 if metadata is set, otherwise -1

--- a/src/inputs/file_http.c
+++ b/src/inputs/file_http.c
@@ -30,96 +30,100 @@
 #include "input.h"
 
 static int
-setup(struct player_source *ps)
+setup(struct input_source *source)
 {
-  ps->input_ctx = transcode_setup(XCODE_PCM_NATIVE, ps->data_kind, ps->path, ps->len_ms, NULL);
-  if (!ps->input_ctx)
+  struct transcode_ctx *ctx;
+
+  ctx = transcode_setup(XCODE_PCM_NATIVE, source->data_kind, source->path, source->len_ms, NULL);
+  if (!ctx)
     return -1;
 
-  ps->setup_done = 1;
+  CHECK_NULL(L_PLAYER, source->evbuf = evbuffer_new());
+
+  source->quality.sample_rate = transcode_encode_query(ctx->encode_ctx, "sample_rate");
+  source->quality.bits_per_sample = transcode_encode_query(ctx->encode_ctx, "bits_per_sample");
+  source->quality.channels = transcode_encode_query(ctx->encode_ctx, "channels");
+
+  source->input_ctx = ctx;
 
   return 0;
 }
 
 static int
-setup_http(struct player_source *ps)
+setup_http(struct input_source *source)
 {
   char *url;
 
-  if (http_stream_setup(&url, ps->path) < 0)
+  if (http_stream_setup(&url, source->path) < 0)
     return -1;
 
-  free(ps->path);
-  ps->path = url;
+  free(source->path);
+  source->path = url;
 
-  return setup(ps);
+  return setup(source);
 }
 
 static int
-start(struct player_source *ps)
+stop(struct input_source *source)
 {
-  struct transcode_ctx *ctx = ps->input_ctx;
-  struct media_quality quality = { 0 };
-  struct evbuffer *evbuf;
-  short flags;
-  int ret;
-  int icy_timer;
-
-  evbuf = evbuffer_new();
-
-  quality.sample_rate = transcode_encode_query(ctx->encode_ctx, "sample_rate");
-  quality.bits_per_sample = transcode_encode_query(ctx->encode_ctx, "bits_per_sample");
-  quality.channels = transcode_encode_query(ctx->encode_ctx, "channels");
-
-  ret = -1;
-  flags = 0;
-  while (!input_loop_break && !(flags & INPUT_FLAG_EOF))
-    {
-      // We set "wanted" to 1 because the read size doesn't matter to us
-      // TODO optimize?
-      ret = transcode(evbuf, &icy_timer, ctx, 1);
-      if (ret < 0)
-	break;
-
-      flags = ((ret == 0) ? INPUT_FLAG_EOF : 0) |
-               (icy_timer ? INPUT_FLAG_METADATA : 0);
-
-      ret = input_write(evbuf, &quality, flags);
-      if (ret < 0)
-	break;
-    }
-
-  evbuffer_free(evbuf);
-
-  return ret;
-}
-
-static int
-stop(struct player_source *ps)
-{
-  struct transcode_ctx *ctx = ps->input_ctx;
+  struct transcode_ctx *ctx = source->input_ctx;
 
   transcode_cleanup(&ctx);
+  evbuffer_free(source->evbuf);
 
-  ps->input_ctx = NULL;
-  ps->setup_done = 0;
+  source->input_ctx = NULL;
 
   return 0;
 }
 
 static int
-seek(struct player_source *ps, int seek_ms)
+play(struct input_source *source)
 {
-  return transcode_seek(ps->input_ctx, seek_ms);
+  struct transcode_ctx *ctx = source->input_ctx;
+  int icy_timer;
+  int ret;
+  short flags;
+
+  ret = input_wait();
+  if (ret < 0)
+    return 0; // Loop, input_buffer is not ready for writing
+
+  // We set "wanted" to 1 because the read size doesn't matter to us
+  // TODO optimize?
+  ret = transcode(source->evbuf, &icy_timer, ctx, 1);
+  if (ret == 0)
+    {
+      input_write(source->evbuf, &source->quality, INPUT_FLAG_EOF);
+      stop(source);
+      return -1;
+    }
+  else if (ret < 0)
+    {
+      input_write(NULL, NULL, INPUT_FLAG_ERROR);
+      stop(source);
+      return -1;
+    }
+
+  flags = (icy_timer ? INPUT_FLAG_METADATA : 0);
+
+  input_write(source->evbuf, &source->quality, flags);
+
+  return 0;
 }
 
 static int
-metadata_get_http(struct input_metadata *metadata, struct player_source *ps, uint64_t rtptime)
+seek(struct input_source *source, int seek_ms)
+{
+  return transcode_seek(source->input_ctx, seek_ms);
+}
+
+static int
+metadata_get_http(struct input_metadata *metadata, struct input_source *source)
 {
   struct http_icy_metadata *m;
   int changed;
 
-  m = transcode_metadata(ps->input_ctx, &changed);
+  m = transcode_metadata(source->input_ctx, &changed);
   if (!m)
     return -1;
 
@@ -147,7 +151,7 @@ struct input_definition input_file =
   .type = INPUT_TYPE_FILE,
   .disabled = 0,
   .setup = setup,
-  .start = start,
+  .play = play,
   .stop = stop,
   .seek = seek,
 };
@@ -158,7 +162,7 @@ struct input_definition input_http =
   .type = INPUT_TYPE_HTTP,
   .disabled = 0,
   .setup = setup_http,
-  .start = start,
+  .play = play,
   .stop = stop,
   .metadata_get = metadata_get_http,
 };

--- a/src/inputs/file_http.c
+++ b/src/inputs/file_http.c
@@ -59,7 +59,7 @@ static int
 start(struct player_source *ps)
 {
   struct transcode_ctx *ctx = ps->input_ctx;
-  struct input_quality quality = { 0 };
+  struct media_quality quality = { 0 };
   struct evbuffer *evbuf;
   short flags;
   int ret;
@@ -69,6 +69,7 @@ start(struct player_source *ps)
 
   quality.sample_rate = transcode_encode_query(ctx->encode_ctx, "sample_rate");
   quality.bits_per_sample = transcode_encode_query(ctx->encode_ctx, "bits_per_sample");
+  quality.channels = transcode_encode_query(ctx->encode_ctx, "channels");
 
   ret = -1;
   flags = 0;

--- a/src/inputs/file_http.c
+++ b/src/inputs/file_http.c
@@ -59,17 +59,16 @@ static int
 start(struct player_source *ps)
 {
   struct transcode_ctx *ctx = ps->input_ctx;
+  struct input_quality quality = { 0 };
   struct evbuffer *evbuf;
   short flags;
-  int sample_rate;
-  int bps;
   int ret;
   int icy_timer;
 
   evbuf = evbuffer_new();
 
-  sample_rate = transcode_encode_query(ctx->encode_ctx, "sample_rate");
-  bps = transcode_encode_query(ctx->encode_ctx, "bits_per_sample");
+  quality.sample_rate = transcode_encode_query(ctx->encode_ctx, "sample_rate");
+  quality.bits_per_sample = transcode_encode_query(ctx->encode_ctx, "bits_per_sample");
 
   ret = -1;
   flags = 0;
@@ -84,7 +83,7 @@ start(struct player_source *ps)
       flags = ((ret == 0) ? INPUT_FLAG_EOF : 0) |
                (icy_timer ? INPUT_FLAG_METADATA : 0);
 
-      ret = input_write(evbuf, sample_rate, bps, flags);
+      ret = input_write(evbuf, &quality, flags);
       if (ret < 0)
 	break;
     }

--- a/src/inputs/file_http.c
+++ b/src/inputs/file_http.c
@@ -69,9 +69,12 @@ stop(struct input_source *source)
   struct transcode_ctx *ctx = source->input_ctx;
 
   transcode_cleanup(&ctx);
-  evbuffer_free(source->evbuf);
+
+  if (source->evbuf)
+    evbuffer_free(source->evbuf);
 
   source->input_ctx = NULL;
+  source->evbuf = NULL;
 
   return 0;
 }

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -831,7 +831,7 @@ static int
 start(struct player_source *ps)
 {
   struct pipe *pipe = ps->input_ctx;
-  struct input_quality quality = { 0 };
+  struct media_quality quality = { 0 };
   struct evbuffer *evbuf;
   short flags;
   int ret;
@@ -845,6 +845,7 @@ start(struct player_source *ps)
 
   quality.sample_rate = pipe_sample_rate;
   quality.bits_per_sample = pipe_bits_per_sample;
+  quality.channels = 2;
 
   ret = -1;
   while (!input_loop_break)

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -840,7 +840,8 @@ stop(struct input_source *source)
 
   DPRINTF(E_DBG, L_PLAYER, "Stopping pipe\n");
 
-  evbuffer_free(source->evbuf);
+  if (source->evbuf)
+    evbuffer_free(source->evbuf);
 
   pipe_close(pipe->fd);
 
@@ -858,6 +859,7 @@ stop(struct input_source *source)
   pipe_free(pipe);
 
   source->input_ctx = NULL;
+  source->evbuf = NULL;
 
   return 0;
 }

--- a/src/inputs/spotify.c
+++ b/src/inputs/spotify.c
@@ -86,7 +86,6 @@ struct input_definition input_spotify =
   .type = INPUT_TYPE_SPOTIFY,
   .disabled = 0,
   .setup = setup,
-  .start = start,
   .stop = stop,
   .seek = seek,
 };

--- a/src/inputs/spotify.c
+++ b/src/inputs/spotify.c
@@ -31,12 +31,12 @@
 #define SPOTIFY_SETUP_RETRY_WAIT 500000
 
 static int
-setup(struct player_source *ps)
+setup(struct input_source *source)
 {
   int i = 0;
   int ret;
 
-  while((ret = spotify_playback_setup(ps->path)) == SPOTIFY_SETUP_ERROR_IS_LOADING)
+  while((ret = spotify_playback_setup(source->path)) == SPOTIFY_SETUP_ERROR_IS_LOADING)
     {
       if (i >= SPOTIFY_SETUP_RETRIES)
 	break;
@@ -49,32 +49,15 @@ setup(struct player_source *ps)
   if (ret < 0)
     return -1;
 
-  ps->setup_done = 1;
+  ret = spotify_playback_play();
+  if (ret < 0)
+    return -1;
 
   return 0;
 }
 
 static int
-start(struct player_source *ps)
-{
-  int ret;
-
-  ret = spotify_playback_play();
-  if (ret < 0)
-    return -1;
-
-  while (!input_loop_break)
-    {
-      input_wait();
-    }
-
-  ret = spotify_playback_pause();
-
-  return ret;
-}
-
-static int
-stop(struct player_source *ps)
+stop(struct input_source *source)
 {
   int ret;
 
@@ -82,13 +65,11 @@ stop(struct player_source *ps)
   if (ret < 0)
     return -1;
 
-  ps->setup_done = 0;
-
   return 0;
 }
 
 static int
-seek(struct player_source *ps, int seek_ms)
+seek(struct input_source *source, int seek_ms)
 {
   int ret;
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -1039,6 +1039,11 @@ murmur_hash64(const void *key, int len, uint32_t seed)
 # error Platform not supported
 #endif
 
+bool
+quality_is_equal(struct media_quality *a, struct media_quality *b)
+{
+  return (a->sample_rate == b->sample_rate && a->bits_per_sample == b->bits_per_sample && a->channels == b->channels);
+}
 
 bool
 peer_address_is_trusted(const char *addr)

--- a/src/misc.h
+++ b/src/misc.h
@@ -12,10 +12,17 @@
 #include <pthread.h>
 
 /* Samples to bytes, bytes to samples */
-#define STOB(s) ((s) * 4)
-#define BTOS(b) ((b) / 4)
+#define STOB(s, bits, c) ((s) * (c) * (bits) / 8)
+#define BTOS(b, bits, c) ((b) / ((c) * (bits) / 8))
 
 #define ARRAY_SIZE(x) ((unsigned int)(sizeof(x) / sizeof((x)[0])))
+
+// Remember to adjust quality_is_equal() if adding elements
+struct media_quality {
+  int sample_rate;
+  int bits_per_sample;
+  int channels;
+};
 
 struct onekeyval {
   char *name;
@@ -113,6 +120,9 @@ b64_encode(const uint8_t *in, size_t len);
 
 uint64_t
 murmur_hash64(const void *key, int len, uint32_t seed);
+
+bool
+quality_is_equal(struct media_quality *a, struct media_quality *b);
 
 // Checks if the address is in a network that is configured as trusted
 bool

--- a/src/misc.h
+++ b/src/misc.h
@@ -17,6 +17,10 @@
 
 #define ARRAY_SIZE(x) ((unsigned int)(sizeof(x) / sizeof((x)[0])))
 
+#ifndef MIN
+# define MIN(a, b) ((a < b) ? a : b)
+#endif
+
 // Remember to adjust quality_is_equal() if adding elements
 struct media_quality {
   int sample_rate;

--- a/src/misc.h
+++ b/src/misc.h
@@ -46,6 +46,15 @@ struct keyval {
   struct onekeyval *tail;
 };
 
+struct ringbuffer {
+  uint8_t *buffer;
+  size_t size;
+  size_t write_avail;
+  size_t read_avail;
+  size_t write_pos;
+  size_t read_pos;
+};
+
 
 char **
 buildopts_get(void);
@@ -136,6 +145,18 @@ quality_is_equal(struct media_quality *a, struct media_quality *b);
 // Checks if the address is in a network that is configured as trusted
 bool
 peer_address_is_trusted(const char *addr);
+
+int
+ringbuffer_init(struct ringbuffer *buf, size_t size);
+
+void
+ringbuffer_free(struct ringbuffer *buf, bool content_only);
+
+size_t
+ringbuffer_write(struct ringbuffer *buf, const void* src, size_t srclen);
+
+size_t
+ringbuffer_read(uint8_t **dst, size_t dstlen, struct ringbuffer *buf);
 
 
 #ifndef HAVE_CLOCK_GETTIME

--- a/src/misc.h
+++ b/src/misc.h
@@ -21,6 +21,11 @@
 # define MIN(a, b) ((a < b) ? a : b)
 #endif
 
+#ifndef MAX
+#define MAX(a, b) ((a > b) ? a : b)
+#endif
+
+
 // Remember to adjust quality_is_equal() if adding elements
 struct media_quality {
   int sample_rate;

--- a/src/outputs.c
+++ b/src/outputs.c
@@ -527,7 +527,7 @@ outputs_listener_notify(void)
 
 /* ---------------------------- Called by player ---------------------------- */
 
-int
+struct output_device *
 outputs_device_add(struct output_device *add, bool new_deselect, int default_volume)
 {
   struct output_device *device;
@@ -603,7 +603,7 @@ outputs_device_add(struct output_device *add, bool new_deselect, int default_vol
 
   listener_notify(LISTENER_SPEAKER);
 
-  return 0;
+  return device;
 }
 
 void

--- a/src/outputs.c
+++ b/src/outputs.c
@@ -815,7 +815,7 @@ outputs_flush(output_status_cb cb)
 }
 
 void
-outputs_write(void *buf, size_t bufsize, struct media_quality *quality, int nsamples, struct timespec *pts)
+outputs_write(void *buf, size_t bufsize, int nsamples, struct media_quality *quality, struct timespec *pts)
 {
   int i;
 

--- a/src/outputs.c
+++ b/src/outputs.c
@@ -223,10 +223,20 @@ quality_to_xcode(struct media_quality *quality)
     return XCODE_PCM16_44100;
   if (quality->sample_rate == 44100 && quality->bits_per_sample == 24)
     return XCODE_PCM24_44100;
+  if (quality->sample_rate == 44100 && quality->bits_per_sample == 32)
+    return XCODE_PCM32_44100;
   if (quality->sample_rate == 48000 && quality->bits_per_sample == 16)
     return XCODE_PCM16_48000;
   if (quality->sample_rate == 48000 && quality->bits_per_sample == 24)
     return XCODE_PCM24_48000;
+  if (quality->sample_rate == 48000 && quality->bits_per_sample == 32)
+    return XCODE_PCM32_48000;
+  if (quality->sample_rate == 96000 && quality->bits_per_sample == 16)
+    return XCODE_PCM16_96000;
+  if (quality->sample_rate == 96000 && quality->bits_per_sample == 24)
+    return XCODE_PCM24_96000;
+  if (quality->sample_rate == 96000 && quality->bits_per_sample == 32)
+    return XCODE_PCM32_96000;
 
   return XCODE_UNKNOWN;
 }
@@ -309,6 +319,9 @@ buffer_fill(struct output_buffer *obuf, void *buf, size_t bufsize, struct media_
     {
       if (quality_is_equal(&output_quality_subscriptions[i].quality, quality))
 	continue; // Skip, no resampling required and we have the data in element 0
+
+      if (!output_quality_subscriptions[i].encode_ctx)
+	continue;
 
       frame = transcode_frame_new(buf, bufsize, nsamples, quality->sample_rate, quality->bits_per_sample);
       if (!frame)

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -199,6 +199,9 @@ struct output_definition
   // Close a session prepared by device_start and call back
   int (*device_stop)(struct output_device *device, int callback_id);
 
+  // Flush device session and call back
+  int (*device_flush)(struct output_device *device, int callback_id);
+
   // Test the connection to a device and call back
   int (*device_probe)(struct output_device *device, int callback_id);
 
@@ -222,9 +225,6 @@ struct output_definition
 
   // Write stream data to the output devices
   void (*write)(struct output_buffer *buffer);
-
-  // Flush all sessions, the return must be number of sessions pending the flush
-  int (*flush)(int callback_id);
 
   // Authorize an output with a pin-code (probably coming from the filescanner)
   void (*authorize)(const char *pin);
@@ -279,6 +279,9 @@ int
 outputs_device_stop(struct output_device *device, output_status_cb cb);
 
 int
+outputs_device_flush(struct output_device *device, output_status_cb cb);
+
+int
 outputs_device_probe(struct output_device *device, output_status_cb cb);
 
 int
@@ -299,11 +302,11 @@ outputs_device_free(struct output_device *device);
 void
 outputs_playback_stop(void);
 
-void
-outputs_write(void *buf, size_t bufsize, struct media_quality *quality, int nsamples, struct timespec *pts);
-
 int
 outputs_flush(output_status_cb cb);
+
+void
+outputs_write(void *buf, size_t bufsize, struct media_quality *quality, int nsamples, struct timespec *pts);
 
 struct output_metadata *
 outputs_metadata_prepare(int id);

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -153,7 +153,7 @@ struct output_metadata
   struct output_metadata *next;
 };
 
-struct output_frame
+struct output_data
 {
   struct media_quality quality;
   struct evbuffer *evbuf;
@@ -166,7 +166,7 @@ struct output_buffer
 {
   uint32_t write_counter; // REMOVE ME? not used for anything
   struct timespec pts;
-  struct output_frame frames[OUTPUTS_MAX_QUALITY_SUBSCRIPTIONS + 1];
+  struct output_data data[OUTPUTS_MAX_QUALITY_SUBSCRIPTIONS + 1];
 } output_buffer;
 
 typedef void (*output_status_cb)(struct output_device *device, enum output_device_state status);

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -309,7 +309,7 @@ int
 outputs_flush(output_status_cb cb);
 
 void
-outputs_write(void *buf, size_t bufsize, struct media_quality *quality, int nsamples, struct timespec *pts);
+outputs_write(void *buf, size_t bufsize, int nsamples, struct media_quality *quality, struct timespec *pts);
 
 struct output_metadata *
 outputs_metadata_prepare(int id);

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -266,7 +266,10 @@ outputs_listener_notify(void);
 
 /* ---------------------------- Called by player ---------------------------- */
 
-int
+// Ownership of *add is transferred, so don't address after calling. Instead you
+// can address the return value (which is not the same if the device was already
+// in the list.
+struct output_device *
 outputs_device_add(struct output_device *add, bool new_deselect, int default_volume);
 
 void

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -172,6 +172,7 @@ struct output_frame
 struct output_buffer
 {
   uint32_t write_counter; // REMOVE ME? not used for anything
+  struct timespec *pts;
   struct output_frame frames[OUTPUTS_MAX_QUALITY_SUBSCRIPTIONS + 1];
 } output_buffer;
 
@@ -202,6 +203,7 @@ struct output_definition
 
   // Prepare a playback session on device and call back
   int (*device_start)(struct output_device *device, output_status_cb cb, uint64_t rtptime);
+  int (*device_start2)(struct output_device *device, output_status_cb cb);
 
   // Close a session prepared by device_start
   void (*device_stop)(struct output_session *session);
@@ -223,7 +225,6 @@ struct output_definition
 
   // Start/stop playback on devices that were started
   void (*playback_start)(uint64_t next_pkt, struct timespec *ts);
-  void (*playback_start2)(struct timespec *start_time);
   void (*playback_stop)(void);
 
   // Write stream data to the output devices
@@ -232,6 +233,7 @@ struct output_definition
 
   // Flush all sessions, the return must be number of sessions pending the flush
   int (*flush)(output_status_cb cb, uint64_t rtptime);
+  int (*flush2)(output_status_cb cb);
 
   // Authorize an output with a pin-code (probably coming from the filescanner)
   void (*authorize)(const char *pin);
@@ -248,6 +250,9 @@ struct output_definition
 
 int
 outputs_device_start(struct output_device *device, output_status_cb cb, uint64_t rtptime);
+
+int
+outputs_device_start2(struct output_device *device, output_status_cb cb);
 
 void
 outputs_device_stop(struct output_session *session);
@@ -269,22 +274,19 @@ int
 outputs_device_quality_set(struct output_device *device, struct media_quality *quality);
 
 void
-outputs_playback_start(uint64_t next_pkt, struct timespec *start_time);
-
-void
-outputs_playback_start2(struct timespec *start_time);
-
-void
 outputs_playback_stop(void);
 
 void
 outputs_write(uint8_t *buf, uint64_t rtptime);
 
 void
-outputs_write2(void *buf, size_t bufsize, struct media_quality *quality, int nsamples);
+outputs_write2(void *buf, size_t bufsize, struct media_quality *quality, int nsamples, struct timespec *pts);
 
 int
 outputs_flush(output_status_cb cb, uint64_t rtptime);
+
+int
+outputs_flush2(output_status_cb cb);
 
 void
 outputs_status_cb(struct output_session *session, output_status_cb cb);

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -114,7 +114,7 @@ struct output_device
 
   // Misc device flags 
   unsigned selected:1;
-  unsigned advertised:1;
+//  unsigned advertised:1;
   unsigned has_password:1;
   unsigned has_video:1;
   unsigned requires_auth:1;
@@ -265,6 +265,12 @@ void
 outputs_listener_notify(void);
 
 /* ---------------------------- Called by player ---------------------------- */
+
+int
+outputs_device_add(struct output_device *add, bool new_deselect, int default_volume);
+
+void
+outputs_device_remove(struct output_device *remove);
 
 int
 outputs_device_start(struct output_device *device, output_status_cb cb);

--- a/src/outputs.h
+++ b/src/outputs.h
@@ -114,7 +114,7 @@ struct output_device
 
   // Misc device flags 
   unsigned selected:1;
-//  unsigned advertised:1;
+  unsigned advertised:1;
   unsigned has_password:1;
   unsigned has_video:1;
   unsigned requires_auth:1;

--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -648,7 +648,7 @@ sync_check(snd_pcm_sframes_t *delay, snd_pcm_sframes_t *avail, struct alsa_sessi
   // The will be used by sync_correct, so it knows how much we are out of sync
   as->last_latency = latency;
 
-  DPRINTF(E_DBG, L_LAUDIO, "Sync=%d, pos=%lu, as->pos=%u, dev_pos=%lu, latency=%d, delay=%li, avail=%li, elapsed=%lu, dev_elapsed=%lu\n",
+  DPRINTF(E_DBG, L_LAUDIO, "Sync=%d, pos=%" PRIu64 ", as->pos=%u, dev_pos=%" PRIu64 ", latency=%d, delay=%li, avail=%li, elapsed=%" PRIu64 ", dev_elapsed=%" PRIu64 "\n",
     sync, pos, as->pos, dev_pos, latency, *delay, *avail, elapsed / 1000000, dev_elapsed / 1000000);
 
   return sync;

--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -196,7 +196,7 @@ alsa_session_make(struct output_device *device, output_status_cb cb)
   as->next = sessions;
   sessions = as;
 
-  device->session = as;
+  outputs_device_session_add(device, as);
 
   return as;
 

--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -1028,7 +1028,6 @@ alsa_init(void)
   device->name = strdup(nickname);
   device->type = OUTPUT_TYPE_ALSA;
   device->type_name = outputs_name(device->type);
-  device->advertised = 1;
   device->has_video = 0;
 
   DPRINTF(E_INFO, L_LAUDIO, "Adding ALSA device '%s' with name '%s'\n", card_name, nickname);

--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Espen Jürgensen <espenjurgensen@gmail.com>
+ * Copyright (C) 2015-2019 Espen Jürgensen <espenjurgensen@gmail.com>
  * Copyright (C) 2010 Julien BLACHE <jb@jblache.org>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -29,7 +29,6 @@
 #include <stdint.h>
 #include <inttypes.h>
 
-#include <event2/event.h>
 #include <asoundlib.h>
 
 #include "misc.h"
@@ -50,27 +49,7 @@
 // within the 10 seconds where we measure latency each second.
 #define ALSA_MAX_LATENCY_VARIANCE 352
 
-// TODO Unglobalise these and add support for multiple sound cards
-static char *card_name;
-static char *mixer_name;
-static char *mixer_device_name;
-static snd_pcm_t *hdl;
-static snd_mixer_t *mixer_hdl;
-static snd_mixer_elem_t *vol_elem;
-static long vol_min;
-static long vol_max;
-static int offset;
-static int adjust_period_seconds;
-
 #define ALSA_F_STARTED  (1 << 15)
-
-enum alsa_state
-{
-  ALSA_STATE_FAILED    = 0,
-  ALSA_STATE_STOPPED   = 1,
-  ALSA_STATE_STARTED   = ALSA_F_STARTED,
-  ALSA_STATE_STREAMING = ALSA_F_STARTED | 0x01,
-};
 
 enum alsa_sync_state
 {
@@ -81,58 +60,681 @@ enum alsa_sync_state
 
 struct alsa_session
 {
-  enum alsa_state state;
+  enum output_device_state state;
 
-  char *devname;
+  uint64_t device_id;
+  int callback_id;
 
-  uint64_t pos;
-  uint64_t start_pos;
+  const char *devname;
+  const char *card_name;
+  const char *mixer_name;
+  const char *mixer_device_name;
 
+  snd_pcm_status_t *pcm_status;
+
+  struct media_quality quality;
+
+  int buffer_nsamp;
+
+  uint32_t pos;
+  uint32_t start_pos;
+
+  struct timespec start_pts;
+  struct timespec last_pts;
+  snd_htimestamp_t dev_start_ts;
+
+  snd_pcm_sframes_t last_avail;
   int32_t last_latency;
-  int sync_counter;
-  unsigned source_sample_rate;  // raw input audio sample rate in Hz
-  unsigned target_sample_rate;  // output rate in Hz to configure ALSA device
 
-  // An array that will hold the packets we prebuffer. The length of the array
-  // is prebuf_len (measured in rtp_packets)
-  uint8_t *prebuf;
-  uint32_t prebuf_len;
-  uint32_t prebuf_head;
-  uint32_t prebuf_tail;
+  // Here we buffer samples during startup
+  struct ringbuffer prebuf;
+
+  int offset;
+  int adjust_period_seconds;
 
   int volume;
+  long vol_min;
+  long vol_max;
 
-  struct event *deferredev;
-  output_status_cb defer_cb;
-
-  struct output_device *device;
-  output_status_cb status_cb;
+  snd_pcm_t *hdl;
+  snd_mixer_t *mixer_hdl;
+  snd_mixer_elem_t *vol_elem;
 
   struct alsa_session *next;
 };
 
-/* From player.c */
-extern struct event_base *evbase_player;
-
 static struct alsa_session *sessions;
 
-/* Forwards */
+// We will try to play the music with the source quality, but if the card
+// doesn't support that we resample to the fallback quality
+static struct media_quality alsa_fallback_quality = { 44100, 16, 2 };
+static struct media_quality alsa_last_quality;
+
+
+/* -------------------------------- FORWARDS -------------------------------- */
+
 static void
-defer_cb(int fd, short what, void *arg);
+alsa_status(struct alsa_session *as);
+
+
+/* ------------------------------- MISC HELPERS ----------------------------- */
+
+static void
+dump_config(struct alsa_session *as)
+{
+  snd_output_t *output;
+  char *debug_pcm_cfg;
+  int ret;
+
+  // Dump PCM config data for E_DBG logging
+  ret = snd_output_buffer_open(&output);
+  if (ret == 0)
+    {
+      if (snd_pcm_dump_setup(as->hdl, output) == 0)
+	{
+	  snd_output_buffer_string(output, &debug_pcm_cfg);
+	  DPRINTF(E_DBG, L_LAUDIO, "Dump of sound device config:\n%s\n", debug_pcm_cfg);
+	}
+
+      snd_output_close(output);
+    }
+}
+
+static int
+mixer_open(struct alsa_session *as)
+{
+  snd_mixer_elem_t *elem;
+  snd_mixer_elem_t *master;
+  snd_mixer_elem_t *pcm;
+  snd_mixer_elem_t *custom;
+  snd_mixer_selem_id_t *sid;
+  int ret;
+
+  ret = snd_mixer_open(&as->mixer_hdl, 0);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Failed to open mixer: %s\n", snd_strerror(ret));
+      as->mixer_hdl = NULL;
+      return -1;
+    }
+
+  ret = snd_mixer_attach(as->mixer_hdl, as->mixer_device_name);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Failed to attach mixer: %s\n", snd_strerror(ret));
+      goto out_close;
+    }
+
+  ret = snd_mixer_selem_register(as->mixer_hdl, NULL, NULL);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Failed to register mixer: %s\n", snd_strerror(ret));
+      goto out_detach;
+    }
+
+  ret = snd_mixer_load(as->mixer_hdl);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Failed to load mixer: %s\n", snd_strerror(ret));
+      goto out_detach;
+    }
+
+  // Grab interesting elements
+  snd_mixer_selem_id_alloca(&sid);
+
+  pcm = NULL;
+  master = NULL;
+  custom = NULL;
+  for (elem = snd_mixer_first_elem(as->mixer_hdl); elem; elem = snd_mixer_elem_next(elem))
+    {
+      snd_mixer_selem_get_id(elem, sid);
+
+      if (as->mixer_name && (strcmp(snd_mixer_selem_id_get_name(sid), as->mixer_name) == 0))
+	{
+	  custom = elem;
+	  break;
+	}
+      else if (strcmp(snd_mixer_selem_id_get_name(sid), "PCM") == 0)
+        pcm = elem;
+      else if (strcmp(snd_mixer_selem_id_get_name(sid), "Master") == 0)
+	master = elem;
+    }
+
+  if (as->mixer_name)
+    {
+      if (custom)
+	as->vol_elem = custom;
+      else
+	{
+	  DPRINTF(E_LOG, L_LAUDIO, "Failed to open configured mixer element '%s'\n", as->mixer_name);
+
+	  goto out_detach;
+	}
+    }
+  else if (pcm)
+    as->vol_elem = pcm;
+  else if (master)
+    as->vol_elem = master;
+  else
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Failed to open PCM or Master mixer element\n");
+
+      goto out_detach;
+    }
+
+  // Get min & max volume
+  snd_mixer_selem_get_playback_volume_range(as->vol_elem, &as->vol_min, &as->vol_max);
+
+  return 0;
+
+ out_detach:
+  snd_mixer_detach(as->mixer_hdl, as->devname);
+ out_close:
+  snd_mixer_close(as->mixer_hdl);
+  as->mixer_hdl = NULL;
+  as->vol_elem = NULL;
+
+  return -1;
+}
+
+static int
+device_open(struct alsa_session *as)
+{
+  snd_pcm_hw_params_t *hw_params;
+  snd_pcm_uframes_t bufsize;
+  int ret;
+
+  hw_params = NULL;
+
+  ret = snd_pcm_open(&as->hdl, as->devname, SND_PCM_STREAM_PLAYBACK, 0);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not open playback device: %s\n", snd_strerror(ret));
+      return -1;
+    }
+
+  // HW params
+  ret = snd_pcm_hw_params_malloc(&hw_params);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not allocate hw params: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  ret = snd_pcm_hw_params_any(as->hdl, hw_params);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not retrieve hw params: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  ret = snd_pcm_hw_params_set_access(as->hdl, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not set access method: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  ret = snd_pcm_hw_params_get_buffer_size_max(hw_params, &bufsize);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not get max buffer size: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  ret = snd_pcm_hw_params_set_buffer_size_max(as->hdl, hw_params, &bufsize);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not set buffer size to max: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  ret = snd_pcm_hw_params(as->hdl, hw_params);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not set hw params: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  snd_pcm_hw_params_free(hw_params);
+  hw_params = NULL;
+
+  ret = mixer_open(as);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not open mixer\n");
+      goto out_fail;
+    }
+
+  return 0;
+
+ out_fail:
+  if (hw_params)
+    snd_pcm_hw_params_free(hw_params);
+
+  snd_pcm_close(as->hdl);
+  as->hdl = NULL;
+
+  return -1;
+}
+
+static int
+device_quality_set(struct alsa_session *as, struct media_quality *quality, char **errmsg)
+{
+  snd_pcm_hw_params_t *hw_params;
+  snd_pcm_format_t format;
+  int ret;
+
+  ret = snd_pcm_hw_params_malloc(&hw_params);
+  if (ret < 0)
+    {
+      *errmsg = safe_asprintf("Could not allocate hw params: %s", snd_strerror(ret));
+      return -1;
+    }
+
+  ret = snd_pcm_hw_params_any(as->hdl, hw_params);
+  if (ret < 0)
+    {
+      *errmsg = safe_asprintf("Could not retrieve hw params: %s", snd_strerror(ret));
+      goto free_params;
+    }
+
+  ret = snd_pcm_hw_params_set_rate(as->hdl, hw_params, quality->sample_rate, 0);
+  if (ret < 0)
+    {
+      *errmsg = safe_asprintf("Hardware doesn't support %d Hz: %s", quality->sample_rate, snd_strerror(ret));
+      goto free_params;
+    }
+
+  switch (quality->bits_per_sample)
+    {
+      case 16:
+	format = SND_PCM_FORMAT_S16_LE;
+	break;
+      case 24:
+	format = SND_PCM_FORMAT_S24_LE;
+	break;
+      case 32:
+	format = SND_PCM_FORMAT_S32_LE;
+	break;
+      default:
+	*errmsg = safe_asprintf("Unrecognized number of bits per sample: %d", quality->bits_per_sample);
+	goto free_params;
+    }
+
+  ret = snd_pcm_hw_params_set_format(as->hdl, hw_params, format);
+  if (ret < 0)
+    {
+      *errmsg = safe_asprintf("Could not set %d bits per sample: %s", quality->bits_per_sample, snd_strerror(ret));
+      goto free_params;
+    }
+
+  ret = snd_pcm_hw_params_set_channels(as->hdl, hw_params, quality->channels);
+  if (ret < 0)
+    {
+      *errmsg = safe_asprintf("Could not set channel number (%d): %s", quality->channels, snd_strerror(ret));
+      goto free_params;
+    }
+
+  ret = snd_pcm_hw_params(as->hdl, hw_params);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not set hw params: %s\n", snd_strerror(ret));
+      goto free_params;
+    }
+
+  snd_pcm_hw_params_free(hw_params);
+  return 0;
+
+ free_params:
+  snd_pcm_hw_params_free(hw_params);
+  return -1;
+}
+
+static int
+device_configure(struct alsa_session *as)
+{
+  snd_pcm_sw_params_t *sw_params;
+  int ret;
+
+  ret = snd_pcm_sw_params_malloc(&sw_params);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not allocate sw params: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  ret = snd_pcm_sw_params_current(as->hdl, sw_params);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not retrieve current sw params: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  ret = snd_pcm_sw_params_set_tstamp_type(as->hdl, sw_params, SND_PCM_TSTAMP_TYPE_MONOTONIC);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not set tstamp type: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  ret = snd_pcm_sw_params_set_tstamp_mode(as->hdl, sw_params, SND_PCM_TSTAMP_ENABLE);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not set tstamp mode: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  ret = snd_pcm_sw_params(as->hdl, sw_params);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not set sw params: %s\n", snd_strerror(ret));
+      goto out_fail;
+    }
+
+  return 0;
+
+ out_fail:
+  snd_pcm_sw_params_free(sw_params);
+
+  return -1;
+}
+
+static void
+device_close(struct alsa_session *as)
+{
+  snd_pcm_close(as->hdl);
+  as->hdl = NULL;
+
+  if (as->mixer_hdl)
+    {
+      snd_mixer_detach(as->mixer_hdl, as->devname);
+      snd_mixer_close(as->mixer_hdl);
+
+      as->mixer_hdl = NULL;
+      as->vol_elem = NULL;
+    }
+}
+
+static inline void
+device_timestamp(struct alsa_session *as, snd_pcm_sframes_t *delay, snd_pcm_sframes_t *avail, snd_htimestamp_t *ts)
+{
+  snd_pcm_status(as->hdl, as->pcm_status);
+
+  if (delay)
+    *delay = snd_pcm_status_get_delay(as->pcm_status);
+  if (avail)
+    *avail = snd_pcm_status_get_avail(as->pcm_status);
+
+  snd_pcm_status_get_htstamp(as->pcm_status, ts);
+}
+
+static void
+playback_restart(struct alsa_session *as, struct output_buffer *obuf)
+{
+  snd_pcm_state_t state;
+  snd_pcm_sframes_t delay;
+  size_t size;
+  char *errmsg;
+  int ret;
+
+  DPRINTF(E_INFO, L_LAUDIO, "Starting ALSA device '%s'\n", as->devname);
+
+  state = snd_pcm_state(as->hdl);
+  if (state != SND_PCM_STATE_PREPARED)
+    {
+      if (state == SND_PCM_STATE_RUNNING)
+	snd_pcm_drop(as->hdl); // FIXME not great to do this during playback - would mean new quality drops audio?
+
+      ret = snd_pcm_prepare(as->hdl);
+      if (ret < 0)
+	{
+	  DPRINTF(E_LOG, L_LAUDIO, "Could not prepare ALSA device '%s' (state %d): %s\n", as->devname, state, snd_strerror(ret));
+	  return;
+	}
+    }
+
+  // Negotiate quality (sample rate) with device - first we try to use the source quality
+  as->quality = obuf->data[0].quality;
+  ret = device_quality_set(as, &as->quality, &errmsg);
+  if (ret < 0)
+    {
+      DPRINTF(E_INFO, L_LAUDIO, "Input quality (%d/%d/%d) not supported, falling back to default. ALSA said: %s\n",
+        as->quality.sample_rate, as->quality.bits_per_sample, as->quality.channels, errmsg);
+      free(errmsg);
+      as->quality = alsa_fallback_quality;
+      ret = device_quality_set(as, &as->quality, &errmsg);
+      if (ret < 0)
+	{
+	  DPRINTF(E_LOG, L_LAUDIO, "ALSA device failed setting fallback quality: %s\n", errmsg);
+	  free(errmsg);
+	  as->state = OUTPUT_STATE_FAILED;
+	  alsa_status(as);
+	  return;
+	}
+    }
+
+  dump_config(as);
+
+  // Clear prebuffer in case start got called twice without a stop in between
+  ringbuffer_free(&as->prebuf, 1);
+
+  as->start_pos = 0;
+  as->pos = 0;
+
+  // Time stamps used for syncing
+  as->start_pts = obuf->pts;
+
+  device_timestamp(as, &delay, &as->last_avail, &as->dev_start_ts);
+  if (as->dev_start_ts.tv_sec == 0 && as->dev_start_ts.tv_nsec == 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Can't get timestamps from ALSA, sync check is disabled\n");
+    }
+
+  // The difference between pos and start_pos should match the 2 second buffer
+  // that AirPlay uses (OUTPUTS_BUFFER_DURATION). We will not use alsa's buffer
+  // for the initial buffering, because my sound card's start_threshold is not
+  // to be counted on. Instead we allocate our own buffer, and when it is time
+  // to play we write as much as we can to alsa's buffer. Delay might be
+  // non-zero if we are restarting (?).
+  as->buffer_nsamp = OUTPUTS_BUFFER_DURATION * as->quality.sample_rate - delay;
+  size = STOB(as->buffer_nsamp, as->quality.bits_per_sample, as->quality.channels);
+  ringbuffer_init(&as->prebuf, size);
+
+  as->state = OUTPUT_STATE_STREAMING;
+}
+
+// This function writes the sample buf into either the prebuffer or directly to
+// ALSA, depending on how much room there is in ALSA, and whether we are
+// prebuffering or not. It also transfers from the the prebuffer to ALSA, if
+// needed. Returns 0 on success, negative on error.
+static int
+buffer_write(struct alsa_session *as, struct output_data *odata, snd_pcm_sframes_t avail)
+{
+  uint8_t *buf;
+  size_t bufsize;
+  size_t wrote;
+  snd_pcm_sframes_t nsamp;
+  snd_pcm_sframes_t ret;
+
+  // Prebuffering, no actual writing
+  if (avail == 0)
+    {
+      wrote = ringbuffer_write(&as->prebuf, odata->buffer, odata->bufsize);
+      nsamp = BTOS(wrote, as->quality.bits_per_sample, as->quality.channels);
+      return nsamp;
+    }
+
+  // Read from prebuffer if it has data and write to device
+  if (as->prebuf.read_avail != 0)
+    {
+      // Maximum amount of bytes we want to read
+      bufsize = STOB(avail, as->quality.bits_per_sample, as->quality.channels);
+
+      bufsize = ringbuffer_read(&buf, bufsize, &as->prebuf);
+      if (bufsize == 0)
+	return 0;
+
+      nsamp = BTOS(bufsize, as->quality.bits_per_sample, as->quality.channels);
+      ret = snd_pcm_writei(as->hdl, buf, nsamp);
+      if (ret < 0)
+	return -1;
+
+      avail -= ret;
+    }
+
+  // Write to prebuffer if device buffer does not have availability. Note that
+  // if the prebuffer doesn't have enough room, which can happen if avail stays
+  // low, i.e. device buffer is overrunning, then the extra samples get dropped
+  if (odata->samples > avail)
+    {
+      ringbuffer_write(&as->prebuf, odata->buffer, odata->bufsize);
+      return odata->samples;
+    }
+
+  ret = snd_pcm_writei(as->hdl, odata->buffer, odata->samples);
+  if (ret < 0)
+    return ret;
+
+  if (ret != odata->samples)
+    DPRINTF(E_WARN, L_LAUDIO, "ALSA partial write detected\n");
+
+  return ret;
+}
+
+static enum alsa_sync_state
+sync_check(snd_pcm_sframes_t *delay, snd_pcm_sframes_t *avail, struct alsa_session *as, struct timespec pts)
+{
+  enum alsa_sync_state sync;
+  snd_htimestamp_t ts;
+  uint64_t elapsed;
+  uint64_t dev_elapsed;
+  uint64_t pos;
+  uint64_t dev_pos;
+  uint32_t buffered_samples;
+  int32_t latency;
+
+  // We don't need avail for the sync check, but to reduce querying we retrieve
+  // it here as a service for the caller
+  device_timestamp(as, delay, avail, &ts);
+  if (ts.tv_sec == 0 && ts.tv_nsec == 0)
+    return ALSA_SYNC_OK;
+
+  // Here we calculate elapsed time since we started, or since we last reset the
+  // sync timers: elapsed is how long the player thinks has elapsed, dev_elapsed
+  // is how long ALSA thinks has elapsed. If these are different, but the
+  // playback positition is the same, then the ALSA clock has drifted and we are
+  // coming out of sync. Unit is milliseconds.
+  elapsed = (pts.tv_sec - as->start_pts.tv_sec) * 1000L + (pts.tv_nsec - as->start_pts.tv_nsec) / 1000000;
+  dev_elapsed = (ts.tv_sec - as->dev_start_ts.tv_sec) * 1000L + (ts.tv_nsec - as->dev_start_ts.tv_nsec) / 1000000;
+
+  // Now calculate playback positions. The pos is where we should be, dev_pos is
+  // where we actually are.
+  pos = as->start_pos + (elapsed - 1000 * OUTPUTS_BUFFER_DURATION) * as->quality.sample_rate / 1000;
+  buffered_samples = *delay + BTOS(as->prebuf.read_avail, as->quality.bits_per_sample, as->quality.channels);
+  dev_pos = as->start_pos + dev_elapsed * as->quality.sample_rate / 1000 - buffered_samples;
+
+  // TODO calculate below and above more efficiently?
+  latency = pos - dev_pos;
+
+  // If the latency is low or very different from our last measurement, we will wait and see
+  if (abs(latency) < ALSA_MAX_LATENCY || abs(as->last_latency - latency) > ALSA_MAX_LATENCY_VARIANCE)
+    sync = ALSA_SYNC_OK;
+  else if (latency > 0)
+    sync = ALSA_SYNC_BEHIND;
+  else
+    sync = ALSA_SYNC_AHEAD;
+
+  // The will be used by sync_correct, so it knows how much we are out of sync
+  as->last_latency = latency;
+
+  DPRINTF(E_DBG, L_LAUDIO, "Sync=%d, pos=%lu, as->pos=%u, dev_pos=%lu, latency=%d, delay=%li, avail=%li, elapsed=%lu, dev_elapsed=%lu\n",
+    sync, pos, as->pos, dev_pos, latency, *delay, *avail, elapsed / 1000000, dev_elapsed / 1000000);
+
+  return sync;
+}
+
+static void
+sync_correct(void)
+{
+  // Not implemented yet
+}
+
+static void
+playback_write(struct alsa_session *as, struct output_buffer *obuf)
+{
+  snd_pcm_sframes_t ret;
+  snd_pcm_sframes_t delay;
+  enum alsa_sync_state sync;
+  bool prebuffering;
+  int i;
+
+  // Find the quality we want
+  for (i = 0; obuf->data[i].buffer; i++)
+    {
+      if (quality_is_equal(&as->quality, &obuf->data[i].quality))
+	break;
+    }
+
+  if (!obuf->data[i].buffer)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Output not delivering required data quality, aborting\n");
+      as->state = OUTPUT_STATE_FAILED;
+      alsa_status(as);
+      return;
+    }
+
+  prebuffering = (as->pos < as->buffer_nsamp);
+  if (prebuffering)
+    {
+      // Can never fail since we don't actually write to the device
+      as->pos += buffer_write(as, &obuf->data[i], 0);
+      return;
+    }
+
+  // Check sync each time a second has passed
+  if (obuf->pts.tv_sec != as->last_pts.tv_sec)
+    {
+      sync = sync_check(&delay, &as->last_avail, as, obuf->pts);
+      if (sync != ALSA_SYNC_OK)
+	sync_correct();
+
+      as->last_pts = obuf->pts;
+    }
+
+  ret = buffer_write(as, &obuf->data[i], as->last_avail);
+  if (ret < 0)
+    goto alsa_error;
+
+  as->pos += ret;
+
+  return;
+
+ alsa_error:
+  if (ret == -EPIPE)
+    {
+      DPRINTF(E_WARN, L_LAUDIO, "ALSA buffer underrun\n");
+
+      ret = snd_pcm_prepare(as->hdl);
+      if (ret < 0)
+	{
+	  DPRINTF(E_WARN, L_LAUDIO, "ALSA couldn't recover from underrun: %s\n", snd_strerror(ret));
+	  return;
+	}
+
+      // Fill the prebuf with audio before restarting, so we don't underrun again
+      playback_restart(as, obuf);
+      return;
+    }
+
+  DPRINTF(E_LOG, L_LAUDIO, "ALSA write error: %s\n", snd_strerror(ret));
+
+  as->state = OUTPUT_STATE_FAILED;
+  alsa_status(as);
+}
+
 
 /* ---------------------------- SESSION HANDLING ---------------------------- */
-
-static void
-prebuf_free(struct alsa_session *as)
-{
-  if (as->prebuf)
-    free(as->prebuf);
-
-  as->prebuf = NULL;
-  as->prebuf_len = 0;
-  as->prebuf_head = 0;
-  as->prebuf_tail = 0;
-}
 
 static void
 alsa_session_free(struct alsa_session *as)
@@ -140,10 +742,12 @@ alsa_session_free(struct alsa_session *as)
   if (!as)
     return;
 
-  if (as->deferredev)
-    event_free(as->deferredev);
+  device_close(as);
 
-  prebuf_free(as);
+  outputs_quality_unsubscribe(&alsa_fallback_quality);
+
+  ringbuffer_free(&as->prebuf, 1);
+  snd_pcm_status_free(as->pcm_status);
 
   free(as);
 }
@@ -166,815 +770,245 @@ alsa_session_cleanup(struct alsa_session *as)
 	s->next = as->next;
     }
 
-  as->device->session = NULL;
+  outputs_device_session_remove(as->device_id);
 
   alsa_session_free(as);
 }
 
 static struct alsa_session *
-alsa_session_make(struct output_device *device, output_status_cb cb)
+alsa_session_make(struct output_device *device, int callback_id)
 {
   struct alsa_session *as;
+  cfg_t *cfg_audio;
+  char *errmsg;
+  int original_adjust;
+  int ret;
 
   CHECK_NULL(L_LAUDIO, as = calloc(1, sizeof(struct alsa_session)));
 
-  as->deferredev = evtimer_new(evbase_player, defer_cb, as);
-  if (!as->deferredev)
+  as->device_id = device->id;
+  as->callback_id = callback_id;
+  as->volume = device->volume;
+
+  cfg_audio = cfg_getsec(cfg, "audio");
+
+  as->devname = cfg_getstr(cfg_audio, "card");
+  as->mixer_name = cfg_getstr(cfg_audio, "mixer");
+  as->mixer_device_name = cfg_getstr(cfg_audio, "mixer_device");
+  if (!as->mixer_device_name || strlen(as->mixer_device_name) == 0)
+    as->mixer_device_name = cfg_getstr(cfg_audio, "card");
+
+  // TODO implement
+  as->offset = cfg_getint(cfg_audio, "offset");
+  if (abs(as->offset) > 44100)
     {
-      DPRINTF(E_LOG, L_LAUDIO, "Out of memory for ALSA deferred event\n");
-      goto failure_cleanup;
+      DPRINTF(E_LOG, L_LAUDIO, "The ALSA offset (%d) set in the configuration is out of bounds\n", as->offset);
+      as->offset = 44100 * (as->offset/abs(as->offset));
     }
 
-  as->state = ALSA_STATE_STOPPED;
-  as->device = device;
-  as->status_cb = cb;
-  as->volume = device->volume;
-  as->devname = card_name;
-  as->source_sample_rate = 44100;
-  as->target_sample_rate = 44100;   // TODO: make ALSA device sample rate configurable
+  // TODO implement
+  original_adjust = cfg_getint(cfg_audio, "adjust_period_seconds");
+  if (original_adjust < 1)
+    as->adjust_period_seconds = 1;
+  else if (original_adjust > 20)
+    as->adjust_period_seconds = 20;
+  else
+    as->adjust_period_seconds = original_adjust;
+  if (as->adjust_period_seconds != original_adjust)
+    DPRINTF(E_LOG, L_LAUDIO, "Clamped ALSA adjust_period_seconds to %d\n", as->adjust_period_seconds);
 
+  snd_pcm_status_malloc(&as->pcm_status);
+
+  ret = device_open(as);
+  if (ret < 0)
+    goto out_free_session;
+
+  ret = device_quality_set(as, &alsa_fallback_quality, &errmsg);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "%s\n", errmsg);
+      free(errmsg);
+      goto out_device_close;
+    }
+
+  // If this fails it just means we won't get timestamps, which we can handle
+  device_configure(as);
+
+  ret = outputs_quality_subscribe(&alsa_fallback_quality);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not subscribe to fallback audio quality\n");
+      goto out_device_close;
+    }
+
+  as->state = OUTPUT_STATE_CONNECTED;
   as->next = sessions;
   sessions = as;
 
-  outputs_device_session_add(device, as);
+  // as is now the official device session
+  outputs_device_session_add(device->id, as);
 
   return as;
 
- failure_cleanup:
-  alsa_session_free(as);
+ out_device_close:
+  device_close(as);
+ out_free_session:
+  free(as);
   return NULL;
 }
 
-
-/* ---------------------------- STATUS HANDLERS ----------------------------- */
-
-// Maps our internal state to the generic output state and then makes a callback
-// to the player to tell that state
-static void
-defer_cb(int fd, short what, void *arg)
-{
-  struct alsa_session *as = arg;
-  enum output_device_state state;
-
-  switch (as->state)
-    {
-      case ALSA_STATE_FAILED:
-	state = OUTPUT_STATE_FAILED;
-	break;
-      case ALSA_STATE_STOPPED:
-	state = OUTPUT_STATE_STOPPED;
-	break;
-      case ALSA_STATE_STARTED:
-	state = OUTPUT_STATE_CONNECTED;
-	break;
-      case ALSA_STATE_STREAMING:
-	state = OUTPUT_STATE_STREAMING;
-	break;
-      default:
-	DPRINTF(E_LOG, L_LAUDIO, "Bug! Unhandled state in alsa_status()\n");
-	state = OUTPUT_STATE_FAILED;
-    }
-
-  if (as->defer_cb)
-    as->defer_cb(as->device, as->output_session, state);
-
-  if (!(as->state & ALSA_F_STARTED))
-    alsa_session_cleanup(as);
-}
-
-// Note: alsa_states also nukes the session if it is not ALSA_F_STARTED
 static void
 alsa_status(struct alsa_session *as)
 {
-  as->defer_cb = as->status_cb;
-  event_active(as->deferredev, 0, 0);
-  as->status_cb = NULL;
+  outputs_cb(as->callback_id, as->device_id, as->state);
+  as->callback_id = -1;
+
+  if (as->state == OUTPUT_STATE_FAILED || as->state == OUTPUT_STATE_STOPPED)
+    alsa_session_cleanup(as);
 }
 
-
-/* ------------------------------- MISC HELPERS ----------------------------- */
-
-/*static int
-start_threshold_set(snd_pcm_uframes_t threshold)
-{
-  snd_pcm_sw_params_t *sw_params;
-  int ret;
-
-  ret = snd_pcm_sw_params_malloc(&sw_params);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not allocate sw params: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_sw_params_current(hdl, sw_params);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not retrieve current sw params: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_sw_params_set_start_threshold(hdl, sw_params, threshold);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not set start threshold: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_sw_params(hdl, sw_params);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not set sw params: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  return 0;
-
- out_fail:
-  snd_pcm_sw_params_free(sw_params);
-
-  return -1;
-}
-*/
-
-static int
-mixer_open(void)
-{
-  snd_mixer_elem_t *elem;
-  snd_mixer_elem_t *master;
-  snd_mixer_elem_t *pcm;
-  snd_mixer_elem_t *custom;
-  snd_mixer_selem_id_t *sid;
-  int ret;
-
-  ret = snd_mixer_open(&mixer_hdl, 0);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Failed to open mixer: %s\n", snd_strerror(ret));
-
-      mixer_hdl = NULL;
-      return -1;
-    }
-
-  ret = snd_mixer_attach(mixer_hdl, mixer_device_name);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Failed to attach mixer: %s\n", snd_strerror(ret));
-
-      goto out_close;
-    }
-
-  ret = snd_mixer_selem_register(mixer_hdl, NULL, NULL);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Failed to register mixer: %s\n", snd_strerror(ret));
-
-      goto out_detach;
-    }
-
-  ret = snd_mixer_load(mixer_hdl);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Failed to load mixer: %s\n", snd_strerror(ret));
-
-      goto out_detach;
-    }
-
-  // Grab interesting elements
-  snd_mixer_selem_id_alloca(&sid);
-
-  pcm = NULL;
-  master = NULL;
-  custom = NULL;
-  for (elem = snd_mixer_first_elem(mixer_hdl); elem; elem = snd_mixer_elem_next(elem))
-    {
-      snd_mixer_selem_get_id(elem, sid);
-
-      if (mixer_name && (strcmp(snd_mixer_selem_id_get_name(sid), mixer_name) == 0))
-	{
-	  custom = elem;
-	  break;
-	}
-      else if (strcmp(snd_mixer_selem_id_get_name(sid), "PCM") == 0)
-        pcm = elem;
-      else if (strcmp(snd_mixer_selem_id_get_name(sid), "Master") == 0)
-	master = elem;
-    }
-
-  if (mixer_name)
-    {
-      if (custom)
-	vol_elem = custom;
-      else
-	{
-	  DPRINTF(E_LOG, L_LAUDIO, "Failed to open configured mixer element '%s'\n", mixer_name);
-
-	  goto out_detach;
-	}
-    }
-  else if (pcm)
-    vol_elem = pcm;
-  else if (master)
-    vol_elem = master;
-  else
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Failed to open PCM or Master mixer element\n");
-
-      goto out_detach;
-    }
-
-  // Get min & max volume
-  snd_mixer_selem_get_playback_volume_range(vol_elem, &vol_min, &vol_max);
-
-  return 0;
-
- out_detach:
-  snd_mixer_detach(mixer_hdl, card_name);
- out_close:
-  snd_mixer_close(mixer_hdl);
-  mixer_hdl = NULL;
-  vol_elem = NULL;
-
-  return -1;
-}
-
-static int
-device_open(struct alsa_session *as)
-{
-  snd_pcm_hw_params_t *hw_params;
-  snd_pcm_uframes_t bufsize;
-  int ret;
-
-  hw_params = NULL;
-
-  ret = snd_pcm_open(&hdl, card_name, SND_PCM_STREAM_PLAYBACK, 0);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not open playback device: %s\n", snd_strerror(ret));
-
-      return -1;
-    }
-
-  // HW params
-  ret = snd_pcm_hw_params_malloc(&hw_params);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not allocate hw params: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_hw_params_any(hdl, hw_params);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not retrieve hw params: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_hw_params_set_access(hdl, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not set access method: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_hw_params_set_format(hdl, hw_params, SND_PCM_FORMAT_S16_LE);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not set S16LE format: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_hw_params_set_channels(hdl, hw_params, 2);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not set stereo output: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_hw_params_set_rate(hdl, hw_params, as->target_sample_rate, 0);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Hardware doesn't support %u Hz: %s\n", as->target_sample_rate, snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_hw_params_get_buffer_size_max(hw_params, &bufsize);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not get max buffer size: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_hw_params_set_buffer_size_max(hdl, hw_params, &bufsize);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not set buffer size to max: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  ret = snd_pcm_hw_params(hdl, hw_params);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not set hw params: %s\n", snd_strerror(ret));
-
-      goto out_fail;
-    }
-
-  snd_pcm_hw_params_free(hw_params);
-  hw_params = NULL;
-
-  ret = mixer_open();
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not open mixer\n");
-
-      goto out_fail;
-    }
-
-  return 0;
-
- out_fail:
-  if (hw_params)
-    snd_pcm_hw_params_free(hw_params);
-
-  snd_pcm_close(hdl);
-  hdl = NULL;
-
-  return -1;
-}
-
-static void
-device_close(void)
-{
-  snd_pcm_close(hdl);
-  hdl = NULL;
-
-  if (mixer_hdl)
-    {
-      snd_mixer_detach(mixer_hdl, card_name);
-      snd_mixer_close(mixer_hdl);
-
-      mixer_hdl = NULL;
-      vol_elem = NULL;
-    }
-}
-
-static void
-playback_start(struct alsa_session *as, uint64_t pos, uint64_t start_pos)
-{
-  snd_output_t *output;
-  snd_pcm_state_t state;
-  char *debug_pcm_cfg;
-  int ret;
-
-  state = snd_pcm_state(hdl);
-  if (state != SND_PCM_STATE_PREPARED)
-    {
-      if (state == SND_PCM_STATE_RUNNING)
-	snd_pcm_drop(hdl);
-
-      ret = snd_pcm_prepare(hdl);
-      if (ret < 0)
-	{
-	  DPRINTF(E_LOG, L_LAUDIO, "Could not prepare ALSA device '%s' (state %d): %s\n", as->devname, state, snd_strerror(ret));
-	  return;
-	}
-    }
-
-  // Clear prebuffer in case start somehow got called twice without a stop in between
-  prebuf_free(as);
-
-  // Adjust the starting position with the configured value
-  start_pos -= offset;
-
-  // The difference between pos and start_pos should match the 2 second
-  // buffer that AirPlay uses. We will not use alsa's buffer for the initial
-  // buffering, because my sound card's start_threshold is not to be counted on.
-  // Instead we allocate our own buffer, and when it is time to play we write as
-  // much as we can to alsa's buffer.
-  as->prebuf_len = (start_pos - pos) / ALSA_SAMPLES_PER_PACKET + 1;
-  if (as->prebuf_len > (3 * 44100 - offset) / ALSA_SAMPLES_PER_PACKET)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Sanity check of prebuf_len (%" PRIu32 " packets) failed\n", as->prebuf_len);
-      return;
-    }
-  DPRINTF(E_DBG, L_LAUDIO, "Will prebuffer %d packets\n", as->prebuf_len);
-
-  as->prebuf = malloc(as->prebuf_len * ALSA_PACKET_SIZE);
-  if (!as->prebuf)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Out of memory for audio buffer (requested %" PRIu32 " packets)\n", as->prebuf_len);
-      return;
-    }
-
-  as->pos = pos;
-  as->start_pos = start_pos - ALSA_SAMPLES_PER_PACKET;
-
-  // Dump PCM config data for E_DBG logging
-  ret = snd_output_buffer_open(&output);
-  if (ret == 0)
-    {
-      if (snd_pcm_dump_setup(hdl, output) == 0)
-	{
-	  snd_output_buffer_string(output, &debug_pcm_cfg);
-	  DPRINTF(E_DBG, L_LAUDIO, "Dump of sound device config:\n%s\n", debug_pcm_cfg);
-	}
-
-      snd_output_close(output);
-    }
-
-  as->state = ALSA_STATE_STREAMING;
-}
-
-
-// This function writes the sample buf into either the prebuffer or directly to
-// ALSA, depending on how much room there is in ALSA, and whether we are
-// prebuffering or not. It also transfers from the the prebuffer to ALSA, if
-// needed. Returns 0 on success, negative on error.
-static int
-buffer_write(struct alsa_session *as, uint8_t *buf, snd_pcm_sframes_t *avail, int prebuffering, int prebuf_empty)
-{
-  uint8_t *pkt;
-  int npackets;
-  snd_pcm_sframes_t nsamp;
-  snd_pcm_sframes_t ret;
-
-  nsamp = ALSA_SAMPLES_PER_PACKET;
-
-  if (as->prebuf && (prebuffering || !prebuf_empty || *avail < ALSA_SAMPLES_PER_PACKET))
-    {
-      pkt = &as->prebuf[as->prebuf_head * ALSA_PACKET_SIZE];
-
-      memcpy(pkt, buf, ALSA_PACKET_SIZE);
-
-      as->prebuf_head = (as->prebuf_head + 1) % as->prebuf_len;
-
-      if (prebuffering || *avail < ALSA_SAMPLES_PER_PACKET)
-	return 0; // No actual writing
-
-      // We will now set buf so that we will transfer as much as possible to ALSA
-      buf = &as->prebuf[as->prebuf_tail * ALSA_PACKET_SIZE];
-
-      if (as->prebuf_head > as->prebuf_tail)
-	npackets = as->prebuf_head - as->prebuf_tail;
-      else
-	npackets = as->prebuf_len - as->prebuf_tail;
-
-      nsamp = npackets * ALSA_SAMPLES_PER_PACKET;
-      while (nsamp > *avail)
-	{
-	  npackets -= 1;
-	  nsamp -= ALSA_SAMPLES_PER_PACKET;
-	}
-
-      as->prebuf_tail = (as->prebuf_tail + npackets) % as->prebuf_len;
-    }
-
-  ret = snd_pcm_writei(hdl, buf, nsamp);
-  if (ret < 0)
-    return ret;
-
-  if (ret != nsamp)
-    DPRINTF(E_WARN, L_LAUDIO, "ALSA partial write detected\n");
-
-  if (avail)
-    *avail -= ret;
-
-  return 0;
-}
-
-// Checks if ALSA's playback position is ahead or behind the player's
-enum alsa_sync_state
-sync_check(struct alsa_session *as, uint64_t rtptime, snd_pcm_sframes_t delay, int prebuf_empty)
-{
-  enum alsa_sync_state sync;
-  struct timespec now;
-  uint64_t cur_pos;
-  uint64_t pb_pos;
-  int32_t latency;
-  int npackets;
-
-  sync = ALSA_SYNC_OK;
-
-  if (player_get_current_pos(&cur_pos, &now, 0) != 0)
-    return sync;
-
-  if (!prebuf_empty)
-    npackets = (as->prebuf_head - (as->prebuf_tail + 1) + as->prebuf_len) % as->prebuf_len + 1;
-  else
-    npackets = 0;
-
-  pb_pos = rtptime - delay - ALSA_SAMPLES_PER_PACKET * npackets;
-  latency = cur_pos - (pb_pos - offset);
-
-  // If the latency is low or very different from our last measurement, we reset the sync_counter
-  if (abs(latency) < ALSA_MAX_LATENCY || abs(as->last_latency - latency) > ALSA_MAX_LATENCY_VARIANCE)
-    {
-      as->sync_counter = 0;
-      sync = ALSA_SYNC_OK;
-    }
-  // If we have measured a consistent latency for configured period, then we take action
-  else if (as->sync_counter >= adjust_period_seconds * 126)
-    {
-      DPRINTF(E_INFO, L_LAUDIO, "Taking action to compensate for ALSA latency of %d samples\n", latency);
-
-      as->sync_counter = 0;
-      if (latency > 0)
-	sync = ALSA_SYNC_BEHIND;
-      else
-	sync = ALSA_SYNC_AHEAD;
-    }
-
-  as->last_latency = latency;
-
-  if (latency)
-    DPRINTF(E_SPAM, L_LAUDIO, "Sync %d cur_pos %" PRIu64 ", pb_pos %" PRIu64 " (diff %d, delay %li), pos %" PRIu64 "\n", sync, cur_pos, pb_pos, latency, delay, as->pos);
-
-  return sync;
-}
-
-static void
-playback_write(struct alsa_session *as, uint8_t *buf, uint64_t rtptime)
-{
-  snd_pcm_sframes_t ret;
-  snd_pcm_sframes_t avail;
-  snd_pcm_sframes_t delay;
-  enum alsa_sync_state sync;
-  int prebuffering;
-  int prebuf_empty;
-
-  prebuffering = (as->pos < as->start_pos);
-  prebuf_empty = (as->prebuf_head == as->prebuf_tail);
-
-  as->pos += ALSA_SAMPLES_PER_PACKET;
-
-  if (prebuffering)
-    {
-      buffer_write(as, buf, NULL, prebuffering, prebuf_empty);
-      return;
-    }
-
-  ret = snd_pcm_avail_delay(hdl, &avail, &delay);
-  if (ret < 0)
-    goto alsa_error;
-
-  // Every second we do a sync check
-  sync = ALSA_SYNC_OK;
-  as->sync_counter++;
-  if (as->sync_counter % 126 == 0)
-    sync = sync_check(as, rtptime, delay, prebuf_empty);
-
-  // Skip write -> reduce the delay
-  if (sync == ALSA_SYNC_BEHIND)
-    return;
-
-  ret = buffer_write(as, buf, &avail, prebuffering, prebuf_empty);
-  // Double write -> increase the delay
-  if (sync == ALSA_SYNC_AHEAD && (ret == 0))
-    ret = buffer_write(as, buf, &avail, prebuffering, prebuf_empty);
-  if (ret < 0)
-    goto alsa_error;
-
-  return;
-
- alsa_error:
-  if (ret == -EPIPE)
-    {
-      DPRINTF(E_WARN, L_LAUDIO, "ALSA buffer underrun\n");
-
-      ret = snd_pcm_prepare(hdl);
-      if (ret < 0)
-	{
-	  DPRINTF(E_WARN, L_LAUDIO, "ALSA couldn't recover from underrun: %s\n", snd_strerror(ret));
-	  return;
-	}
-
-      // Fill the prebuf with audio before restarting, so we don't underrun again
-      as->start_pos = as->pos + ALSA_SAMPLES_PER_PACKET * (as->prebuf_len - 1);
-
-      return;
-    }
-
-  DPRINTF(E_LOG, L_LAUDIO, "ALSA write error: %s\n", snd_strerror(ret));
-
-  as->state = ALSA_STATE_FAILED;
-  alsa_status(as);
-}
-
-static void
-playback_pos_get(uint64_t *pos, uint64_t next_pkt)
-{
-  uint64_t cur_pos;
-  struct timespec now;
-  int ret;
-
-  ret = player_get_current_pos(&cur_pos, &now, 0);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Could not get playback position, setting to next_pkt - 2 seconds\n");
-      cur_pos = next_pkt - 88200;
-    }
-
-  // Make pos the rtptime of the packet containing cur_pos
-  *pos = next_pkt;
-  while (*pos > cur_pos)
-    *pos -= ALSA_SAMPLES_PER_PACKET;
-}
 
 /* ------------------ INTERFACE FUNCTIONS CALLED BY OUTPUTS.C --------------- */
 
 static int
-alsa_device_start(struct output_device *device, output_status_cb cb, uint64_t rtptime)
+alsa_device_start(struct output_device *device, int callback_id)
 {
   struct alsa_session *as;
-  int ret;
 
-  as = alsa_session_make(device, cb);
+  as = alsa_session_make(device, callback_id);
   if (!as)
     return -1;
 
-  ret = device_open(as);
-  if (ret < 0)
-    {
-      alsa_session_cleanup(as);
-      return -1;
-    }
-
-  as->state = ALSA_STATE_STARTED;
+  as->state = OUTPUT_STATE_CONNECTED;
   alsa_status(as);
 
   return 0;
 }
 
-static void
-alsa_device_stop(struct output_session *session)
+static int
+alsa_device_stop(struct output_device *device, int callback_id)
 {
-  struct alsa_session *as = session->session;
+  struct alsa_session *as = device->session;
 
-  device_close();
+  as->callback_id = callback_id;
+  as->state = OUTPUT_STATE_STOPPED;
+  alsa_status(as); // Will terminate the session since the state is STOPPED
 
-  as->state = ALSA_STATE_STOPPED;
-  alsa_status(as);
+  return 0;
 }
 
 static int
 alsa_device_flush(struct output_device *device, int callback_id)
 {
   struct alsa_session *as = device->session;
-  int i;
 
-  // TODO close device?
+  snd_pcm_drop(as->hdl);
 
-  snd_pcm_drop(hdl);
-  prebuf_free(as);
+  ringbuffer_free(&as->prebuf, 1);
 
   as->callback_id = callback_id;
-  as->state = ALSA_STATE_STARTED;
+  as->state = OUTPUT_STATE_CONNECTED;
   alsa_status(as);
 
   return 0;
 }
 
 static int
-alsa_device_probe(struct output_device *device, output_status_cb cb)
+alsa_device_probe(struct output_device *device, int callback_id)
 {
   struct alsa_session *as;
-  int ret;
 
-  as = alsa_session_make(device, cb);
+  as = alsa_session_make(device, callback_id);
   if (!as)
     return -1;
 
-  ret = device_open(as);
-  if (ret < 0)
-    {
-      alsa_session_cleanup(as);
-      return -1;
-    }
-
-  device_close();
-
-  as->state = ALSA_STATE_STOPPED;
-  alsa_status(as);
+  as->state = OUTPUT_STATE_STOPPED;
+  alsa_status(as); // Will terminate the session since the state is STOPPED
 
   return 0;
 }
 
 static int
-alsa_device_volume_set(struct output_device *device, output_status_cb cb)
+alsa_device_volume_set(struct output_device *device, int callback_id)
 {
-  struct alsa_session *as;
+  struct alsa_session *as = device->session;
   int pcm_vol;
 
-  if (!device->session || !device->session->session)
+  if (!as)
     return 0;
 
-  as = device->session->session;
+  snd_mixer_handle_events(as->mixer_hdl);
 
-  if (!mixer_hdl || !vol_elem)
-    return 0;
-
-  snd_mixer_handle_events(mixer_hdl);
-
-  if (!snd_mixer_selem_is_active(vol_elem))
+  if (!snd_mixer_selem_is_active(as->vol_elem))
     return 0;
 
   switch (device->volume)
     {
       case 0:
-	pcm_vol = vol_min;
+	pcm_vol = as->vol_min;
 	break;
 
       case 100:
-	pcm_vol = vol_max;
+	pcm_vol = as->vol_max;
 	break;
 
       default:
-	pcm_vol = vol_min + (device->volume * (vol_max - vol_min)) / 100;
+	pcm_vol = as->vol_min + (device->volume * (as->vol_max - as->vol_min)) / 100;
 	break;
     }
 
   DPRINTF(E_DBG, L_LAUDIO, "Setting ALSA volume to %d (%d)\n", pcm_vol, device->volume);
 
-  snd_mixer_selem_set_playback_volume_all(vol_elem, pcm_vol);
+  snd_mixer_selem_set_playback_volume_all(as->vol_elem, pcm_vol);
 
-  as->status_cb = cb;
+  as->callback_id = callback_id;
   alsa_status(as);
 
   return 1;
 }
 
 static void
-alsa_playback_start(uint64_t next_pkt, struct timespec *ts)
+alsa_device_cb_set(struct output_device *device, int callback_id)
 {
-  struct alsa_session *as;
-  uint64_t pos;
+  struct alsa_session *as = device->session;
 
-  if (!sessions)
-    return;
-
-  playback_pos_get(&pos, next_pkt);
-
-  DPRINTF(E_DBG, L_LAUDIO, "Starting ALSA audio (pos %" PRIu64 ", next_pkt %" PRIu64 ")\n", pos, next_pkt);
-
-  for (as = sessions; as; as = as->next)
-    playback_start(as, pos, next_pkt);
+  as->callback_id = callback_id;
 }
 
 static void
 alsa_playback_stop(void)
 {
   struct alsa_session *as;
+  struct alsa_session *next;
 
-  for (as = sessions; as; as = as->next)
+  for (as = sessions; as; as = next)
     {
-      snd_pcm_drop(hdl);
-      prebuf_free(as);
+      next = as->next;
+      snd_pcm_drop(as->hdl);
 
-      as->state = ALSA_STATE_STARTED;
-      alsa_status(as);
+      as->state = OUTPUT_STATE_STOPPED;
+      alsa_status(as); // Will stop the session
     }
 }
 
 static void
-alsa_write(uint8_t *buf, uint64_t rtptime)
+alsa_write(struct output_buffer *obuf)
 {
   struct alsa_session *as;
-  uint64_t pos;
+  struct alsa_session *next;
 
-  for (as = sessions; as; as = as->next)
+  for (as = sessions; as; as = next)
     {
-      if (as->state == ALSA_STATE_STARTED)
-	{
-	  playback_pos_get(&pos, rtptime);
+      next = as->next;
+      // Need to adjust buffers and device params if sample rate changed, or if
+      // this was the first write to the device
+      if (!quality_is_equal(&obuf->data[0].quality, &alsa_last_quality) || as->state == OUTPUT_STATE_CONNECTED)
+	playback_restart(as, obuf); 
 
-	  DPRINTF(E_DBG, L_LAUDIO, "Starting ALSA device '%s' (pos %" PRIu64 ", rtptime %" PRIu64 ")\n", as->devname, pos, rtptime);
+      playback_write(as, obuf);
 
-	  playback_start(as, pos, rtptime);
-	}
-
-      playback_write(as, buf, rtptime);
+      alsa_last_quality = obuf->data[0].quality;
     }
-}
-
-static void
-alsa_set_status_cb(struct output_session *session, output_status_cb cb)
-{
-  struct alsa_session *as = session->session;
-
-  as->status_cb = cb;
 }
 
 static int
@@ -982,59 +1016,27 @@ alsa_init(void)
 {
   struct output_device *device;
   cfg_t *cfg_audio;
-  char *nickname;
-  char *type;
-  int original_adjust;
+  const char *type;
 
+  // Is ALSA enabled in config?
   cfg_audio = cfg_getsec(cfg, "audio");
   type = cfg_getstr(cfg_audio, "type");
-
   if (type && (strcasecmp(type, "alsa") != 0))
     return -1;
 
-  card_name = cfg_getstr(cfg_audio, "card");
-  mixer_name = cfg_getstr(cfg_audio, "mixer");
-  mixer_device_name = cfg_getstr(cfg_audio, "mixer_device");
-  if (mixer_device_name == NULL || strlen(mixer_device_name) == 0)
-    mixer_device_name = card_name;
-  nickname = cfg_getstr(cfg_audio, "nickname");
-  offset = cfg_getint(cfg_audio, "offset");
-  if (abs(offset) > 44100)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "The ALSA offset (%d) set in the configuration is out of bounds\n", offset);
-      offset = 44100 * (offset/abs(offset));
-    }
-
-  original_adjust = adjust_period_seconds = cfg_getint(cfg_audio, "adjust_period_seconds");
-  if (adjust_period_seconds < 1)
-    adjust_period_seconds = 1;
-  else if (adjust_period_seconds > 20)
-    adjust_period_seconds = 20;
-  if (original_adjust != adjust_period_seconds)
-    DPRINTF(E_LOG, L_LAUDIO, "Clamped ALSA adjust_period_seconds from %d to %d\n", original_adjust, adjust_period_seconds);
-
-  device = calloc(1, sizeof(struct output_device));
-  if (!device)
-    {
-      DPRINTF(E_LOG, L_LAUDIO, "Out of memory for ALSA device\n");
-      return -1;
-    }
+  CHECK_NULL(L_LAUDIO, device = calloc(1, sizeof(struct output_device)));
 
   device->id = 0;
-  device->name = strdup(nickname);
+  device->name = strdup(cfg_getstr(cfg_audio, "nickname"));
   device->type = OUTPUT_TYPE_ALSA;
   device->type_name = outputs_name(device->type);
   device->has_video = 0;
 
-  DPRINTF(E_INFO, L_LAUDIO, "Adding ALSA device '%s' with name '%s'\n", card_name, nickname);
+  DPRINTF(E_INFO, L_LAUDIO, "Adding ALSA device '%s' with name '%s'\n", cfg_getstr(cfg_audio, "card"), device->name);
 
   player_device_add(device);
 
   snd_lib_error_set_handler(logger_alsa);
-
-  hdl = NULL;
-  mixer_hdl = NULL;
-  vol_elem = NULL;
 
   return 0;
 }
@@ -1042,7 +1044,15 @@ alsa_init(void)
 static void
 alsa_deinit(void)
 {
+  struct alsa_session *as;
+
   snd_lib_error_set_handler(NULL);
+
+  for (as = sessions; sessions; as = sessions)
+    {
+      sessions = as->next;
+      alsa_session_free(as);
+    }
 }
 
 struct output_definition output_alsa =
@@ -1058,8 +1068,7 @@ struct output_definition output_alsa =
   .device_flush = alsa_device_flush,
   .device_probe = alsa_device_probe,
   .device_volume_set = alsa_device_volume_set,
-  .playback_start = alsa_playback_start,
+  .device_cb_set = alsa_device_cb_set,
   .playback_stop = alsa_playback_stop,
   .write = alsa_write,
-  .status_cb = alsa_set_status_cb,
 };

--- a/src/outputs/cast.c
+++ b/src/outputs/cast.c
@@ -361,7 +361,8 @@ struct cast_msg_basic cast_msg[] =
     // codecName can be aac or opus, ssrc should be random
     // We don't set 'aesKey' and 'aesIvMask'
     // sampleRate seems to be ignored
-    // storeTime unknown meaning
+    // storeTime unknown meaning - perhaps size of buffer?
+    // targetDelay - should be RTP delay in ms, but doesn't seem to change anything?
     .payload = "{'type':'OFFER','seqNum':%d,'offer':{'castMode':'mirroring','supportedStreams':[{'index':0,'type':'audio_source','codecName':'opus','rtpProfile':'cast','rtpPayloadType':127,'ssrc':%d,'storeTime':400,'targetDelay':400,'bitRate':128000,'sampleRate':48000,'timeBase':'1/48000','channels':2,'receiverRtcpEventLog':false}]}}",
     .flags = USE_TRANSPORT_ID | USE_REQUEST_ID,
   },
@@ -617,6 +618,9 @@ master_session_cleanup(struct cast_master_session *cms)
       if (cs->master_session == cms)
 	return;
     }
+
+  if (cms == cast_master_session)
+    cast_master_session = NULL;
 
   master_session_free(cms);
 }

--- a/src/outputs/cast.c
+++ b/src/outputs/cast.c
@@ -1,8 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Espen Jürgensen <espenjurgensen@gmail.com>
- *
- * Credit goes to the authors of pychromecast and those before that who have
- * discovered how to do this.
+ * Copyright (C) 2015-2019 Espen Jürgensen <espenjurgensen@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,8 +47,10 @@
 
 #include "conffile.h"
 #include "mdns.h"
+#include "transcode.h"
 #include "logger.h"
 #include "player.h"
+#include "rtp_common.h"
 #include "outputs.h"
 
 #ifdef HAVE_PROTOBUF_OLD
@@ -66,26 +65,45 @@
 #define CAFILE "/etc/ssl/certs/ca-certificates.crt"
 
 // Seconds without a heartbeat from the Chromecast before we close the session
-#define HEARTBEAT_TIMEOUT 8
-// Seconds after a flush (pause) before we close the session
-#define FLUSH_TIMEOUT 30
+//#define HEARTBEAT_TIMEOUT 30
 // Seconds to wait for a reply before making the callback requested by caller
 #define REPLY_TIMEOUT 5
 
-// ID of the default receiver app
-#define CAST_APP_ID "CC1AD845"
+// ID of the audio mirroring app used by Chrome (Google Home)
+//#define CAST_APP_ID "85CDB22F"
+
+// Old mirroring app (Chromecast)
+#define CAST_APP_ID "0F5096E8"
 
 // Namespaces
 #define NS_CONNECTION "urn:x-cast:com.google.cast.tp.connection"
 #define NS_RECEIVER "urn:x-cast:com.google.cast.receiver"
 #define NS_HEARTBEAT "urn:x-cast:com.google.cast.tp.heartbeat"
 #define NS_MEDIA "urn:x-cast:com.google.cast.media"
+#define NS_WEBRTC "urn:x-cast:com.google.cast.webrtc"
 
 #define USE_TRANSPORT_ID     (1 << 1)
 #define USE_REQUEST_ID       (1 << 2)
 #define USE_REQUEST_ID_ONLY  (1 << 3)
 
 #define CALLBACK_REGISTER_SIZE 32
+
+// Chromium will send OPUS encoded 10 ms packets (48kHz), about 120 bytes. We
+// use a 20 ms packet, so 50 pkts/sec, because that's the default for ffmpeg.
+// A 20 ms audio packet at 48000 kHz makes this number 48000 * (20 / 1000)
+#define CAST_SAMPLES_PER_PACKET 960
+
+#define CAST_QUALITY_SAMPLE_RATE_DEFAULT     48000
+#define CAST_QUALITY_BITS_PER_SAMPLE_DEFAULT 16
+#define CAST_QUALITY_CHANNELS_DEFAULT        2
+
+/* Notes
+ * OFFER/ANSWER <-webrtc
+ * RTCP/RTP
+ * XR custom receiver report
+ * Control and data on same UDP connection
+ * OPUS encoded
+ */
 
 //#define DEBUG_CONNECTION 1
 
@@ -100,6 +118,13 @@ union sockaddr_all
 struct cast_session;
 struct cast_msg_payload;
 
+// See cast_packet_header_make()
+#define CAST_HEADER_SIZE 11
+#define CAST_PACKET_BUFFER_SIZE 1000
+
+static struct encode_ctx *cast_encode_ctx;
+static struct evbuffer *cast_encoded_data;
+
 typedef void (*cast_reply_cb)(struct cast_session *cs, struct cast_msg_payload *payload);
 
 // Session is starting up
@@ -109,7 +134,7 @@ typedef void (*cast_reply_cb)(struct cast_session *cs, struct cast_msg_payload *
 // Media is loaded in the receiver app
 #define CAST_STATE_F_MEDIA_LOADED    (1 << 15)
 // Media is playing in the receiver app
-#define CAST_STATE_F_MEDIA_PLAYING   (1 << 16)
+#define CAST_STATE_F_MEDIA_STREAMING (1 << 16)
 
 // Beware, the order of this enum has meaning
 enum cast_state
@@ -122,22 +147,51 @@ enum cast_state
   CAST_STATE_DISCONNECTED    = CAST_STATE_F_STARTUP | 0x01,
   // TCP connect, TLS handshake, CONNECT and GET_STATUS request
   CAST_STATE_CONNECTED       = CAST_STATE_F_STARTUP | 0x02,
-  // Default media receiver app is launched
+  // Receiver app has been launched
   CAST_STATE_MEDIA_LAUNCHED  = CAST_STATE_F_STARTUP | 0x03,
-  // CONNECT and GET_STATUS made to receiver app
+  // CONNECT, GET_STATUS and OFFER made to receiver app
   CAST_STATE_MEDIA_CONNECTED = CAST_STATE_F_MEDIA_CONNECTED,
+  // After OFFER
+  CAST_STATE_MEDIA_STREAMING = CAST_STATE_F_MEDIA_CONNECTED | CAST_STATE_F_MEDIA_STREAMING,
+
+/*
   // Receiver app has loaded our media
   CAST_STATE_MEDIA_LOADED    = CAST_STATE_F_MEDIA_CONNECTED | CAST_STATE_F_MEDIA_LOADED,
   // After PAUSE
   CAST_STATE_MEDIA_PAUSED    = CAST_STATE_F_MEDIA_CONNECTED | CAST_STATE_F_MEDIA_LOADED | 0x01,
   // After LOAD
-  CAST_STATE_MEDIA_BUFFERING = CAST_STATE_F_MEDIA_CONNECTED | CAST_STATE_F_MEDIA_LOADED | CAST_STATE_F_MEDIA_PLAYING,
+  CAST_STATE_MEDIA_BUFFERING = CAST_STATE_F_MEDIA_CONNECTED | CAST_STATE_F_MEDIA_LOADED | CAST_STATE_F_MEDIA_STREAMING,
   // After PLAY
-  CAST_STATE_MEDIA_PLAYING   = CAST_STATE_F_MEDIA_CONNECTED | CAST_STATE_F_MEDIA_LOADED | CAST_STATE_F_MEDIA_PLAYING | 0x01,
+  CAST_STATE_MEDIA_PLAYING   = CAST_STATE_F_MEDIA_CONNECTED | CAST_STATE_F_MEDIA_LOADED | CAST_STATE_F_MEDIA_STREAMING | 0x01,
+*/
+};
+
+struct cast_master_session
+{
+  struct evbuffer *evbuf;
+  int evbuf_samples;
+
+  struct rtp_session *rtp_session;
+
+  struct media_quality quality;
+
+  uint8_t *rawbuf;
+  size_t rawbuf_size;
+  int samples_per_packet;
+
+  // Number of samples that we tell the output to buffer (this will mean that
+  // the position that we send in the sync packages are offset by this amount
+  // compared to the rtptimes of the corresponding RTP packages we are sending)
+  int output_buffer_samples;
 };
 
 struct cast_session
 {
+  uint64_t device_id;
+  int callback_id;
+
+  struct cast_master_session *master_session;
+
   // Current state
   enum cast_state state;
 
@@ -145,16 +199,19 @@ struct cast_session
   enum cast_state wanted_state;
 
   // Connection fd and session, and listener event
-  int server_fd;
+  int64_t server_fd; // Use int64 so we can cast in gnutls_transport_set_ptr()
   gnutls_session_t tls_session;
   struct event *ev;
 
   char *devname;
   char *address;
+  int family;
   unsigned short port;
 
   // ChromeCast uses a float between 0 - 1
   float volume;
+
+  uint32_t ssrc_id;
 
   // IP address URL of forked-daapd's mp3 stream
   char stream_url[128];
@@ -172,13 +229,13 @@ struct cast_session
   // register our retry so that we on only retry once.
   int retry;
 
-  // Session info from the ChromeCast
+  // Session info from the Chromecast
   char *transport_id;
   char *session_id;
   int media_session_id;
 
-  struct output_device *device;
-  output_status_cb status_cb;
+  int udp_fd;
+  unsigned short udp_port;
 
   struct cast_session *next;
 };
@@ -196,6 +253,8 @@ enum cast_msg_types
   STOP,
   MEDIA_CONNECT,
   MEDIA_CLOSE,
+  OFFER,
+  ANSWER,
   MEDIA_GET_STATUS,
   MEDIA_STATUS,
   MEDIA_LOAD,
@@ -225,7 +284,9 @@ struct cast_msg_payload
   const char *session_id;
   const char *transport_id;
   const char *player_state;
+  const char *result;
   int media_session_id;
+  unsigned short udp_port;
 };
 
 // Array of the cast messages that we use. Must be in sync with cast_msg_types.
@@ -295,6 +356,20 @@ struct cast_msg_basic cast_msg[] =
     .flags = USE_TRANSPORT_ID,
   },
   {
+    .type = OFFER,
+    .namespace = NS_WEBRTC,
+    // codecName can be aac or opus, ssrc should be random
+    // We don't set 'aesKey' and 'aesIvMask'
+    // sampleRate seems to be ignored
+    // storeTime unknown meaning
+    .payload = "{'type':'OFFER','seqNum':%d,'offer':{'castMode':'mirroring','supportedStreams':[{'index':0,'type':'audio_source','codecName':'opus','rtpProfile':'cast','rtpPayloadType':127,'ssrc':%d,'storeTime':400,'targetDelay':400,'bitRate':128000,'sampleRate':48000,'timeBase':'1/48000','channels':2,'receiverRtcpEventLog':false}]}}",
+    .flags = USE_TRANSPORT_ID | USE_REQUEST_ID,
+  },
+  {
+    .type = ANSWER,
+    .tag = "ANSWER",
+  },
+  {
     .type = MEDIA_GET_STATUS,
     .namespace = NS_MEDIA,
     .payload = "{'type':'GET_STATUS','requestId':%d}",
@@ -352,29 +427,31 @@ extern struct event_base *evbase_player;
 
 /* Globals */
 static gnutls_certificate_credentials_t tls_credentials;
-static struct cast_session *sessions;
-static struct event *flush_timer;
-static struct timeval heartbeat_timeout = { HEARTBEAT_TIMEOUT, 0 };
-static struct timeval flush_timeout = { FLUSH_TIMEOUT, 0 };
+static struct cast_session *cast_sessions;
+static struct cast_master_session *cast_master_session;
+//static struct timeval heartbeat_timeout = { HEARTBEAT_TIMEOUT, 0 };
 static struct timeval reply_timeout = { REPLY_TIMEOUT, 0 };
+static struct media_quality cast_quality_default = { CAST_QUALITY_SAMPLE_RATE_DEFAULT, CAST_QUALITY_BITS_PER_SAMPLE_DEFAULT, CAST_QUALITY_CHANNELS_DEFAULT };
 
 
 /* ------------------------------- MISC HELPERS ----------------------------- */
 
 static int
-tcp_connect(const char *address, unsigned int port, int family)
+cast_connect(const char *address, unsigned short port, int family, int type)
 {
   union sockaddr_all sa;
   int fd;
   int len;
   int ret;
 
+  DPRINTF(E_DBG, L_CAST, "Connecting to %s (family=%d), port %u\n", address, family, port);
+
   // TODO Open non-block right away so we don't block the player while connecting
   // and during TLS handshake (we would probably need to introduce a deferredev)
 #ifdef SOCK_CLOEXEC
-  fd = socket(family, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  fd = socket(family, type | SOCK_CLOEXEC, 0);
 #else
-  fd = socket(family, SOCK_STREAM, 0);
+  fd = socket(family, type, 0);
 #endif
   if (fd < 0)
     {
@@ -423,7 +500,7 @@ tcp_connect(const char *address, unsigned int port, int family)
 }
 
 static void
-tcp_close(int fd)
+cast_disconnect(int fd)
 {
   /* no more receptions */
   shutdown(fd, SHUT_RDWR);
@@ -517,16 +594,48 @@ squote_to_dquote(char *buf)
 /* ----------------------------- SESSION CLEANUP ---------------------------- */
 
 static void
+master_session_free(struct cast_master_session *cms)
+{
+  if (!cms)
+    return;
+
+  outputs_quality_unsubscribe(&cms->rtp_session->quality);
+  rtp_session_free(cms->rtp_session);
+  evbuffer_free(cms->evbuf);
+  free(cms->rawbuf);
+  free(cms);
+}
+
+static void
+master_session_cleanup(struct cast_master_session *cms)
+{
+  struct cast_session *cs;
+
+  // First check if any other session is using the master session
+  for (cs = cast_sessions; cs; cs=cs->next)
+    {
+      if (cs->master_session == cms)
+	return;
+    }
+
+  master_session_free(cms);
+}
+
+static void
 cast_session_free(struct cast_session *cs)
 {
   if (!cs)
     return;
 
+  master_session_cleanup(cs->master_session);
+
   event_free(cs->reply_timeout);
   event_free(cs->ev);
 
   if (cs->server_fd >= 0)
-    tcp_close(cs->server_fd);
+    cast_disconnect(cs->server_fd);
+  if (cs->udp_fd >= 0)
+    cast_disconnect(cs->udp_fd);
 
   gnutls_deinit(cs->tls_session);
 
@@ -540,8 +649,6 @@ cast_session_free(struct cast_session *cs)
   if (cs->transport_id)
     free(cs->transport_id);
 
-  free(cs->output_session);
-
   free(cs);
 }
 
@@ -550,11 +657,11 @@ cast_session_cleanup(struct cast_session *cs)
 {
   struct cast_session *s;
 
-  if (cs == sessions)
-    sessions = sessions->next;
+  if (cs == cast_sessions)
+    cast_sessions = cast_sessions->next;
   else
     {
-      for (s = sessions; s && (s->next != cs); s = s->next)
+      for (s = cast_sessions; s && (s->next != cs); s = s->next)
 	; /* EMPTY */
 
       if (!s)
@@ -562,6 +669,8 @@ cast_session_cleanup(struct cast_session *cs)
       else
 	s->next = cs->next;
     }
+
+  outputs_device_session_remove(cs->device_id);
 
   cast_session_free(cs);
 }
@@ -616,6 +725,8 @@ cast_msg_send(struct cast_session *cs, enum cast_msg_types type, cast_reply_cb r
     snprintf(msg_buf, sizeof(msg_buf), cast_msg[type].payload, cs->request_id);
   else if (type == STOP)
     snprintf(msg_buf, sizeof(msg_buf), cast_msg[type].payload, cs->session_id, cs->request_id);
+  else if (type == OFFER)
+    snprintf(msg_buf, sizeof(msg_buf), cast_msg[type].payload, cs->request_id, cs->ssrc_id);
   else if (type == MEDIA_LOAD)
     snprintf(msg_buf, sizeof(msg_buf), cast_msg[type].payload, cs->stream_url, cs->session_id, cs->request_id);
   else if ((type == MEDIA_PLAY) || (type == MEDIA_PAUSE) || (type == MEDIA_STOP))
@@ -692,6 +803,17 @@ cast_msg_parse(struct cast_msg_payload *payload, char *s)
 
   if (json_object_object_get_ex(haystack, "requestId", &needle))
     payload->request_id = json_object_get_int(needle);
+  else if (json_object_object_get_ex(haystack, "seqNum", &needle))
+    payload->request_id = json_object_get_int(needle);
+
+  if (json_object_object_get_ex(haystack, "answer", &somehay) &&
+      json_object_object_get_ex(somehay, "udpPort", &needle) &&
+      json_object_get_type(needle) == json_type_int )
+    payload->udp_port = json_object_get_int(needle);
+
+  if (json_object_object_get_ex(haystack, "result", &needle) &&
+      json_object_get_type(needle) == json_type_string )
+    payload->result = json_object_get_string(needle);
 
   // Might be done now
   if ((payload->type != RECEIVER_STATUS) && (payload->type != MEDIA_STATUS))
@@ -823,7 +945,15 @@ cast_msg_process(struct cast_session *cs, const uint8_t *data, size_t len)
 	}
     }
 
-  if (payload.type == MEDIA_STATUS && (cs->state & CAST_STATE_F_MEDIA_PLAYING))
+  if (payload.type == CLOSE && (cs->state & CAST_STATE_F_MEDIA_CONNECTED))
+    {
+      // Downgrade state, we can't write any more
+      cs->state = CAST_STATE_CONNECTED;
+      cast_session_shutdown(cs, CAST_STATE_FAILED);
+      goto out_free_parsed;
+    }
+
+  if (payload.type == MEDIA_STATUS && (cs->state & CAST_STATE_F_MEDIA_STREAMING))
     {
       if (payload.player_state && (strcmp(payload.player_state, "PAUSED") == 0))
 	{
@@ -851,7 +981,6 @@ cast_msg_process(struct cast_session *cs, const uint8_t *data, size_t len)
 static void
 cast_status(struct cast_session *cs)
 {
-  output_status_cb status_cb = cs->status_cb;
   enum output_device_state state;
 
   switch (cs->state)
@@ -868,10 +997,14 @@ cast_status(struct cast_session *cs)
       case CAST_STATE_MEDIA_CONNECTED:
 	state = OUTPUT_STATE_CONNECTED;
 	break;
-      case CAST_STATE_MEDIA_LOADED ... CAST_STATE_MEDIA_PAUSED:
+/*      case CAST_STATE_MEDIA_LOADED ... CAST_STATE_MEDIA_PAUSED:
 	state = OUTPUT_STATE_CONNECTED;
 	break;
-      case CAST_STATE_MEDIA_BUFFERING ... CAST_STATE_MEDIA_PLAYING:
+      case CAST_STATE_MEDIA_BUFFERING ... CAST_STATE_MEDIA_STREAMING:
+	state = OUTPUT_STATE_STREAMING;
+	break;
+*/
+      case CAST_STATE_MEDIA_STREAMING:
 	state = OUTPUT_STATE_STREAMING;
 	break;
       default:
@@ -879,9 +1012,8 @@ cast_status(struct cast_session *cs)
 	state = OUTPUT_STATE_FAILED;
     }
 
-  cs->status_cb = NULL;
-  if (status_cb)
-    status_cb(cs->device, cs->output_session, state);
+  outputs_cb(cs->callback_id, cs->device_id, state);
+  cs->callback_id = -1;
 }
 
 /* cast_cb_stop*: Callback chain for shutting down a session */
@@ -929,6 +1061,47 @@ cast_cb_startup_volume(struct cast_session *cs, struct cast_msg_payload *payload
 }
 
 static void
+cast_cb_startup_offer(struct cast_session *cs, struct cast_msg_payload *payload)
+{
+  int ret;
+
+  if (!payload)
+    {
+      DPRINTF(E_LOG, L_CAST, "No reply from '%s' to our OFFER request\n", cs->devname);
+      goto error;
+    }
+  else if (payload->type != ANSWER)
+    {
+      DPRINTF(E_LOG, L_CAST, "The device '%s' did not give us an ANSWER to our OFFER\n", cs->devname);
+      goto error;
+    }
+  else if (!payload->udp_port || strcmp(payload->result, "ok") != 0)
+    {
+      DPRINTF(E_LOG, L_CAST, "Missing UDP port (or unexpected result '%s') in ANSWER - aborting\n", payload->result);
+      goto error;
+    }
+
+  DPRINTF(E_INFO, L_CAST, "UDP port in ANSWER is %d\n", payload->udp_port);
+
+  cs->udp_port = payload->udp_port;
+
+  cs->udp_fd = cast_connect(cs->address, cs->udp_port, cs->family, SOCK_DGRAM);
+  if (cs->udp_fd < 0)
+    goto error;
+
+  ret = cast_msg_send(cs, SET_VOLUME, cast_cb_startup_volume);
+  if (ret < 0)
+    goto error;
+
+  cs->state = CAST_STATE_MEDIA_CONNECTED;
+
+  return;
+
+ error:
+  cast_session_shutdown(cs, CAST_STATE_FAILED);
+}
+
+static void
 cast_cb_startup_media(struct cast_session *cs, struct cast_msg_payload *payload)
 {
   int ret;
@@ -944,11 +1117,9 @@ cast_cb_startup_media(struct cast_session *cs, struct cast_msg_payload *payload)
       goto error;
     }
 
-  ret = cast_msg_send(cs, SET_VOLUME, cast_cb_startup_volume);
+  ret = cast_msg_send(cs, OFFER, cast_cb_startup_offer);
   if (ret < 0)
     goto error;
-
-  cs->state = CAST_STATE_MEDIA_CONNECTED;
 
   return;
 
@@ -1073,28 +1244,35 @@ cast_cb_probe(struct cast_session *cs, struct cast_msg_payload *payload)
 }
 
 /* cast_cb_load: Callback from starting playback */
-static void
+/*static void
 cast_cb_load(struct cast_session *cs, struct cast_msg_payload *payload)
 {
   if (!payload)
     {
-      DPRINTF(E_LOG, L_CAST, "No reply from '%s' to our LOAD request\n", cs->devname);
+      DPRINTF(E_LOG, L_CAST, "No reply from '%s' to our OFFER request\n", cs->devname);
       goto error;
     }
-  else if ((payload->type == MEDIA_LOAD_FAILED) || (payload->type == MEDIA_LOAD_CANCELLED))
+  else if ((payload->type != ANSWER))
     {
-      DPRINTF(E_LOG, L_CAST, "The device '%s' could not start playback\n", cs->devname);
+      DPRINTF(E_LOG, L_CAST, "The device '%s' did not give us an ANSWER to our OFFER\n", cs->devname);
       goto error;
     }
-  else if (!payload->media_session_id)
+// TODO check result == "ok"
+  else if (!payload->udp_port)
     {
-      DPRINTF(E_LOG, L_CAST, "Missing media session id in MEDIA_STATUS - aborting\n");
+      DPRINTF(E_LOG, L_CAST, "Missing UDP port in ANSWER - aborting\n");
       goto error;
     }
 
-  cs->media_session_id = payload->media_session_id;
-  // We autoplay for the time being
-  cs->state = CAST_STATE_MEDIA_PLAYING;
+  DPRINTF(E_LOG, L_CAST, "UDP port in ANSWER is %d\n", payload->udp_port);
+
+  cs->udp_port = payload->udp_port;
+
+  cs->udp_fd = cast_connect(cs->address, cs->udp_port, cs->family, SOCK_DGRAM);
+  if (cs->udp_fd < 0)
+    goto error;
+
+  cs->state = CAST_STATE_MEDIA_LOADED;
 
   cast_status(cs);
 
@@ -1103,7 +1281,7 @@ cast_cb_load(struct cast_session *cs, struct cast_msg_payload *payload)
  error:
   cast_session_shutdown(cs, CAST_STATE_FAILED);
 }
-
+*/
 static void
 cast_cb_volume(struct cast_session *cs, struct cast_msg_payload *payload)
 {
@@ -1118,7 +1296,7 @@ cast_cb_flush(struct cast_session *cs, struct cast_msg_payload *payload)
   else if (payload->type != MEDIA_STATUS)
     DPRINTF(E_LOG, L_CAST, "Unexpected reply to PAUSE request from '%s' - will continue\n", cs->devname);
 
-  cs->state = CAST_STATE_MEDIA_PAUSED;
+  cs->state = CAST_STATE_MEDIA_CONNECTED;
 
   cast_status(cs);
 }
@@ -1138,7 +1316,7 @@ cast_listen_cb(int fd, short what, void *arg)
   int received;
   int ret;
 
-  for (cs = sessions; cs; cs = cs->next)
+  for (cs = cast_sessions; cs; cs = cs->next)
     {
       if (cs == (struct cast_session *)arg)
 	break;
@@ -1243,7 +1421,6 @@ cast_device_cb(const char *name, const char *type, const char *domain, const cha
 {
   struct output_device *device;
   const char *friendly_name;
-  cfg_t *chromecast;
   uint32_t id;
 
   id = djb_hash(name, strlen(name));
@@ -1258,13 +1435,6 @@ cast_device_cb(const char *name, const char *type, const char *domain, const cha
     name = friendly_name;
 
   DPRINTF(E_DBG, L_CAST, "Event for Chromecast device '%s' (port %d, id %" PRIu32 ")\n", name, port, id);
-
-  chromecast = cfg_gettsec(cfg, "chromecast", name);
-  if (chromecast && cfg_getbool(chromecast, "exclude"))
-    {
-      DPRINTF(E_LOG, L_CAST, "Excluding Chromecast device '%s' as set in config\n", name);
-      return;
-    }
 
   device = calloc(1, sizeof(struct output_device));
   if (!device)
@@ -1299,6 +1469,8 @@ cast_device_cb(const char *name, const char *type, const char *domain, const cha
 
   DPRINTF(E_INFO, L_CAST, "Adding Chromecast device '%s'\n", name);
 
+  device->advertised = 1;
+
   switch (family)
     {
       case AF_INET:
@@ -1318,10 +1490,49 @@ cast_device_cb(const char *name, const char *type, const char *domain, const cha
 
 /* --------------------- SESSION CONSTRUCTION AND SHUTDOWN ------------------ */
 
-// Allocates a session and sets of the startup sequence until the session reaches
-// the CAST_STATE_MEDIA_CONNECTED status (so it is ready to load media)
+static struct cast_master_session *
+master_session_make(struct media_quality *quality)
+{
+  struct cast_master_session *cms;
+  int ret;
+
+  // First check if we already have a master session, then just use that
+  if (cast_master_session)
+    return cast_master_session;
+
+  // Let's create a master session
+  ret = outputs_quality_subscribe(quality);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_CAST, "Could not subscribe to required audio quality (%d/%d/%d)\n", quality->sample_rate, quality->bits_per_sample, quality->channels);
+      return NULL;
+    }
+
+  CHECK_NULL(L_CAST, cms = calloc(1, sizeof(struct cast_master_session)));
+
+  cms->rtp_session = rtp_session_new(quality, CAST_PACKET_BUFFER_SIZE, 0);
+  if (!cms->rtp_session)
+    {
+      outputs_quality_unsubscribe(quality);
+      free(cms);
+      return NULL;
+    }
+
+  cms->quality = *quality;
+  cms->samples_per_packet = CAST_SAMPLES_PER_PACKET;
+  cms->rawbuf_size = STOB(cms->samples_per_packet, quality->bits_per_sample, quality->channels);
+  cms->output_buffer_samples = OUTPUTS_BUFFER_DURATION * quality->sample_rate;
+
+  CHECK_NULL(L_CAST, cms->rawbuf = malloc(cms->rawbuf_size));
+  CHECK_NULL(L_CAST, cms->evbuf = evbuffer_new());
+
+  cast_master_session = cms;
+
+  return cms;
+}
+
 static struct cast_session *
-cast_session_make(struct output_device *device, int family, output_status_cb cb)
+cast_session_make(struct output_device *device, int family, int callback_id)
 {
   struct cast_session *cs;
   const char *proto;
@@ -1357,8 +1568,17 @@ cast_session_make(struct output_device *device, int family, output_status_cb cb)
   CHECK_NULL(L_CAST, cs = calloc(1, sizeof(struct cast_session)));
 
   cs->state = CAST_STATE_DISCONNECTED;
-  cs->device = device;
-  cs->status_cb = cb;
+  cs->device_id = device->id;
+  cs->callback_id = callback_id;
+
+  cs->master_session = master_session_make(&cast_quality_default);
+  if (!cs->master_session)
+    {
+      DPRINTF(E_LOG, L_CAST, "Could not attach a master session for device '%s'\n", device->name);
+      goto out_free_session;
+    }
+
+  cs->ssrc_id = cs->master_session->rtp_session->ssrc_id;
 
   /* Init TLS session, use default priorities and put the x509 credentials to the current session */
   if ( ((ret = gnutls_init(&cs->tls_session, GNUTLS_CLIENT)) != GNUTLS_E_SUCCESS) ||
@@ -1366,10 +1586,10 @@ cast_session_make(struct output_device *device, int family, output_status_cb cb)
        ((ret = gnutls_credentials_set(cs->tls_session, GNUTLS_CRD_CERTIFICATE, tls_credentials)) != GNUTLS_E_SUCCESS) )
     {
       DPRINTF(E_LOG, L_CAST, "Could not initialize GNUTLS session: %s\n", gnutls_strerror(ret));
-      goto out_free_session;
+      goto out_free_master_session;
     }
 
-  cs->server_fd = tcp_connect(address, port, family);
+  cs->server_fd = cast_connect(address, port, family, SOCK_STREAM);
   if (cs->server_fd < 0)
     {
       DPRINTF(E_LOG, L_CAST, "Could not connect to %s\n", device->name);
@@ -1408,18 +1628,21 @@ cast_session_make(struct output_device *device, int family, output_status_cb cb)
   flags = fcntl(cs->server_fd, F_GETFL, 0);
   fcntl(cs->server_fd, F_SETFL, flags | O_NONBLOCK);
 
-  event_add(cs->ev, &heartbeat_timeout);
+  event_add(cs->ev, NULL); // &heartbeat_timeout
 
   cs->devname = strdup(device->name);
   cs->address = strdup(address);
+  cs->family = family;
+
+  cs->udp_fd = -1;
 
   cs->volume = 0.01 * device->volume;
 
-  cs->next = sessions;
-  sessions = cs;
+  cs->next = cast_sessions;
+  cast_sessions = cs;
 
-  // cs is now the official session for the device
-  outputs_device_session_add(device, cs);
+  // cs is now the official device session
+  outputs_device_session_add(device->id, cs);
 
   proto = gnutls_protocol_get_name(gnutls_protocol_get_version(cs->tls_session));
 
@@ -1431,9 +1654,11 @@ cast_session_make(struct output_device *device, int family, output_status_cb cb)
   event_free(cs->reply_timeout);
   event_free(cs->ev);
  out_close_connection:
-  tcp_close(cs->server_fd);
+  cast_disconnect(cs->server_fd);
  out_deinit_gnutls:
   gnutls_deinit(cs->tls_session);
+ out_free_master_session:
+  master_session_cleanup(cs->master_session);
  out_free_session:
   free(cs);
 
@@ -1464,12 +1689,15 @@ cast_session_shutdown(struct cast_session *cs, enum cast_state wanted_state)
   pending = 0;
   switch (cs->state)
     {
-      case CAST_STATE_MEDIA_LOADED ... CAST_STATE_MEDIA_PLAYING:
+//      case CAST_STATE_MEDIA_LOADED ... CAST_STATE_MEDIA_STREAMING:
+      case CAST_STATE_MEDIA_STREAMING:
 	ret = cast_msg_send(cs, MEDIA_STOP, cast_cb_stop_media);
 	pending = 1;
 	break;
 
       case CAST_STATE_MEDIA_CONNECTED:
+	cast_disconnect(cs->udp_fd);
+	cs->udp_fd = -1;
 	ret = cast_msg_send(cs, MEDIA_CLOSE, NULL);
 	cs->state = CAST_STATE_MEDIA_LAUNCHED;
 	if ((ret < 0) || (wanted_state >= CAST_STATE_MEDIA_LAUNCHED))
@@ -1486,7 +1714,7 @@ cast_session_shutdown(struct cast_session *cs, enum cast_state wanted_state)
 	ret = cast_msg_send(cs, CLOSE, NULL);
 	if (ret == 0)
 	  gnutls_bye(cs->tls_session, GNUTLS_SHUT_RDWR);
-	tcp_close(cs->server_fd);
+	cast_disconnect(cs->server_fd);
 	cs->server_fd = -1;
 	cs->state = CAST_STATE_DISCONNECTED;
 	break;
@@ -1526,20 +1754,207 @@ cast_session_shutdown(struct cast_session *cs, enum cast_state wanted_state)
 }
 
 
+/* ------------------ PREPARING AND SENDING CAST RTP PACKETS ---------------- */
+
+// Makes a Cast RTP packet (source: Chromium's media/cast/net/rtp/rtp_packetizer.cc)
+//
+// A Cast RTP packet is made of:
+//   RTP header (12 bytes)
+//   Cast header (7 bytes)
+//   Extension data (4 bytes)
+//   Packet data
+//
+// The Cast header + extension (optional?) consists of:
+//    0                   1                   2                   3
+//    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |k|r|   n_ext   |   frame_id    |          packet id            |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |         max_packet_id         | ref_frame_id  |   ext_type    |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//   |   ext_size    |      new_playout_delay_ms     |
+//   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//
+// k: Is the frame a key frame?
+// r: Is there a reference frame id?
+// n_ext: Number of Cast extensions (Chromium uses 1: Adaptive Latency)
+// ext_type: 0x04 Adaptive Latency extension
+// ext_size: 0x02 -> 2 bytes
+// new_playout_delay_ms: ??
+
+// OPUS encodes the rawbuf payload
+static int
+payload_encode(struct evbuffer *evbuf, uint8_t *rawbuf, size_t rawbuf_size, int nsamples, struct media_quality *quality)
+{
+  transcode_frame *frame;
+  int len;
+
+  frame = transcode_frame_new(rawbuf, rawbuf_size, nsamples, quality->sample_rate, quality->bits_per_sample);
+  if (!frame)
+    {
+      DPRINTF(E_LOG, L_CAST, "Could not convert raw PCM to frame (bufsize=%ld)\n", rawbuf_size);
+      return -1;
+    }
+
+  len = transcode_encode(evbuf, cast_encode_ctx, frame, 0);
+  transcode_frame_free(frame);
+  if (len < 0)
+    {
+      DPRINTF(E_LOG, L_CAST, "Could not Opus encode frame\n");
+      return -1;
+    }
+
+  return len;
+}
+
+static int
+packet_prepare(struct rtp_packet *pkt, struct evbuffer *evbuf)
+{
+
+  // Cast header
+  memset(pkt->payload, 0, CAST_HEADER_SIZE);
+  pkt->payload[0] = 0xc1; // k = 1, r = 1 and one extension
+  pkt->payload[1] = (char)pkt->seqnum;
+  // packet_id and max_packet_id don't seem to be used, so leave them at 0
+  pkt->payload[6] = (char)pkt->seqnum;
+  pkt->payload[7] = 0x04; // kCastRtpExtensionAdaptiveLatency has id (1 << 2)
+  pkt->payload[8] = 0x02; // Extension will use two bytes
+  // leave extension values at 0, but Chromium sets them to:
+  //   (frame.new_playout_delay_ms >> 8) and frame.new_playout_delay_ms (normal byte values are 0x03 0x20)
+
+  // Copy payload
+  return evbuffer_remove(evbuf, pkt->payload + CAST_HEADER_SIZE, pkt->payload_len - CAST_HEADER_SIZE);
+}
+
+static int
+packet_send(struct cast_session *cs, struct rtp_packet *pkt)
+{
+  int ret;
+
+  ret = send(cs->udp_fd, pkt->data, pkt->data_len, 0);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_CAST, "Send error for '%s': %s\n", cs->devname, strerror(errno));
+      return -1;
+    }
+  else if (ret != pkt->data_len)
+    {
+      DPRINTF(E_WARN, L_CAST, "Partial send (%d) for '%s'\n", ret, cs->devname);
+      return 0;
+    }
+
+/*  DPRINTF(E_DBG, L_PLAYER, "RTP PACKET seqnum %u, rtptime %u, payload 0x%x, pktbuf_s %zu\n",
+    cs->master_session->rtp_session->seqnum,
+    cs->master_session->rtp_session->pos,
+    pkt->header[1],
+    cs->master_session->rtp_session->pktbuf_len
+    );
+*/
+  return 0;
+}
+
+static int
+packets_send(struct cast_master_session *cms)
+{
+  struct rtp_packet *pkt;
+  struct cast_session *cs;
+  struct cast_session *next;
+  int len;
+  int ret;
+
+  // Encode payload into cast_encoded_data
+  len = payload_encode(cast_encoded_data, cms->rawbuf, cms->rawbuf_size, cms->samples_per_packet, &cms->quality);
+  if (len < 0)
+    return -1;
+
+  // Chromium uses a RTP payload type that is 0xff
+  pkt = rtp_packet_next(cms->rtp_session, CAST_HEADER_SIZE + len, cms->samples_per_packet, 0xff);
+
+  // Creates Cast header + adds payload
+  ret = packet_prepare(pkt, cast_encoded_data);
+  if (ret < 0)
+    return -1;
+
+  for (cs = cast_sessions; cs; cs = next)
+    {
+      next = cs->next;
+
+      if (cs->master_session != cms || !(cs->state & CAST_STATE_F_MEDIA_CONNECTED))
+	continue;
+
+      ret = packet_send(cs, pkt);
+      if (ret < 0)
+        {
+	  // Downgrade state immediately to avoid further write attempts
+	  cs->state = CAST_STATE_MEDIA_LAUNCHED;
+	  cast_session_shutdown(cs, CAST_STATE_FAILED);
+	}
+    }
+
+  // Commits packet to retransmit buffer, and prepares the session for the next packet
+  rtp_packet_commit(cms->rtp_session, pkt);
+
+  return 0;
+}
+
+/* TODO This does not currently work - need to investigate what sync the devices support
+static void
+packets_sync_send(struct cast_master_session *cms, struct timespec pts)
+{
+  struct rtp_packet *sync_pkt;
+  struct cast_session *cs;
+  struct rtcp_timestamp cur_stamp;
+  struct timespec ts;
+  bool is_sync_time;
+
+  // Check if it is time send a sync packet to sessions that are already running
+  is_sync_time = rtp_sync_is_time(cms->rtp_session);
+
+  // (See raop.c for more comments on sync packets)
+  cur_stamp.ts.tv_sec = pts.tv_sec;
+  cur_stamp.ts.tv_nsec = pts.tv_nsec;
+
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+
+  cur_stamp.pos = cms->rtp_session->pos + cms->evbuf_samples - cms->output_buffer_samples;
+
+  for (cs = cast_sessions; cs; cs = cs->next)
+    {
+      if (cs->master_session != cms)
+	continue;
+
+      // A device has joined and should get an init sync packet
+      if (cs->state == CAST_STATE_MEDIA_CONNECTED)
+	{
+	  sync_pkt = rtp_sync_packet_next(cms->rtp_session, &cur_stamp, 0x80);
+	  packet_send(cs, sync_pkt);
+
+	  DPRINTF(E_DBG, L_PLAYER, "Start sync packet sent to '%s': cur_pos=%" PRIu32 ", cur_ts=%lu:%lu, now=%lu:%lu, rtptime=%" PRIu32 ",\n",
+	    cs->devname, cur_stamp.pos, cur_stamp.ts.tv_sec, cur_stamp.ts.tv_nsec, ts.tv_sec, ts.tv_nsec, cms->rtp_session->pos);
+	}
+      else if (is_sync_time && cs->state == CAST_STATE_MEDIA_STREAMING)
+	{
+	  sync_pkt = rtp_sync_packet_next(cms->rtp_session, &cur_stamp, 0x80);
+	  packet_send(cs, sync_pkt);
+	}
+    }
+}
+*/
+
 /* ------------------ INTERFACE FUNCTIONS CALLED BY OUTPUTS.C --------------- */
 
 static int
-cast_device_start(struct output_device *device, output_status_cb cb, uint64_t rtptime)
+cast_device_start_generic(struct output_device *device, int callback_id, cast_reply_cb reply_cb)
 {
   struct cast_session *cs;
   int ret;
 
-  cs = cast_session_make(device, AF_INET6, cb);
+  cs = cast_session_make(device, AF_INET6, callback_id);
   if (cs)
     {
       ret = cast_msg_send(cs, CONNECT, NULL);
       if (ret == 0)
-	ret = cast_msg_send(cs, GET_STATUS, cast_cb_startup_connect);
+	ret = cast_msg_send(cs, GET_STATUS, reply_cb);
 
       if (ret < 0)
 	{
@@ -1550,13 +1965,13 @@ cast_device_start(struct output_device *device, output_status_cb cb, uint64_t rt
 	return 0;
     }
 
-  cs = cast_session_make(device, AF_INET, cb);
+  cs = cast_session_make(device, AF_INET, callback_id);
   if (!cs)
     return -1;
 
   ret = cast_msg_send(cs, CONNECT, NULL);
   if (ret == 0)
-    ret = cast_msg_send(cs, GET_STATUS, cast_cb_startup_connect);
+    ret = cast_msg_send(cs, GET_STATUS, reply_cb);
 
   if (ret < 0)
     {
@@ -1564,70 +1979,68 @@ cast_device_start(struct output_device *device, output_status_cb cb, uint64_t rt
       cast_session_cleanup(cs);
       return -1;
     }
+
+  return 0;
+}
+
+static int
+cast_device_start(struct output_device *device, int callback_id)
+{
+  return cast_device_start_generic(device, callback_id, cast_cb_startup_connect);
+}
+
+static int
+cast_device_probe(struct output_device *device, int callback_id)
+{
+  return cast_device_start_generic(device, callback_id, cast_cb_probe);
+}
+
+static int
+cast_device_stop(struct output_device *device, int callback_id)
+{
+  struct cast_session *cs = device->session;
+
+  cs->callback_id = callback_id;
+
+  cast_session_shutdown(cs, CAST_STATE_NONE);
+
+  return 0;
+}
+
+static int
+cast_device_flush(struct output_device *device, int callback_id)
+{
+  struct cast_session *cs = device->session;
+  int ret;
+
+  if (!(cs->state & CAST_STATE_F_MEDIA_STREAMING))
+    return -1;
+
+  // TODO Can't do this, we need to pause the stream in some other way
+  ret = cast_msg_send(cs, MEDIA_PAUSE, cast_cb_flush);
+  if (ret < 0)
+    return -1;
+
+  cs->callback_id = callback_id;
 
   return 0;
 }
 
 static void
-cast_device_stop(struct output_session *session)
+cast_device_cb_set(struct output_device *device, int callback_id)
 {
-  struct cast_session *cs = session->session;
+  struct cast_session *cs = device->session;
 
-  cast_session_shutdown(cs, CAST_STATE_NONE);
+  cs->callback_id = callback_id;
 }
 
 static int
-cast_device_probe(struct output_device *device, output_status_cb cb)
+cast_device_volume_set(struct output_device *device, int callback_id)
 {
-  struct cast_session *cs;
+  struct cast_session *cs = device->session;
   int ret;
 
-  cs = cast_session_make(device, AF_INET6, cb);
-  if (cs)
-    {
-      ret = cast_msg_send(cs, CONNECT, NULL);
-      if (ret == 0)
-	ret = cast_msg_send(cs, GET_STATUS, cast_cb_probe);
-
-      if (ret < 0)
-	{
-	  DPRINTF(E_WARN, L_CAST, "Could not send CONNECT or GET_STATUS request on IPv6 (start)\n");
-	  cast_session_cleanup(cs);
-	}
-      else
-	return 0;
-    }
-
-  cs = cast_session_make(device, AF_INET, cb);
-  if (!cs)
-    return -1;
-
-  ret = cast_msg_send(cs, CONNECT, NULL);
-  if (ret == 0)
-    ret = cast_msg_send(cs, GET_STATUS, cast_cb_probe);
-
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_CAST, "Could not send CONNECT or GET_STATUS request on IPv4 (start)\n");
-      cast_session_cleanup(cs);
-      return -1;
-    }
-
-  return 0;
-}
-
-static int
-cast_volume_set(struct output_device *device, output_status_cb cb)
-{
-  struct cast_session *cs;
-  int ret;
-
-  if (!device->session || !device->session->session)
-    return 0;
-
-  cs = device->session->session;
-
-  if (!(cs->state & CAST_STATE_F_MEDIA_CONNECTED))
+  if (!cs || !(cs->state & CAST_STATE_F_MEDIA_CONNECTED))
     return 0;
 
   cs->volume = 0.01 * device->volume;
@@ -1640,25 +2053,9 @@ cast_volume_set(struct output_device *device, output_status_cb cb)
     }
 
   // Setting it here means it will not be used for the above cast_session_shutdown
-  cs->status_cb = cb;
+  cs->callback_id = callback_id;
 
   return 1;
-}
-
-static void
-cast_playback_start(uint64_t next_pkt, struct timespec *ts)
-{
-  struct cast_session *cs;
-
-  if (evtimer_pending(flush_timer, NULL))
-    event_del(flush_timer);
-
-  // TODO Maybe we could avoid reloading and instead support play->pause->play
-  for (cs = sessions; cs; cs = cs->next)
-    {
-      if (cs->state & CAST_STATE_F_MEDIA_CONNECTED)
-	cast_msg_send(cs, MEDIA_LOAD, cast_cb_load);
-    }
 }
 
 static void
@@ -1667,7 +2064,7 @@ cast_playback_stop(void)
   struct cast_session *cs;
   struct cast_session *next;
 
-  for (cs = sessions; cs; cs = next)
+  for (cs = cast_sessions; cs; cs = next)
     {
       next = cs->next;
       if (cs->state & CAST_STATE_F_MEDIA_CONNECTED)
@@ -1676,57 +2073,55 @@ cast_playback_stop(void)
 }
 
 static void
-cast_flush_timer_cb(int fd, short what, void *arg)
+cast_write(struct output_buffer *obuf)
 {
-  DPRINTF(E_DBG, L_CAST, "Flush timer expired; tearing down all sessions\n");
-
-  cast_playback_stop();
-}
-
-static int
-cast_flush(output_status_cb cb, uint64_t rtptime)
-{
+  struct cast_master_session *cms;
   struct cast_session *cs;
-  struct cast_session *next;
-  int pending;
-  int ret;
+  int i;
 
-  pending = 0;
-  for (cs = sessions; cs; cs = next)
+  if (!cast_sessions)
+    return;
+
+  cms = cast_master_session;
+
+  for (i = 0; obuf->data[i].buffer; i++)
     {
-      next = cs->next;
-
-      if (!(cs->state & CAST_STATE_F_MEDIA_PLAYING))
+      if (!quality_is_equal(&obuf->data[i].quality, &cast_quality_default))
 	continue;
 
-      ret = cast_msg_send(cs, MEDIA_PAUSE, cast_cb_flush);
-      if (ret < 0)
-	{
-	  cast_session_shutdown(cs, CAST_STATE_FAILED);
-	  continue;
-	}
+      // Sends sync packets to new sessions, and if it is sync time then also to old sessions
+//      packets_sync_send(cms, obuf->pts);
 
-      cs->status_cb = cb;
-      pending++;
+      // TODO avoid this copy
+      evbuffer_add(cms->evbuf, obuf->data[i].buffer, obuf->data[i].bufsize);
+      cms->evbuf_samples += obuf->data[i].samples;
+
+      // Send as many packets as we have data for (one packet requires rawbuf_size bytes)
+      while (evbuffer_get_length(cms->evbuf) >= cms->rawbuf_size)
+	{
+	  evbuffer_remove(cms->evbuf, cms->rawbuf, cms->rawbuf_size);
+	  cms->evbuf_samples -= cms->samples_per_packet;
+
+	  packets_send(cms);
+	}
     }
 
-  if (pending > 0)
-    evtimer_add(flush_timer, &flush_timeout);
+  // Check for devices that have joined since last write (we have already sent them
+  // initialization sync and rtp packets via packets_sync_send and packets_send)
+  for (cs = cast_sessions; cs; cs = cs->next)
+    {
+      if (cs->state != CAST_STATE_MEDIA_CONNECTED)
+	continue;
 
-  return pending;
-}
-
-static void
-cast_set_status_cb(struct output_session *session, output_status_cb cb)
-{
-  struct cast_session *cs = session->session;
-
-  cs->status_cb = cb;
+      cs->state = CAST_STATE_MEDIA_STREAMING;
+      // Make a cb?
+    }
 }
 
 static int
 cast_init(void)
 {
+  struct decode_ctx *decode_ctx;
   int family;
   int i;
   int ret;
@@ -1751,10 +2146,18 @@ cast_init(void)
       return -1;
     }
 
-  flush_timer = evtimer_new(evbase_player, cast_flush_timer_cb, NULL);
-  if (!flush_timer)
+  decode_ctx = transcode_decode_setup_raw(XCODE_PCM16_48000);
+  if (!decode_ctx)
     {
-      DPRINTF(E_LOG, L_CAST, "Out of memory for flush timer\n");
+      DPRINTF(E_LOG, L_CAST, "Could not create decoding context\n");
+      goto out_tls_deinit;
+    }
+
+  cast_encode_ctx = transcode_encode_setup(XCODE_OPUS, decode_ctx, NULL, 0, 0);
+  transcode_decode_cleanup(&decode_ctx);
+  if (!cast_encode_ctx)
+    {
+      DPRINTF(E_LOG, L_CAST, "Will not be able to stream Chromecast, libav does not support Opus encoding\n");
       goto out_tls_deinit;
     }
 
@@ -1767,13 +2170,15 @@ cast_init(void)
   if (ret < 0)
     {
       DPRINTF(E_LOG, L_CAST, "Could not add mDNS browser for Chromecast devices\n");
-      goto out_free_flush_timer;
+      goto out_encode_ctx_free;
     }
+
+  CHECK_NULL(L_CAST, cast_encoded_data = evbuffer_new());
 
   return 0;
 
- out_free_flush_timer:
-  event_free(flush_timer);
+ out_encode_ctx_free:
+  transcode_encode_cleanup(&cast_encode_ctx);
  out_tls_deinit:
   gnutls_certificate_free_credentials(tls_credentials);
   gnutls_global_deinit();
@@ -1786,13 +2191,14 @@ cast_deinit(void)
 {
   struct cast_session *cs;
 
-  for (cs = sessions; sessions; cs = sessions)
+  for (cs = cast_sessions; cast_sessions; cs = cast_sessions)
     {
-      sessions = cs->next;
+      cast_sessions = cs->next;
       cast_session_free(cs);
     }
 
-  event_free(flush_timer);
+  evbuffer_free(cast_encoded_data);
+  transcode_encode_cleanup(&cast_encode_ctx);
 
   gnutls_certificate_free_credentials(tls_credentials);
   gnutls_global_deinit();
@@ -1804,18 +2210,16 @@ struct output_definition output_cast =
   .type = OUTPUT_TYPE_CAST,
   .priority = 2,
   .disabled = 0,
+  .device_start = cast_device_start,
+  .device_probe = cast_device_probe,
+  .device_stop = cast_device_stop,
+  .device_flush = cast_device_flush,
+  .device_cb_set = cast_device_cb_set,
+  .device_volume_set = cast_device_volume_set,
+  .playback_stop = cast_playback_stop,
+  .write = cast_write,
   .init = cast_init,
   .deinit = cast_deinit,
-  .device_start = cast_device_start,
-  .device_stop = cast_device_stop,
-  .device_probe = cast_device_probe,
-//  .device_free_extra is unset - nothing to free
-  .device_volume_set = cast_volume_set,
-  .playback_start = cast_playback_start,
-  .playback_stop = cast_playback_stop,
-//  .write is unset - we don't write, the Chromecast will read our mp3 stream
-  .flush = cast_flush,
-  .status_cb = cast_set_status_cb,
 /* TODO metadata support
   .metadata_prepare = cast_metadata_prepare,
   .metadata_send = cast_metadata_send,

--- a/src/outputs/cast.c
+++ b/src/outputs/cast.c
@@ -1420,7 +1420,8 @@ cast_session_make(struct output_device *device, int family, output_status_cb cb)
   cs->next = sessions;
   sessions = cs;
 
-  device->session = cs;
+  // cs is now the official session for the device
+  outputs_device_session_add(device, cs);
 
   proto = gnutls_protocol_get_name(gnutls_protocol_get_version(cs->tls_session));
 

--- a/src/outputs/cast.c
+++ b/src/outputs/cast.c
@@ -1299,8 +1299,6 @@ cast_device_cb(const char *name, const char *type, const char *domain, const cha
 
   DPRINTF(E_INFO, L_CAST, "Adding Chromecast device '%s'\n", name);
 
-  device->advertised = 1;
-
   switch (family)
     {
       case AF_INET:

--- a/src/outputs/dummy.c
+++ b/src/outputs/dummy.c
@@ -132,6 +132,19 @@ dummy_device_stop(struct output_device *device, int callback_id)
 }
 
 static int
+dummy_device_flush(struct output_device *device, int callback_id)
+{
+  struct dummy_session *ds = device->session;
+
+  ds->callback_id = callback_id;
+  ds->state = OUTPUT_STATE_STOPPED;
+
+  dummy_status(ds);
+
+  return 0;
+}
+
+static int
 dummy_device_probe(struct output_device *device, int callback_id)
 {
   struct dummy_session *ds;
@@ -228,6 +241,7 @@ struct output_definition output_dummy =
   .deinit = dummy_deinit,
   .device_start = dummy_device_start,
   .device_stop = dummy_device_stop,
+  .device_flush = dummy_device_flush,
   .device_probe = dummy_device_probe,
   .device_volume_set = dummy_device_volume_set,
   .device_cb_set = dummy_device_cb_set,

--- a/src/outputs/dummy.c
+++ b/src/outputs/dummy.c
@@ -203,7 +203,6 @@ dummy_init(void)
   device->name = strdup(nickname);
   device->type = OUTPUT_TYPE_DUMMY;
   device->type_name = outputs_name(device->type);
-  device->advertised = 1;
   device->has_video = 0;
 
   DPRINTF(E_INFO, L_LAUDIO, "Adding dummy output device '%s'\n", nickname);

--- a/src/outputs/fifo.c
+++ b/src/outputs/fifo.c
@@ -505,7 +505,6 @@ fifo_init(void)
   device->name = strdup(nickname);
   device->type = OUTPUT_TYPE_FIFO;
   device->type_name = outputs_name(device->type);
-  device->advertised = 1;
   device->has_video = 0;
   device->extra_device_info = path;
   DPRINTF(E_INFO, L_FIFO, "Adding fifo output device '%s' with path '%s'\n", nickname, path);

--- a/src/outputs/fifo.c
+++ b/src/outputs/fifo.c
@@ -39,13 +39,13 @@
 #include "player.h"
 #include "outputs.h"
 
-#define FIFO_BUFFER_SIZE 65536 /* pipe capacity on Linux >= 2.6.11 */
-
+#define FIFO_BUFFER_SIZE 65536 // pipe capacity on Linux >= 2.6.11
+#define FIFO_PACKET_SIZE 1408  // 352 samples/packet * 16 bit/sample * 2 channels
 
 struct fifo_packet
 {
   /* pcm data */
-  uint8_t samples[1408]; // STOB(AIRTUNES_V2_PACKET_SAMPLES)
+  uint8_t samples[FIFO_PACKET_SIZE];
 
   /* RTP-time of the first sample*/
   uint64_t rtptime;
@@ -453,7 +453,7 @@ static void
 fifo_write(uint8_t *buf, uint64_t rtptime)
 {
   struct fifo_session *fifo_session = sessions;
-  size_t length = STOB(AIRTUNES_V2_PACKET_SAMPLES);
+  size_t length = FIFO_PACKET_SIZE;
   ssize_t bytes;
   struct fifo_packet *packet;
   uint64_t cur_pos;

--- a/src/outputs/fifo.c
+++ b/src/outputs/fifo.c
@@ -413,13 +413,13 @@ fifo_write(struct output_buffer *obuf)
   if (!fifo_session)
     return;
 
-  for (i = 0; obuf->frames[i].buffer; i++)
+  for (i = 0; obuf->data[i].buffer; i++)
     {
-      if (quality_is_equal(&fifo_quality, &obuf->frames[i].quality))
+      if (quality_is_equal(&fifo_quality, &obuf->data[i].quality))
         break;
     }
 
-  if (!obuf->frames[i].buffer)
+  if (!obuf->data[i].buffer)
     {
       DPRINTF(E_LOG, L_FIFO, "Bug! Did not get audio in quality required\n");
       return;
@@ -428,10 +428,10 @@ fifo_write(struct output_buffer *obuf)
   fifo_session->state = OUTPUT_STATE_STREAMING;
 
   CHECK_NULL(L_FIFO, packet = calloc(1, sizeof(struct fifo_packet)));
-  CHECK_NULL(L_FIFO, packet->samples = malloc(obuf->frames[i].bufsize));
+  CHECK_NULL(L_FIFO, packet->samples = malloc(obuf->data[i].bufsize));
 
-  memcpy(packet->samples, obuf->frames[i].buffer, obuf->frames[i].bufsize);
-  packet->samples_size = obuf->frames[i].bufsize;
+  memcpy(packet->samples, obuf->data[i].buffer, obuf->data[i].bufsize);
+  packet->samples_size = obuf->data[i].bufsize;
   packet->pts = obuf->pts;
 
   if (buffer.head)

--- a/src/outputs/fifo.c
+++ b/src/outputs/fifo.c
@@ -324,6 +324,21 @@ fifo_device_stop(struct output_device *device, int callback_id)
 }
 
 static int
+fifo_device_flush(struct output_device *device, int callback_id)
+{
+  struct fifo_session *fifo_session = device->session;
+
+  fifo_empty(fifo_session);
+  free_buffer();
+
+  fifo_session->callback_id = callback_id;
+  fifo_session->state = OUTPUT_STATE_CONNECTED;
+  fifo_status(fifo_session);
+
+  return 0;
+}
+
+static int
 fifo_device_probe(struct output_device *device, int callback_id)
 {
   struct fifo_session *fifo_session;
@@ -384,23 +399,6 @@ fifo_playback_stop(void)
 
   fifo_session->state = OUTPUT_STATE_CONNECTED;
   fifo_status(fifo_session);
-}
-
-static int
-fifo_flush(int callback_id)
-{
-  struct fifo_session *fifo_session = sessions;
-
-  if (!fifo_session)
-    return 0;
-
-  fifo_empty(fifo_session);
-  free_buffer();
-
-  fifo_session->callback_id = callback_id;
-  fifo_session->state = OUTPUT_STATE_CONNECTED;
-  fifo_status(fifo_session);
-  return 1;
 }
 
 static void
@@ -530,10 +528,10 @@ struct output_definition output_fifo =
   .deinit = fifo_deinit,
   .device_start = fifo_device_start,
   .device_stop = fifo_device_stop,
+  .device_flush = fifo_device_flush,
   .device_probe = fifo_device_probe,
   .device_volume_set = fifo_device_volume_set,
   .device_cb_set = fifo_device_cb_set,
   .playback_stop = fifo_playback_stop,
   .write = fifo_write,
-  .flush = fifo_flush,
 };

--- a/src/outputs/pulse.c
+++ b/src/outputs/pulse.c
@@ -160,7 +160,7 @@ pulse_session_make(struct output_device *device, output_status_cb cb)
   ps->next = sessions;
   sessions = ps;
 
-  device->session = ps;
+  outputs_device_session_add(device, ps);
 
   return ps;
 }

--- a/src/outputs/pulse.c
+++ b/src/outputs/pulse.c
@@ -38,8 +38,6 @@
 #include "outputs.h"
 #include "commands.h"
 
-// From Airplay
-#define PULSE_SAMPLES_PER_PACKET 352
 #define PULSE_MAX_DEVICES 64
 #define PULSE_LOG_MAX 10
 
@@ -60,18 +58,20 @@ struct pulse
 
 struct pulse_session
 {
+  uint64_t device_id;
+  int callback_id;
+
+  char *devname;
+
   pa_stream_state_t state;
   pa_stream *stream;
 
   pa_buffer_attr attr;
   pa_volume_t volume;
 
+  struct media_quality quality;
+
   int logcount;
-
-  char *devname;
-
-  struct output_device *device;
-  output_status_cb status_cb;
 
   struct pulse_session *next;
 };
@@ -84,6 +84,9 @@ static struct pulse_session *sessions;
 
 // Internal list with indeces of the Pulseaudio devices (sinks) we have registered
 static uint32_t pulse_known_devices[PULSE_MAX_DEVICES];
+
+static struct media_quality pulse_last_quality;
+static struct media_quality pulse_fallback_quality = { 44100, 16, 2 };
 
 // Converts from 0 - 100 to Pulseaudio's scale
 static inline pa_volume_t
@@ -113,10 +116,9 @@ pulse_session_free(struct pulse_session *ps)
       pa_threaded_mainloop_unlock(pulse.mainloop);
     }
 
-  if (ps->devname)
-    free(ps->devname);
+  outputs_quality_unsubscribe(&pulse_fallback_quality);
 
-  free(ps->output_session);
+  free(ps->devname);
 
   free(ps);
 }
@@ -139,28 +141,36 @@ pulse_session_cleanup(struct pulse_session *ps)
 	p->next = ps->next;
     }
 
-  ps->device->session = NULL;
+  outputs_device_session_remove(ps->device_id);
 
   pulse_session_free(ps);
 }
 
 static struct pulse_session *
-pulse_session_make(struct output_device *device, output_status_cb cb)
+pulse_session_make(struct output_device *device, int callback_id)
 {
   struct pulse_session *ps;
+  int ret;
+
+  ret = outputs_quality_subscribe(&pulse_fallback_quality);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not subscribe to fallback audio quality\n");
+      return NULL;
+    }
 
   CHECK_NULL(L_LAUDIO, ps = calloc(1, sizeof(struct pulse_session)));
 
   ps->state = PA_STREAM_UNCONNECTED;
-  ps->device = device;
-  ps->status_cb = cb;
+  ps->device_id = device->id;
+  ps->callback_id = callback_id;
   ps->volume = pulse_from_device_volume(device->volume);
   ps->devname = strdup(device->extra_device_info);
 
   ps->next = sessions;
   sessions = ps;
 
-  outputs_device_session_add(device, ps);
+  outputs_device_session_add(device->id, ps);
 
   return ps;
 }
@@ -173,7 +183,6 @@ static enum command_state
 send_status(void *arg, int *ptr)
 {
   struct pulse_session *ps = arg;
-  output_status_cb status_cb;
   enum output_device_state state;
 
   switch (ps->state)
@@ -196,10 +205,8 @@ send_status(void *arg, int *ptr)
 	state = OUTPUT_STATE_FAILED;
     }
 
-  status_cb = ps->status_cb;
-  ps->status_cb = NULL;
-  if (status_cb)
-    status_cb(ps->device, ps->output_session, state);
+  outputs_cb(ps->callback_id, ps->device_id, state);
+  ps->callback_id = -1;
 
   return COMMAND_PENDING; // Don't want the command module to clean up ps
 }
@@ -557,25 +564,33 @@ pulse_free(void)
 }
 
 static int
-stream_open(struct pulse_session *ps, pa_stream_notify_cb_t cb)
+stream_open(struct pulse_session *ps, struct media_quality *quality, pa_stream_notify_cb_t cb)
 {
   pa_stream_flags_t flags;
   pa_sample_spec ss;
   pa_cvolume cvol;
-  int offset;
+  int offset_ms;
   int ret;
 
   DPRINTF(E_DBG, L_LAUDIO, "Opening Pulseaudio stream to '%s'\n", ps->devname);
 
-  ss.format = PA_SAMPLE_S16LE;
-  ss.channels = 2;
-  ss.rate = 44100;
+  if (quality->bits_per_sample == 16)
+    ss.format = PA_SAMPLE_S16LE;
+  else if (quality->bits_per_sample == 24)
+    ss.format = PA_SAMPLE_S24LE;
+  else if (quality->bits_per_sample == 32)
+    ss.format = PA_SAMPLE_S32LE;
+  else
+    ss.format = 0;
 
-  offset = cfg_getint(cfg_getsec(cfg, "audio"), "offset");
-  if (abs(offset) > 44100)
+  ss.channels = quality->channels;
+  ss.rate = quality->sample_rate;
+
+  offset_ms = cfg_getint(cfg_getsec(cfg, "audio"), "offset_ms");
+  if (abs(offset_ms) > 1000)
     {
-      DPRINTF(E_LOG, L_LAUDIO, "The audio offset (%d) set in the configuration is out of bounds\n", offset);
-      offset = 44100 * (offset/abs(offset));
+      DPRINTF(E_LOG, L_LAUDIO, "The audio offset (%d) set in the configuration is out of bounds\n", offset_ms);
+      offset_ms = 1000 * (offset_ms/abs(offset_ms));
     }
 
   pa_threaded_mainloop_lock(pulse.mainloop);
@@ -587,7 +602,7 @@ stream_open(struct pulse_session *ps, pa_stream_notify_cb_t cb)
 
   flags = PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE;
 
-  ps->attr.tlength   = STOB(2 * ss.rate + PULSE_SAMPLES_PER_PACKET - offset, 16, 2); // 2 second latency
+  ps->attr.tlength   = STOB((OUTPUTS_BUFFER_DURATION * 1000 + offset_ms) * ss.rate / 1000, quality->bits_per_sample, quality->channels);
   ps->attr.maxlength = 2 * ps->attr.tlength;
   ps->attr.prebuf    = (uint32_t)-1;
   ps->attr.minreq    = (uint32_t)-1;
@@ -610,7 +625,8 @@ stream_open(struct pulse_session *ps, pa_stream_notify_cb_t cb)
  unlock_and_fail:
   ret = pa_context_errno(pulse.context);
 
-  DPRINTF(E_LOG, L_LAUDIO, "Pulseaudio could not start '%s': %s\n", ps->devname, pa_strerror(ret));
+  DPRINTF(E_LOG, L_LAUDIO, "Pulseaudio could not start '%s' using quality %d/%d/%d: %s\n",
+    ps->devname, quality->sample_rate, quality->bits_per_sample, quality->channels, pa_strerror(ret));
 
   pa_threaded_mainloop_unlock(pulse.mainloop);
 
@@ -620,11 +636,15 @@ stream_open(struct pulse_session *ps, pa_stream_notify_cb_t cb)
 static void
 stream_close(struct pulse_session *ps, pa_stream_notify_cb_t cb)
 {
+  if (!ps->stream)
+    return;
+
   pa_threaded_mainloop_lock(pulse.mainloop);
 
   pa_stream_set_underflow_callback(ps->stream, NULL, NULL);
   pa_stream_set_overflow_callback(ps->stream, NULL, NULL);
   pa_stream_set_state_callback(ps->stream, cb, ps);
+
   pa_stream_disconnect(ps->stream);
   pa_stream_unref(ps->stream);
 
@@ -634,39 +654,121 @@ stream_close(struct pulse_session *ps, pa_stream_notify_cb_t cb)
   pa_threaded_mainloop_unlock(pulse.mainloop);
 }
 
+static void
+playback_restart(struct pulse_session *ps, struct output_buffer *obuf)
+{
+  int ret;
+
+  stream_close(ps, NULL);
+
+  // Negotiate quality (sample rate) with device - first we try to use the source quality
+  ps->quality = obuf->data[0].quality;
+  ret = stream_open(ps, &ps->quality, start_cb);
+  if (ret < 0)
+    {
+      DPRINTF(E_INFO, L_LAUDIO, "Input quality (%d/%d/%d) not supported, falling back to default\n",
+        ps->quality.sample_rate, ps->quality.bits_per_sample, ps->quality.channels);
+
+      ps->quality = pulse_fallback_quality;
+      ret = stream_open(ps, &ps->quality, start_cb);
+      if (ret < 0)
+	{
+	  DPRINTF(E_LOG, L_LAUDIO, "Pulseaudio device failed setting fallback quality\n");
+	  ps->state = PA_STREAM_FAILED;
+	  pulse_session_shutdown(ps);
+	  return;
+	}
+    }
+}
+
+static void
+playback_write(struct pulse_session *ps, struct output_buffer *obuf)
+{
+  int i;
+  int ret;
+
+  // Find the quality we want
+  for (i = 0; obuf->data[i].buffer; i++)
+    {
+      if (quality_is_equal(&ps->quality, &obuf->data[i].quality))
+	break;
+    }
+
+  if (!obuf->data[i].buffer)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Output not delivering required data quality, aborting\n");
+      ps->state = PA_STREAM_FAILED;
+      pulse_session_shutdown(ps);
+      return;
+    }
+
+  pa_threaded_mainloop_lock(pulse.mainloop);
+
+  ret = pa_stream_write(ps->stream, obuf->data[i].buffer, obuf->data[i].bufsize, NULL, 0LL, PA_SEEK_RELATIVE);
+  if (ret < 0)
+    {
+      ret = pa_context_errno(pulse.context);
+      DPRINTF(E_LOG, L_LAUDIO, "Error writing Pulseaudio stream data to '%s': %s\n", ps->devname, pa_strerror(ret));
+      ps->state = PA_STREAM_FAILED;
+      pulse_session_shutdown(ps);
+      goto unlock;
+    }
+
+ unlock:
+  pa_threaded_mainloop_unlock(pulse.mainloop);
+}
+
+static void
+playback_resume(struct pulse_session *ps)
+{
+  pa_operation* o;
+
+  pa_threaded_mainloop_lock(pulse.mainloop);
+
+  o = pa_stream_cork(ps->stream, 0, NULL, NULL);
+  if (!o)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Pulseaudio could not resume '%s': %s\n", ps->devname, pa_strerror(pa_context_errno(pulse.context)));
+      goto unlock;
+    }
+
+  pa_operation_unref(o);
+
+ unlock:
+  pa_threaded_mainloop_unlock(pulse.mainloop);
+}
+
 
 /* ------------------ INTERFACE FUNCTIONS CALLED BY OUTPUTS.C --------------- */
 
 static int
-pulse_device_start(struct output_device *device, output_status_cb cb, uint64_t rtptime)
+pulse_device_start(struct output_device *device, int callback_id)
 {
   struct pulse_session *ps;
-  int ret;
 
   DPRINTF(E_DBG, L_LAUDIO, "Pulseaudio starting '%s'\n", device->name);
 
-  ps = pulse_session_make(device, cb);
+  ps = pulse_session_make(device, callback_id);
   if (!ps)
     return -1;
 
-  ret = stream_open(ps, start_cb);
-  if (ret < 0)
-    {
-      pulse_session_cleanup(ps);
-      return -1;
-    }
+  pulse_status(ps);
 
   return 0;
 }
 
-static void
-pulse_device_stop(struct output_session *session)
+static int
+pulse_device_stop(struct output_device *device, int callback_id)
 {
-  struct pulse_session *ps = session->session;
+  struct pulse_session *ps = device->session;
 
   DPRINTF(E_DBG, L_LAUDIO, "Pulseaudio stopping '%s'\n", ps->devname);
 
+  ps->callback_id = callback_id;
+
   stream_close(ps, close_cb);
+
+  return 0;
 }
 
 
@@ -704,18 +806,18 @@ pulse_device_flush(struct output_device *device, int callback_id)
 }
 
 static int
-pulse_device_probe(struct output_device *device, output_status_cb cb)
+pulse_device_probe(struct output_device *device, int callback_id)
 {
   struct pulse_session *ps;
   int ret;
 
   DPRINTF(E_DBG, L_LAUDIO, "Pulseaudio probing '%s'\n", device->name);
 
-  ps = pulse_session_make(device, cb);
+  ps = pulse_session_make(device, callback_id);
   if (!ps)
     return -1;
 
-  ret = stream_open(ps, probe_cb);
+  ret = stream_open(ps, &pulse_fallback_quality, probe_cb);
   if (ret < 0)
     {
       pulse_session_cleanup(ps);
@@ -731,18 +833,25 @@ pulse_device_free_extra(struct output_device *device)
   free(device->extra_device_info);
 }
 
-static int
-pulse_device_volume_set(struct output_device *device, output_status_cb cb)
+static void
+pulse_device_cb_set(struct output_device *device, int callback_id)
 {
-  struct pulse_session *ps;
+  struct pulse_session *ps = device->session;
+
+  ps->callback_id = callback_id;
+}
+
+static int
+pulse_device_volume_set(struct output_device *device, int callback_id)
+{
+  struct pulse_session *ps = device->session;
   uint32_t idx;
   pa_operation* o;
   pa_cvolume cvol;
 
-  if (!sessions || !device->session || !device->session->session)
+  if (!ps)
     return 0;
 
-  ps = device->session->session;
   idx = pa_stream_get_index(ps->stream);
 
   ps->volume = pulse_from_device_volume(device->volume);
@@ -752,7 +861,7 @@ pulse_device_volume_set(struct output_device *device, output_status_cb cb)
 
   pa_threaded_mainloop_lock(pulse.mainloop);
 
-  ps->status_cb = cb;
+  ps->callback_id = callback_id;
 
   o = pa_context_set_sink_input_volume(pulse.context, idx, &cvol, volume_cb, ps);
   if (!o)
@@ -769,63 +878,33 @@ pulse_device_volume_set(struct output_device *device, output_status_cb cb)
 }
 
 static void
-pulse_write(uint8_t *buf, uint64_t rtptime)
+pulse_write(struct output_buffer *obuf)
 {
   struct pulse_session *ps;
   struct pulse_session *next;
-  size_t length;
-  int ret;
 
   if (!sessions)
     return;
-
-  length = STOB(PULSE_SAMPLES_PER_PACKET, 16, 2);
-
-  pa_threaded_mainloop_lock(pulse.mainloop);
 
   for (ps = sessions; ps; ps = next)
     {
       next = ps->next;
 
-      if (ps->state != PA_STREAM_READY)
+      // We have not set up a stream OR the quality changed, so we need to set it up again
+      if (ps->state == PA_STREAM_UNCONNECTED || !quality_is_equal(&obuf->data[0].quality, &pulse_last_quality))
+	{
+	  playback_restart(ps, obuf);
+	  pulse_last_quality = obuf->data[0].quality;
+	  continue; // Async, so the device won't be ready for writing just now
+	}
+      else if (ps->state != PA_STREAM_READY)
 	continue;
 
-      ret = pa_stream_write(ps->stream, buf, length, NULL, 0LL, PA_SEEK_RELATIVE);
-      if (ret < 0)
-	{
-	  ret = pa_context_errno(pulse.context);
-	  DPRINTF(E_LOG, L_LAUDIO, "Error writing Pulseaudio stream data to '%s': %s\n", ps->devname, pa_strerror(ret));
+      if (ps->stream && pa_stream_is_corked(ps->stream))
+	playback_resume(ps);
 
-	  ps->state = PA_STREAM_FAILED;
-	  pulse_session_shutdown(ps);
-
-	  continue;
-	}
+      playback_write(ps, obuf);
     }
-
-  pa_threaded_mainloop_unlock(pulse.mainloop);
-}
-
-static void
-pulse_playback_start(uint64_t next_pkt, struct timespec *ts)
-{
-  struct pulse_session *ps;
-  pa_operation* o;
-
-  pa_threaded_mainloop_lock(pulse.mainloop);
-
-  for (ps = sessions; ps; ps = ps->next)
-    {
-      o = pa_stream_cork(ps->stream, 0, NULL, NULL);
-      if (!o)
-	{
-	  DPRINTF(E_LOG, L_LAUDIO, "Pulseaudio could not resume '%s': %s\n", ps->devname, pa_strerror(pa_context_errno(pulse.context)));
-	  continue;
-	}
-      pa_operation_unref(o);
-    }
-
-  pa_threaded_mainloop_unlock(pulse.mainloop);
 }
 
 static void
@@ -856,14 +935,6 @@ pulse_playback_stop(void)
     }
 
   pa_threaded_mainloop_unlock(pulse.mainloop);
-}
-
-static void
-pulse_set_status_cb(struct output_session *session, output_status_cb cb)
-{
-  struct pulse_session *ps = session->session;
-
-  ps->status_cb = cb;
 }
 
 static int
@@ -959,10 +1030,9 @@ struct output_definition output_pulse =
   .device_flush = pulse_device_flush,
   .device_probe = pulse_device_probe,
   .device_free_extra = pulse_device_free_extra,
+  .device_cb_set = pulse_device_cb_set,
   .device_volume_set = pulse_device_volume_set,
-  .playback_start = pulse_playback_start,
   .playback_stop = pulse_playback_stop,
   .write = pulse_write,
-  .status_cb = pulse_set_status_cb,
 };
 

--- a/src/outputs/pulse.c
+++ b/src/outputs/pulse.c
@@ -38,6 +38,8 @@
 #include "outputs.h"
 #include "commands.h"
 
+// From Airplay
+#define PULSE_SAMPLES_PER_PACKET 352
 #define PULSE_MAX_DEVICES 64
 #define PULSE_LOG_MAX 10
 
@@ -602,7 +604,7 @@ stream_open(struct pulse_session *ps, pa_stream_notify_cb_t cb)
 
   flags = PA_STREAM_INTERPOLATE_TIMING | PA_STREAM_AUTO_TIMING_UPDATE;
 
-  ps->attr.tlength   = STOB(2 * ss.rate + AIRTUNES_V2_PACKET_SAMPLES - offset); // 2 second latency
+  ps->attr.tlength   = STOB(2 * ss.rate + PULSE_SAMPLES_PER_PACKET - offset, 16, 2); // 2 second latency
   ps->attr.maxlength = 2 * ps->attr.tlength;
   ps->attr.prebuf    = (uint32_t)-1;
   ps->attr.minreq    = (uint32_t)-1;
@@ -760,7 +762,7 @@ pulse_write(uint8_t *buf, uint64_t rtptime)
   if (!sessions)
     return;
 
-  length = STOB(AIRTUNES_V2_PACKET_SAMPLES);
+  length = STOB(PULSE_SAMPLES_PER_PACKET, 16, 2);
 
   pa_threaded_mainloop_lock(pulse.mainloop);
 

--- a/src/outputs/pulse.c
+++ b/src/outputs/pulse.c
@@ -428,7 +428,6 @@ sinklist_cb(pa_context *ctx, const pa_sink_info *info, int eol, void *userdata)
   device->name = strdup(name);
   device->type = OUTPUT_TYPE_PULSE;
   device->type_name = outputs_name(device->type);
-  device->advertised = 1;
   device->extra_device_info = strdup(info->name);
 
   player_device_add(device);

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -4868,16 +4868,16 @@ raop_write(struct output_buffer *obuf)
 
   for (rms = raop_master_sessions; rms; rms = rms->next)
     {
-      for (i = 0; obuf->frames[i].buffer; i++)
+      for (i = 0; obuf->data[i].buffer; i++)
 	{
-	  if (!quality_is_equal(&obuf->frames[i].quality, &rms->rtp_session->quality))
+	  if (!quality_is_equal(&obuf->data[i].quality, &rms->rtp_session->quality))
 	    continue;
 
 	  // Sends sync packets to new sessions, and if it is sync time then also to old sessions
 	  packets_sync_send(rms, obuf->pts);
 
-	  evbuffer_add_buffer_reference(rms->evbuf, obuf->frames[i].evbuf);
-	  rms->evbuf_samples += obuf->frames[i].samples;
+	  evbuffer_add_buffer_reference(rms->evbuf, obuf->data[i].evbuf);
+	  rms->evbuf_samples += obuf->data[i].samples;
 
 	  // Send as many packets as we have data for (one packet requires rawbuf_size bytes)
 	  while (evbuffer_get_length(rms->evbuf) >= rms->rawbuf_size)

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -4712,8 +4712,6 @@ raop_device_cb(const char *name, const char *type, const char *domain, const cha
       free(et);
     }
 
-  rd->advertised = 1;
-
   switch (family)
     {
       case AF_INET:

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -2358,6 +2358,9 @@ raop_metadata_send_progress(struct raop_session *rs, struct evbuffer *evbuf, str
       return -1;
     }
 
+  DPRINTF(E_DBG, L_PLAYER, "Metadata send is start_time=%zu, start=%zu, display=%zu, current=%zu, end=%zu\n",
+    rs->start_rtptime, rmd->start, rmd->start - delay, rmd->start + offset, rmd->end);
+
   ret = raop_send_req_set_parameter(rs, evbuf, "text/parameters", NULL, raop_cb_metadata, "send_progress");
   if (ret < 0)
     DPRINTF(E_LOG, L_RAOP, "Could not send SET_PARAMETER progress request to '%s'\n", rs->devname);
@@ -3014,7 +3017,8 @@ packets_sync_send(struct raop_master_session *rms, struct timespec pts)
   // OUTPUTS_BUFFER_DURATION secs into the future. However, in the sync packet
   // we want to tell the device what it should be playing right now. So we give
   // it a cur_time where we subtract this duration.
-  cur_stamp.ts.tv_sec = pts.tv_sec - OUTPUTS_BUFFER_DURATION;
+// TODO update comment to match reality
+  cur_stamp.ts.tv_sec = pts.tv_sec;
   cur_stamp.ts.tv_nsec = pts.tv_nsec;
 
   // The cur_pos will be the rtptime of the coming packet, minus

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -213,7 +213,7 @@ struct raop_session
   int family;
 
   int volume;
-  uint64_t start_rtptime;
+  uint32_t start_rtptime;
 
   /* AirTunes v2 */
   unsigned short server_port;
@@ -244,8 +244,8 @@ struct raop_metadata
   int artwork_fmt;
 
   /* Progress data */
-  uint64_t start;
-  uint64_t end;
+  uint32_t start;
+  uint32_t end;
 
   struct raop_metadata *next;
 };
@@ -2327,7 +2327,7 @@ raop_cb_metadata(struct evrtsp_request *req, void *arg)
 }
 
 static int
-raop_metadata_send_progress(struct raop_session *rs, struct evbuffer *evbuf, struct raop_metadata *rmd, uint64_t offset, uint32_t delay)
+raop_metadata_send_progress(struct raop_session *rs, struct evbuffer *evbuf, struct raop_metadata *rmd, uint32_t offset, uint32_t delay)
 {
   uint32_t display;
   int ret;
@@ -2354,7 +2354,7 @@ raop_metadata_send_progress(struct raop_session *rs, struct evbuffer *evbuf, str
       return -1;
     }
 
-  DPRINTF(E_DBG, L_PLAYER, "Metadata send is start_time=%zu, start=%zu, display=%zu, current=%zu, end=%zu\n",
+  DPRINTF(E_DBG, L_PLAYER, "Metadata send is start_time=%" PRIu32 ", start=%" PRIu32 ", display=%" PRIu32 ", current=%" PRIu32 ", end=%" PRIu32 "\n",
     rs->start_rtptime, rmd->start, rmd->start - delay, rmd->start + offset, rmd->end);
 
   ret = raop_send_req_set_parameter(rs, evbuf, "text/parameters", NULL, raop_cb_metadata, "send_progress");
@@ -2432,7 +2432,7 @@ raop_metadata_send_metadata(struct raop_session *rs, struct evbuffer *evbuf, str
 }
 
 static int
-raop_metadata_send_internal(struct raop_session *rs, struct raop_metadata *rmd, uint64_t offset, uint32_t delay)
+raop_metadata_send_internal(struct raop_session *rs, struct raop_metadata *rmd, uint32_t offset, uint32_t delay)
 {
   char rtptime[32];
   struct evbuffer *evbuf;
@@ -2496,7 +2496,7 @@ static void
 raop_metadata_startup_send(struct raop_session *rs)
 {
   struct raop_metadata *rmd;
-  uint64_t offset;
+  uint32_t offset;
   int sent;
   int ret;
 
@@ -4876,7 +4876,8 @@ raop_write(struct output_buffer *obuf)
 	  // Sends sync packets to new sessions, and if it is sync time then also to old sessions
 	  packets_sync_send(rms, obuf->pts);
 
-	  evbuffer_add_buffer_reference(rms->evbuf, obuf->data[i].evbuf);
+	  // TODO avoid this copy
+	  evbuffer_add(rms->evbuf, obuf->data[i].buffer, obuf->data[i].bufsize);
 	  rms->evbuf_samples += obuf->data[i].samples;
 
 	  // Send as many packets as we have data for (one packet requires rawbuf_size bytes)

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -1805,6 +1805,9 @@ master_session_make(struct media_quality *quality, bool encrypt)
 static void
 master_session_free(struct raop_master_session *rms)
 {
+  if (!rms)
+    return;
+
   outputs_quality_unsubscribe(&rms->rtp_session->quality);
   rtp_session_free(rms->rtp_session);
   evbuffer_free(rms->evbuf);

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -1939,7 +1939,7 @@ session_teardown_cb(struct evrtsp_request *req, void *arg)
   if (!req || req->response_code != RTSP_OK)
     DPRINTF(E_LOG, L_RAOP, "TEARDOWN request failed in session shutdown: %d %s\n", req->response_code, req->response_code_line);
 
-  rs->state = OUTPUT_STATE_STOPPED;
+  rs->state = RAOP_STATE_STOPPED;
 
   raop_status(rs);
 
@@ -4817,7 +4817,6 @@ static int
 raop_device_flush(struct output_device *device, int callback_id)
 {
   struct raop_session *rs = device->session;
-  struct timeval tv;
   int ret;
 
   if (rs->state != RAOP_STATE_STREAMING)
@@ -4828,10 +4827,6 @@ raop_device_flush(struct output_device *device, int callback_id)
     return -1;
 
   rs->callback_id = callback_id;
-
-  evutil_timerclear(&tv);
-  tv.tv_sec = 10;
-  evtimer_add(rs->deferredev, &tv);
 
   return 0;
 }
@@ -4901,8 +4896,6 @@ raop_write(struct output_buffer *obuf)
     {
       if (rs->state != RAOP_STATE_CONNECTED)
 	continue;
-
-      event_del(rs->deferredev); // Kills flush timer in case playback was stopped but then restarted again
 
       rs->state = RAOP_STATE_STREAMING;
       // Make a cb?

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -2991,6 +2991,7 @@ packets_sync_send(struct raop_master_session *rms, struct timespec pts)
   struct rtp_packet *sync_pkt;
   struct raop_session *rs;
   struct rtcp_timestamp cur_stamp;
+  struct timespec ts;
   bool is_sync_time;
 
   // Check if it is time send a sync packet to sessions that are already running
@@ -3005,6 +3006,8 @@ packets_sync_send(struct raop_master_session *rms, struct timespec pts)
 // TODO update comment to match reality
   cur_stamp.ts.tv_sec = pts.tv_sec;
   cur_stamp.ts.tv_nsec = pts.tv_nsec;
+
+  clock_gettime(CLOCK_MONOTONIC, &ts);
 
   // The cur_pos will be the rtptime of the coming packet, minus
   // OUTPUTS_BUFFER_DURATION in samples (output_buffer_samples). Because we
@@ -3023,7 +3026,8 @@ packets_sync_send(struct raop_master_session *rms, struct timespec pts)
 	  sync_pkt = rtp_sync_packet_next(rms->rtp_session, &cur_stamp, 0x90);
 	  control_packet_send(rs, sync_pkt);
 
-	  DPRINTF(E_DBG, L_PLAYER, "Start sync packet sent to '%s': cur_pos=%" PRIu32 ", rtptime=%" PRIu32 "\n", rs->devname, cur_stamp.pos, rms->rtp_session->pos);
+	  DPRINTF(E_DBG, L_PLAYER, "Start sync packet sent to '%s': cur_pos=%" PRIu32 ", cur_ts=%lu:%lu, now=%lu:%lu, rtptime=%" PRIu32 ",\n",
+	    rs->devname, cur_stamp.pos, cur_stamp.ts.tv_sec, cur_stamp.ts.tv_nsec, ts.tv_sec, ts.tv_nsec, rms->rtp_session->pos);
 	}
       else if (is_sync_time && rs->state == RAOP_STATE_STREAMING)
 	{

--- a/src/outputs/rtp_common.c
+++ b/src/outputs/rtp_common.c
@@ -156,7 +156,17 @@ rtp_packet_next(struct rtp_session *session, size_t payload_len, int samples, ch
   pkt->data_len    = RTP_HEADER_LEN + payload_len;
   pkt->seqnum      = session->seqnum;
 
-  // RTP Header
+
+  // The RTP header is made of these 12 bytes (RFC 3550):
+  //    0                   1                   2                   3
+  //    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+  //   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  //   |V=2|P|X|  CC   |M|     PT      |       sequence number         |
+  //   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  //   |                           timestamp                           |
+  //   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  //   |           synchronization source (SSRC) identifier            |
+  //   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   pkt->header[0] = 0x80; // Version = 2, P, X and CC are 0
   pkt->header[1] = type; // RTP payload type
 

--- a/src/outputs/rtp_common.c
+++ b/src/outputs/rtp_common.c
@@ -252,14 +252,14 @@ rtp_sync_packet_next(struct rtp_session *session, struct rtcp_timestamp *cur_sta
   rtptime = htobe32(session->pos);
   memcpy(session->sync_packet_next.data + 16, &rtptime, 4);
 
-  DPRINTF(E_DBG, L_PLAYER, "SYNC PACKET cur_ts:%ld.%ld, next_pkt:%u, cur_pos:%u, type:0x%x, sync_counter:%d\n",
+/*  DPRINTF(E_DBG, L_PLAYER, "SYNC PACKET cur_ts:%ld.%ld, next_pkt:%u, cur_pos:%u, type:0x%x, sync_counter:%d\n",
     cur_stamp->ts.tv_sec, cur_stamp->ts.tv_nsec,
     session->pos,
     cur_stamp->pos,
     session->sync_packet_next.data[0],
     session->sync_counter
     );
-
+*/
   return &session->sync_packet_next;
 }
 

--- a/src/outputs/rtp_common.c
+++ b/src/outputs/rtp_common.c
@@ -45,9 +45,7 @@
 #include <gcrypt.h>
 
 #include "logger.h"
-#include "conffile.h"
 #include "misc.h"
-#include "player.h"
 #include "rtp_common.h"
 
 #define RTP_HEADER_LEN        12
@@ -83,7 +81,7 @@ ntp_to_timespec(struct ntp_timestamp *ns, struct timespec *ts)
 }
 
 struct rtp_session *
-rtp_session_new(struct media_quality *quality, int pktbuf_size, int sync_each_nsamples, int buffer_duration)
+rtp_session_new(struct media_quality *quality, int pktbuf_size, int sync_each_nsamples)
 {
   struct rtp_session *session;
 
@@ -104,10 +102,6 @@ rtp_session_new(struct media_quality *quality, int pktbuf_size, int sync_each_ns
   else if (sync_each_nsamples == 0)
     session->sync_each_nsamples = quality->sample_rate;
 
-  session->buffer_duration = buffer_duration;
-
-  session->is_virgin = true;
-
   return session;
 }
 
@@ -125,10 +119,8 @@ rtp_session_free(struct rtp_session *session)
 }
 
 void
-rtp_session_restart(struct rtp_session *session, struct timespec *ts)
+rtp_session_flush(struct rtp_session *session)
 {
-  session->is_virgin = true;
-  session->start_time = *ts;
   session->pktbuf_len = 0;
   session->sync_counter = 0;
 }
@@ -136,7 +128,7 @@ rtp_session_restart(struct rtp_session *session, struct timespec *ts)
 // We don't want the caller to malloc payload for every packet, so instead we
 // will get him a packet from the ring buffer, thus in most cases reusing memory
 struct rtp_packet *
-rtp_packet_next(struct rtp_session *session, size_t payload_len, int samples)
+rtp_packet_next(struct rtp_session *session, size_t payload_len, int samples, char type)
 {
   struct rtp_packet *pkt;
   uint16_t seq;
@@ -166,7 +158,7 @@ rtp_packet_next(struct rtp_session *session, size_t payload_len, int samples)
 
   // RTP Header
   pkt->header[0] = 0x80; // Version = 2, P, X and CC are 0
-  pkt->header[1] = (session->is_virgin) ? 0xe0 : 0x60; // TODO allow other payloads
+  pkt->header[1] = type; // RTP payload type
 
   seq = htobe16(session->seqnum);
   memcpy(pkt->header + 2, &seq, 2);
@@ -177,13 +169,6 @@ rtp_packet_next(struct rtp_session *session, size_t payload_len, int samples)
   ssrc_id = htobe32(session->ssrc_id);
   memcpy(pkt->header + 8, &ssrc_id, 4);
 
-/*  DPRINTF(E_DBG, L_PLAYER, "RTP PACKET seqnum %u, rtptime %u, payload 0x%x, pktbuf_s %zu\n",
-    session->seqnum,
-    session->pos,
-    pkt->header[1],
-    session->pktbuf_len
-    );
-*/
   return pkt;
 }
 
@@ -198,8 +183,7 @@ rtp_packet_commit(struct rtp_session *session, struct rtp_packet *pkt)
   session->pktbuf_next = (session->pktbuf_next + 1) % session->pktbuf_size;
   session->seqnum++;
   session->pos += pkt->samples;
-
-  session->is_virgin = false;
+  session->sync_counter += pkt->samples;
 }
 
 struct rtp_packet *
@@ -226,33 +210,23 @@ rtp_packet_get(struct rtp_session *session, uint16_t seqnum)
 }
 
 bool
-rtp_sync_check(struct rtp_session *session, struct rtp_packet *pkt)
+rtp_sync_is_time(struct rtp_session *session)
 {
-  if (!session->sync_each_nsamples)
-    {
-      return false;
-    }
-
-  if (session->sync_counter > session->sync_each_nsamples)
+  if (session->sync_each_nsamples && session->sync_counter > session->sync_each_nsamples)
     {
       session->sync_counter = 0;
       return true;
     }
 
-  session->sync_counter += pkt->samples; // TODO Should this move to a sync_commit function?
   return false;
 }
 
 struct rtp_packet *
-rtp_sync_packet_next(struct rtp_session *session)
+rtp_sync_packet_next(struct rtp_session *session, struct rtcp_timestamp *cur_stamp, char type)
 {
-  struct timespec ts;
-  struct ntp_timestamp cur_stamp;
-  uint64_t elapsed_usec;
-  uint64_t elapsed_samples;
+  struct ntp_timestamp cur_ts;
   uint32_t rtptime;
   uint32_t cur_pos;
-  int ret;
 
   if (!session->sync_packet_next.data)
     {
@@ -260,54 +234,32 @@ rtp_sync_packet_next(struct rtp_session *session)
       session->sync_packet_next.data_len = RTCP_SYNC_PACKET_LEN;
     }
 
-  memset(session->sync_packet_next.data, 0, session->sync_packet_next.data_len); // TODO remove this and just zero byte 3 instead?
-
-  session->sync_packet_next.data[0] = (session->is_virgin) ? 0x90 : 0x80;
+  session->sync_packet_next.data[0] = type;
   session->sync_packet_next.data[1] = 0xd4;
+  session->sync_packet_next.data[2] = 0x00;
   session->sync_packet_next.data[3] = 0x07;
 
-  if (session->is_virgin)
-    {
-      session->sync_last_check.pos = session->pos - session->buffer_duration * session->quality.sample_rate;
-      session->sync_last_check.ts = session->start_time;
-      timespec_to_ntp(&session->start_time, &cur_stamp);
-    }
-  else
-    {
-      ret = player_get_time(&ts);
-      if (ret < 0)
-	return NULL;
+  timespec_to_ntp(&cur_stamp->ts, &cur_ts);
 
-      elapsed_usec = (ts.tv_sec - session->sync_last_check.ts.tv_sec) * 1000000 + (ts.tv_nsec - session->sync_last_check.ts.tv_nsec) / 1000;
-
-      // How many samples should have been played since last check
-      elapsed_samples = (elapsed_usec * session->quality.sample_rate) / 1000000;
-
-      session->sync_last_check.pos += elapsed_samples; // TODO should updating sync_last_check move to a commit function?
-      session->sync_last_check.ts = ts;
-      timespec_to_ntp(&ts, &cur_stamp);
-    }
-
-  cur_pos = htobe32(session->sync_last_check.pos);
+  cur_pos = htobe32(cur_stamp->pos);
   memcpy(session->sync_packet_next.data + 4, &cur_pos, 4);
 
-  cur_stamp.sec = htobe32(cur_stamp.sec);
-  cur_stamp.frac = htobe32(cur_stamp.frac);
-  memcpy(session->sync_packet_next.data + 8, &cur_stamp.sec, 4);
-  memcpy(session->sync_packet_next.data + 12, &cur_stamp.frac, 4);
+  cur_ts.sec = htobe32(cur_ts.sec);
+  cur_ts.frac = htobe32(cur_ts.frac);
+  memcpy(session->sync_packet_next.data + 8, &cur_ts.sec, 4);
+  memcpy(session->sync_packet_next.data + 12, &cur_ts.frac, 4);
 
   rtptime = htobe32(session->pos);
   memcpy(session->sync_packet_next.data + 16, &rtptime, 4);
 
-/*  DPRINTF(E_DBG, L_PLAYER, "SYNC PACKET ts:%ld.%ld, next_pkt:%u, cur_pos:%u, payload:0x%x, sync_counter:%d, init:%d\n",
-    ts.tv_sec, ts.tv_nsec,
+  DPRINTF(E_DBG, L_PLAYER, "SYNC PACKET cur_ts:%ld.%ld, next_pkt:%u, cur_pos:%u, type:0x%x, sync_counter:%d\n",
+    cur_stamp->ts.tv_sec, cur_stamp->ts.tv_nsec,
     session->pos,
-    session->sync_last_check.pos,
+    cur_stamp->pos,
     session->sync_packet_next.data[0],
-    session->sync_counter,
-    session->is_virgin
+    session->sync_counter
     );
-*/
+
   return &session->sync_packet_next;
 }
 

--- a/src/outputs/rtp_common.c
+++ b/src/outputs/rtp_common.c
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2019- Espen Jürgensen <espenjurgensen@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <limits.h>
+#include <sys/param.h>
+
+#ifdef HAVE_ENDIAN_H
+# include <endian.h>
+#elif defined(HAVE_SYS_ENDIAN_H)
+# include <sys/endian.h>
+#elif defined(HAVE_LIBKERN_OSBYTEORDER_H)
+#include <libkern/OSByteOrder.h>
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#endif
+
+#include <gcrypt.h>
+
+#include "logger.h"
+#include "conffile.h"
+#include "misc.h"
+#include "player.h"
+#include "rtp_common.h"
+
+#define RTP_HEADER_LEN        12
+#define RTCP_SYNC_PACKET_LEN  20 
+
+// NTP timestamp definitions
+#define FRAC             4294967296. // 2^32 as a double
+#define NTP_EPOCH_DELTA  0x83aa7e80  // 2208988800 - that's 1970 - 1900 in seconds
+
+struct ntp_timestamp
+{
+  uint32_t sec;
+  uint32_t frac;
+};
+
+
+static inline void
+timespec_to_ntp(struct timespec *ts, struct ntp_timestamp *ns)
+{
+  /* Seconds since NTP Epoch (1900-01-01) */
+  ns->sec = ts->tv_sec + NTP_EPOCH_DELTA;
+
+  ns->frac = (uint32_t)((double)ts->tv_nsec * 1e-9 * FRAC);
+}
+
+static inline void
+ntp_to_timespec(struct ntp_timestamp *ns, struct timespec *ts)
+{
+  /* Seconds since Unix Epoch (1970-01-01) */
+  ts->tv_sec = ns->sec - NTP_EPOCH_DELTA;
+
+  ts->tv_nsec = (long)((double)ns->frac / (1e-9 * FRAC));
+}
+
+struct rtp_session *
+rtp_session_new(struct media_quality *quality, int pktbuf_size, int sync_each_nsamples, int buffer_duration)
+{
+  struct rtp_session *session;
+
+  CHECK_NULL(L_PLAYER, session = calloc(1, sizeof(struct rtp_session)));
+
+  // Random SSRC ID, RTP time start and sequence start
+  gcry_randomize(&session->ssrc_id, sizeof(session->ssrc_id), GCRY_STRONG_RANDOM);
+  gcry_randomize(&session->pos, sizeof(session->pos), GCRY_STRONG_RANDOM);
+  gcry_randomize(&session->seqnum, sizeof(session->seqnum), GCRY_STRONG_RANDOM);
+
+  session->quality = *quality;
+
+  session->pktbuf_size = pktbuf_size;
+  CHECK_NULL(L_PLAYER, session->pktbuf = calloc(session->pktbuf_size, sizeof(struct rtp_packet)));
+
+  if (sync_each_nsamples > 0)
+    session->sync_each_nsamples = sync_each_nsamples;
+  else if (sync_each_nsamples == 0)
+    session->sync_each_nsamples = quality->sample_rate;
+
+  session->buffer_duration = buffer_duration;
+
+  session->is_virgin = true;
+
+  return session;
+}
+
+void
+rtp_session_free(struct rtp_session *session)
+{
+  int i;
+
+  for (i = 0; i < session->pktbuf_size; i++)
+    free(session->pktbuf[i].data);
+
+  free(session->sync_packet_next.data);
+
+  free(session);
+}
+
+void
+rtp_session_restart(struct rtp_session *session, struct timespec *ts)
+{
+  session->is_virgin = true;
+  session->start_time = *ts;
+  session->pktbuf_len = 0;
+  session->sync_counter = 0;
+}
+
+// We don't want the caller to malloc payload for every packet, so instead we
+// will get him a packet from the ring buffer, thus in most cases reusing memory
+struct rtp_packet *
+rtp_packet_next(struct rtp_session *session, size_t payload_len, int samples)
+{
+  struct rtp_packet *pkt;
+  uint16_t seq;
+  uint32_t rtptime;
+  uint32_t ssrc_id;
+
+  pkt = &session->pktbuf[session->pktbuf_next];
+
+  // When first filling up the buffer we malloc, but otherwise the existing data
+  // allocation should in most cases suffice. If not, we realloc.
+  if (!pkt->data || payload_len > pkt->payload_size)
+    {
+      pkt->data_size = RTP_HEADER_LEN + payload_len;
+      if (!pkt->data)
+	CHECK_NULL(L_PLAYER, pkt->data = malloc(pkt->data_size));
+      else
+	CHECK_NULL(L_PLAYER, pkt->data = realloc(pkt->data, pkt->data_size));
+      pkt->header  = pkt->data;
+      pkt->payload = pkt->data + RTP_HEADER_LEN;
+      pkt->payload_size = payload_len;
+    }
+
+  pkt->samples     = samples;
+  pkt->payload_len = payload_len;
+  pkt->data_len    = RTP_HEADER_LEN + payload_len;
+  pkt->seqnum      = session->seqnum;
+
+  // RTP Header
+  pkt->header[0] = 0x80; // Version = 2, P, X and CC are 0
+  pkt->header[1] = (session->is_virgin) ? 0xe0 : 0x60; // TODO allow other payloads
+
+  seq = htobe16(session->seqnum);
+  memcpy(pkt->header + 2, &seq, 2);
+
+  rtptime = htobe32(session->pos);
+  memcpy(pkt->header + 4, &rtptime, 4);
+
+  ssrc_id = htobe32(session->ssrc_id);
+  memcpy(pkt->header + 8, &ssrc_id, 4);
+
+/*  DPRINTF(E_DBG, L_PLAYER, "RTP PACKET seqnum %u, rtptime %u, payload 0x%x, pktbuf_s %zu\n",
+    session->seqnum,
+    session->pos,
+    pkt->header[1],
+    session->pktbuf_len
+    );
+*/
+  return pkt;
+}
+
+void
+rtp_packet_commit(struct rtp_session *session, struct rtp_packet *pkt)
+{
+  // Increase size of retransmit buffer since we just wrote a packet
+  if (session->pktbuf_len < session->pktbuf_size)
+    session->pktbuf_len++;
+
+  // Advance counters to prepare for next packet
+  session->pktbuf_next = (session->pktbuf_next + 1) % session->pktbuf_size;
+  session->seqnum++;
+  session->pos += pkt->samples;
+
+  session->is_virgin = false;
+}
+
+struct rtp_packet *
+rtp_packet_get(struct rtp_session *session, uint16_t seqnum)
+{
+  uint16_t first;
+  uint16_t last;
+  size_t idx;
+
+  if (!session->seqnum || !session->pktbuf_len)
+    return NULL;
+
+  last = session->seqnum - 1;
+  first = session->seqnum - session->pktbuf_len;
+  if (seqnum < first || seqnum > last)
+    {
+      DPRINTF(E_DBG, L_PLAYER, "Seqnum %" PRIu16 " not in buffer (have seqnum %" PRIu16 " to %" PRIu16 ")\n", seqnum, first, last);
+      return NULL;
+    }
+
+  idx = (session->pktbuf_next - (session->seqnum - seqnum)) % session->pktbuf_size;
+
+  return &session->pktbuf[idx];
+}
+
+bool
+rtp_sync_check(struct rtp_session *session, struct rtp_packet *pkt)
+{
+  if (!session->sync_each_nsamples)
+    {
+      return false;
+    }
+
+  if (session->sync_counter > session->sync_each_nsamples)
+    {
+      session->sync_counter = 0;
+      return true;
+    }
+
+  session->sync_counter += pkt->samples; // TODO Should this move to a sync_commit function?
+  return false;
+}
+
+struct rtp_packet *
+rtp_sync_packet_next(struct rtp_session *session)
+{
+  struct timespec ts;
+  struct ntp_timestamp cur_stamp;
+  uint64_t elapsed_usec;
+  uint64_t elapsed_samples;
+  uint32_t rtptime;
+  uint32_t cur_pos;
+  int ret;
+
+  if (!session->sync_packet_next.data)
+    {
+      CHECK_NULL(L_PLAYER, session->sync_packet_next.data = malloc(RTCP_SYNC_PACKET_LEN));
+      session->sync_packet_next.data_len = RTCP_SYNC_PACKET_LEN;
+    }
+
+  memset(session->sync_packet_next.data, 0, session->sync_packet_next.data_len); // TODO remove this and just zero byte 3 instead?
+
+  session->sync_packet_next.data[0] = (session->is_virgin) ? 0x90 : 0x80;
+  session->sync_packet_next.data[1] = 0xd4;
+  session->sync_packet_next.data[3] = 0x07;
+
+  if (session->is_virgin)
+    {
+      session->sync_last_check.pos = session->pos - session->buffer_duration * session->quality.sample_rate;
+      session->sync_last_check.ts = session->start_time;
+      timespec_to_ntp(&session->start_time, &cur_stamp);
+    }
+  else
+    {
+      ret = player_get_time(&ts);
+      if (ret < 0)
+	return NULL;
+
+      elapsed_usec = (ts.tv_sec - session->sync_last_check.ts.tv_sec) * 1000000 + (ts.tv_nsec - session->sync_last_check.ts.tv_nsec) / 1000;
+
+      // How many samples should have been played since last check
+      elapsed_samples = (elapsed_usec * session->quality.sample_rate) / 1000000;
+
+      session->sync_last_check.pos += elapsed_samples; // TODO should updating sync_last_check move to a commit function?
+      session->sync_last_check.ts = ts;
+      timespec_to_ntp(&ts, &cur_stamp);
+    }
+
+  cur_pos = htobe32(session->sync_last_check.pos);
+  memcpy(session->sync_packet_next.data + 4, &cur_pos, 4);
+
+  cur_stamp.sec = htobe32(cur_stamp.sec);
+  cur_stamp.frac = htobe32(cur_stamp.frac);
+  memcpy(session->sync_packet_next.data + 8, &cur_stamp.sec, 4);
+  memcpy(session->sync_packet_next.data + 12, &cur_stamp.frac, 4);
+
+  rtptime = htobe32(session->pos);
+  memcpy(session->sync_packet_next.data + 16, &rtptime, 4);
+
+/*  DPRINTF(E_DBG, L_PLAYER, "SYNC PACKET ts:%ld.%ld, next_pkt:%u, cur_pos:%u, payload:0x%x, sync_counter:%d, init:%d\n",
+    ts.tv_sec, ts.tv_nsec,
+    session->pos,
+    session->sync_last_check.pos,
+    session->sync_packet_next.data[0],
+    session->sync_counter,
+    session->is_virgin
+    );
+*/
+  return &session->sync_packet_next;
+}
+

--- a/src/outputs/rtp_common.h
+++ b/src/outputs/rtp_common.h
@@ -1,0 +1,93 @@
+#ifndef __RTP_COMMON_H__
+#define __RTP_COMMON_H__
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+struct rtcp_timestamp
+{
+  uint32_t pos;
+  struct timespec ts;
+};
+
+struct rtp_packet
+{
+  uint16_t seqnum;     // Sequence number
+  int samples;         // Number of samples in the packet
+
+  uint8_t *header;     // Pointer to the RTP header
+
+  uint8_t *payload;    // Pointer to the RTP payload
+  size_t payload_size; // Size of allocated memory for RTP payload
+  size_t payload_len;  // Length of payload (must of course not exceed size)
+
+  uint8_t *data;       // Pointer to the complete packet data
+  size_t data_size;    // Size of packet data
+  size_t data_len;     // Length of actual packet data
+};
+
+// An RTP session is characterised by all the receivers belonging to the session
+// getting the same RTP and RTCP packets. So if you have clients that require
+// different sample rates or where only some can accept encrypted payloads then
+// you need multiple sessions.
+struct rtp_session
+{
+  uint32_t ssrc_id;
+  uint32_t pos;
+  uint16_t seqnum;
+
+  // True if we haven't started streaming yet
+  bool is_virgin;
+
+  struct media_quality quality;
+
+  // Packet buffer (ring buffer), used for retransmission
+  struct rtp_packet *pktbuf;
+  size_t pktbuf_next;
+  size_t pktbuf_size;
+  size_t pktbuf_len;
+
+  // Time of playback start (given by player)
+  struct timespec start_time;
+
+  // Number of seconds that we tell the client to buffer (this will mean that
+  // the position that we send in the sync packages are offset by this amount
+  // compared to the rtptimes of the corresponding RTP packages we are sending)
+  int buffer_duration;
+
+  // Number of samples to elapse before sync'ing. If 0 we set it to the s/r, so
+  // we sync once a second. If negative we won't sync.
+  int sync_each_nsamples;
+  int sync_counter;
+  struct rtp_packet sync_packet_next;
+
+  struct rtcp_timestamp sync_last_check;
+};
+
+
+struct rtp_session *
+rtp_session_new(struct media_quality *quality, int pktbuf_size, int sync_each_nsamples, int buffer_duration);
+
+void
+rtp_session_free(struct rtp_session *session);
+
+void
+rtp_session_restart(struct rtp_session *session, struct timespec *ts);
+
+struct rtp_packet *
+rtp_packet_next(struct rtp_session *session, size_t payload_len, int samples);
+
+void
+rtp_packet_commit(struct rtp_session *session, struct rtp_packet *pkt);
+
+struct rtp_packet *
+rtp_packet_get(struct rtp_session *session, uint16_t seqnum);
+
+bool
+rtp_sync_check(struct rtp_session *session, struct rtp_packet *pkt);
+
+struct rtp_packet *
+rtp_sync_packet_next(struct rtp_session *session);
+
+#endif  /* !__RTP_COMMON_H__ */

--- a/src/outputs/rtp_common.h
+++ b/src/outputs/rtp_common.h
@@ -37,9 +37,6 @@ struct rtp_session
   uint32_t pos;
   uint16_t seqnum;
 
-  // True if we haven't started streaming yet
-  bool is_virgin;
-
   struct media_quality quality;
 
   // Packet buffer (ring buffer), used for retransmission
@@ -48,35 +45,25 @@ struct rtp_session
   size_t pktbuf_size;
   size_t pktbuf_len;
 
-  // Time of playback start (given by player)
-  struct timespec start_time;
-
-  // Number of seconds that we tell the client to buffer (this will mean that
-  // the position that we send in the sync packages are offset by this amount
-  // compared to the rtptimes of the corresponding RTP packages we are sending)
-  int buffer_duration;
-
   // Number of samples to elapse before sync'ing. If 0 we set it to the s/r, so
   // we sync once a second. If negative we won't sync.
   int sync_each_nsamples;
   int sync_counter;
   struct rtp_packet sync_packet_next;
-
-  struct rtcp_timestamp sync_last_check;
 };
 
 
 struct rtp_session *
-rtp_session_new(struct media_quality *quality, int pktbuf_size, int sync_each_nsamples, int buffer_duration);
+rtp_session_new(struct media_quality *quality, int pktbuf_size, int sync_each_nsamples);
 
 void
 rtp_session_free(struct rtp_session *session);
 
 void
-rtp_session_restart(struct rtp_session *session, struct timespec *ts);
+rtp_session_flush(struct rtp_session *session);
 
 struct rtp_packet *
-rtp_packet_next(struct rtp_session *session, size_t payload_len, int samples);
+rtp_packet_next(struct rtp_session *session, size_t payload_len, int samples, char type);
 
 void
 rtp_packet_commit(struct rtp_session *session, struct rtp_packet *pkt);
@@ -85,9 +72,9 @@ struct rtp_packet *
 rtp_packet_get(struct rtp_session *session, uint16_t seqnum);
 
 bool
-rtp_sync_check(struct rtp_session *session, struct rtp_packet *pkt);
+rtp_sync_is_time(struct rtp_session *session);
 
 struct rtp_packet *
-rtp_sync_packet_next(struct rtp_session *session);
+rtp_sync_packet_next(struct rtp_session *session, struct rtcp_timestamp *cur_stamp, char type);
 
 #endif  /* !__RTP_COMMON_H__ */

--- a/src/outputs/streaming.c
+++ b/src/outputs/streaming.c
@@ -24,7 +24,6 @@
 #include "outputs.h"
 #include "httpd_streaming.h"
 
-
 struct output_definition output_streaming =
 {
   .name = "mp3 streaming",

--- a/src/player.c
+++ b/src/player.c
@@ -794,8 +794,8 @@ session_update_read_next(void)
 static void
 session_update_read_eof(void)
 {
-  pb_session.reading_now->read_end = pb_session.pos - 1;
-  pb_session.reading_now->play_end = pb_session.pos - 1 + pb_session.reading_now->output_buffer_samples;
+  pb_session.reading_now->read_end = pb_session.pos;
+  pb_session.reading_now->play_end = pb_session.pos + pb_session.reading_now->output_buffer_samples;
 
   source_free(&pb_session.reading_prev);
   pb_session.reading_prev = pb_session.reading_now;
@@ -1196,9 +1196,10 @@ device_add(void *arg, int *retval)
   // Never turn on new devices during playback
   new_deselect = (player_state == PLAY_PLAYING);
 
-  *retval = outputs_device_add(device, new_deselect, default_volume);
+  device = outputs_device_add(device, new_deselect, default_volume);
+  *retval = device ? 0 : -1;
 
-  if (device->selected)
+  if (device && device->selected)
     speaker_select_output(device);
 
   return COMMAND_END;

--- a/src/player.c
+++ b/src/player.c
@@ -712,10 +712,14 @@ source_next(void)
 static int
 source_start(void)
 {
+  short flags;
+
   if (!pb_session.reading_next)
     return 0;
 
   DPRINTF(E_DBG, L_PLAYER, "(Re)opening track: '%s' (id=%d, seek=%d)\n", pb_session.reading_next->path, pb_session.reading_next->item_id, pb_session.reading_next->seek_ms);
+
+  input_flush(&flags);
 
   return input_seek(pb_session.reading_next->item_id, (int)pb_session.reading_next->seek_ms);
 }
@@ -829,7 +833,7 @@ session_update_read_eof(void)
     return;
 
   // We inherit this because the input will only notify on quality changes, not
-  // if it the same as the previous track
+  // if it is the same as the previous track
   pb_session.reading_now->quality = pb_session.reading_prev->quality;
   pb_session.reading_now->output_buffer_samples = pb_session.reading_prev->output_buffer_samples;
 
@@ -1110,6 +1114,7 @@ source_read(int *nbytes, int *nsamples, struct media_quality *quality, uint8_t *
   if (*nbytes == 0 || quality->channels == 0)
     {
       event_read(0); // This will set start_ts even if source isn't open yet
+      event_read_quality(); // Will poll input for quality since we don't have it
       return 0;
     }
 

--- a/src/player.c
+++ b/src/player.c
@@ -2218,11 +2218,8 @@ speaker_enumerate(void *arg, int *retval)
 
   for (device = output_device_list; device; device = device->next)
     {
-      if (device->selected)
-	{
-	  device_to_speaker_info(&spk, device);
-	  spk_enum->cb(&spk, spk_enum->arg);
-	}
+      device_to_speaker_info(&spk, device);
+      spk_enum->cb(&spk, spk_enum->arg);
     }
 
   *retval = 0;

--- a/src/player.c
+++ b/src/player.c
@@ -1205,10 +1205,12 @@ playback_cb(int fd, short what, void *arg)
 
       if (nbytes < pb_session.bufsize)
 	{
-	  DPRINTF(E_DBG, L_PLAYER, "Incomplete read, wanted %zu, got %d, deficit %zu\n", pb_session.bufsize, nbytes, pb_session.read_deficit);
 	  // How much the number of samples we got corresponds to in time (nanoseconds)
 	  ts.tv_sec = 0;
-	  ts.tv_nsec = 1000000000L * nsamples / quality.sample_rate;
+	  ts.tv_nsec = 1000000000UL * (uint64_t)nsamples / quality.sample_rate;
+
+	  DPRINTF(E_DBG, L_PLAYER, "Incomplete read, wanted %zu, got %d (samples=%d/time=%lu), deficit %zu\n", pb_session.bufsize, nbytes, nsamples, ts.tv_nsec, pb_session.read_deficit);
+
 	  pb_session.pts = timespec_add(pb_session.pts, ts);
 	}
       else
@@ -1818,6 +1820,7 @@ playback_stop(void *arg, int *retval)
   // stop just yet; this saves time when restarting, which is nicer for the user
   *retval = outputs_flush(device_command_cb);
 
+  // Stops the input
   playback_session_stop();
 
   status_update(PLAY_STOPPED);

--- a/src/player.c
+++ b/src/player.c
@@ -2235,7 +2235,7 @@ speaker_get_byid(void *arg, int *retval)
   struct speaker_get_param *spk_param = arg;
   struct output_device *device;
 
-  for (device = dev_list; device; device = device->next)
+  for (device = output_device_list; device; device = device->next)
     {
       if ((device->advertised || device->selected)
 	  && device->id == spk_param->spk_id)

--- a/src/player.c
+++ b/src/player.c
@@ -1053,9 +1053,19 @@ source_read(int *nbytes, int *nsamples, struct media_quality *quality, uint8_t *
 {
   short flags;
 
-  // Nothing to read, stream silence until event_read() stops playback
-  if (!pb_session.reading_now && pb_session.playing_now)
+  // Nothing to read
+  if (!pb_session.reading_now)
     {
+      // This can happen if the loop tries to catch up with an overrun or a
+      // deficit, but the playback ends in the first iteration
+      if (!pb_session.playing_now)
+	{
+	  *nbytes = 0;
+	  *nsamples = 0;
+	  return 0;
+	}
+
+      // Stream silence until event_read() stops playback
       memset(buf, 0, len);
       *quality = pb_session.playing_now->quality;
       *nbytes = len;

--- a/src/player.c
+++ b/src/player.c
@@ -287,6 +287,8 @@ playback_abort(void);
 static void
 playback_suspend(void);
 
+static int
+player_get_current_pos(uint64_t *pos, struct timespec *ts, int commit);
 
 /* ----------------------------- Volume helpers ----------------------------- */
 
@@ -1009,7 +1011,7 @@ source_switch(int nbytes)
 }
 
 static void
-session_init(struct player_session *session, struct media_quality *quality)
+session_reset(struct player_session *session, struct media_quality *quality)
 {
   session->samples_written = 0;
   session->quality = *quality;
@@ -1033,7 +1035,7 @@ session_init(struct player_session *session, struct media_quality *quality)
 }
 
 static void
-session_deinit(struct player_session *session)
+session_clear(struct player_session *session)
 {
   free(session->buffer);
   memset(session, 0, sizeof(struct player_session));
@@ -1083,7 +1085,9 @@ source_read(uint8_t *buf, int len)
   else if (flags & INPUT_FLAG_QUALITY)
     {
       input_quality_get(&quality);
-      session_init(&pb_session, &quality);
+
+      if (!quality_is_equal(&quality, &pb_session.quality))
+	session_reset(&pb_session, &quality);
     }
 
   // We pad the output buffer with silence if we don't have enough data for a
@@ -1171,7 +1175,7 @@ playback_cb(int fd, short what, void *arg)
 	}
 
       nsamples = BTOS(got, pb_session.quality.bits_per_sample, pb_session.quality.channels);
-      outputs_write2(pb_session.buffer, pb_session.bufsize, &pb_session.quality, nsamples, &pb_session.pts);
+      outputs_write(pb_session.buffer, pb_session.bufsize, &pb_session.quality, nsamples, &pb_session.pts);
       pb_session.samples_written += nsamples;
 
       if (got < pb_session.bufsize)
@@ -1468,11 +1472,11 @@ device_metadata_send(void *arg, int *retval)
 /* -------- Output device callbacks executed in the player thread ----------- */
 
 static void
-device_streaming_cb(struct output_device *device, struct output_session *session, enum output_device_state status)
+device_streaming_cb(struct output_device *device, enum output_device_state status)
 {
   int ret;
 
-  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_streaming_cb\n", outputs_name(device->type));
+  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_streaming_cb (status %d)\n", outputs_name(device->type), status);
 
   ret = device_check(device);
   if (ret < 0)
@@ -1492,8 +1496,6 @@ device_streaming_cb(struct output_device *device, struct output_session *session
       if (player_state == PLAY_PLAYING)
 	speaker_deselect_output(device);
 
-      device->session = NULL;
-
       if (!device->advertised)
 	device_remove(device);
 
@@ -1506,24 +1508,22 @@ device_streaming_cb(struct output_device *device, struct output_session *session
 
       output_sessions--;
 
-      device->session = NULL;
-
       if (!device->advertised)
 	device_remove(device);
     }
   else
-    outputs_status_cb(session, device_streaming_cb);
+    outputs_device_set_cb(device, device_streaming_cb);
 }
 
 static void
-device_command_cb(struct output_device *device, struct output_session *session, enum output_device_state status)
+device_command_cb(struct output_device *device, enum output_device_state status)
 {
-  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_command_cb\n", outputs_name(device->type));
+  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_command_cb (status %d)\n", outputs_name(device->type), status);
 
-  outputs_status_cb(session, device_streaming_cb);
+  outputs_device_set_cb(device, device_streaming_cb);
 
   if (status == OUTPUT_STATE_FAILED)
-    device_streaming_cb(device, session, status);
+    device_streaming_cb(device, status);
 
   // Used by playback_suspend - is basically the bottom half
   if (player_flush_pending > 0)
@@ -1537,12 +1537,12 @@ device_command_cb(struct output_device *device, struct output_session *session, 
 }
 
 static void
-device_shutdown_cb(struct output_device *device, struct output_session *session, enum output_device_state status)
+device_shutdown_cb(struct output_device *device, enum output_device_state status)
 {
   int retval;
   int ret;
 
-  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_shutdown_cb\n", outputs_name(device->type));
+  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_shutdown_cb (status %d)\n", outputs_name(device->type), status);
 
   if (output_sessions)
     output_sessions--;
@@ -1558,8 +1558,6 @@ device_shutdown_cb(struct output_device *device, struct output_session *session,
       goto out;
     }
 
-  device->session = NULL;
-
   if (!device->advertised)
     device_remove(device);
 
@@ -1572,9 +1570,9 @@ device_shutdown_cb(struct output_device *device, struct output_session *session,
 }
 
 static void
-device_lost_cb(struct output_device *device, struct output_session *session, enum output_device_state status)
+device_lost_cb(struct output_device *device, enum output_device_state status)
 {
-  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_lost_cb\n", outputs_name(device->type));
+  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_lost_cb (status %d)\n", outputs_name(device->type), status);
 
   // We lost that device during startup for some reason, not much we can do here
   if (status == OUTPUT_STATE_FAILED)
@@ -1584,12 +1582,12 @@ device_lost_cb(struct output_device *device, struct output_session *session, enu
 }
 
 static void
-device_activate_cb(struct output_device *device, struct output_session *session, enum output_device_state status)
+device_activate_cb(struct output_device *device, enum output_device_state status)
 {
   int retval;
   int ret;
 
-  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_activate_cb\n", outputs_name(device->type));
+  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_activate_cb (status %d)\n", outputs_name(device->type), status);
 
   retval = commands_exec_returnvalue(cmdbase);
   ret = device_check(device);
@@ -1597,8 +1595,7 @@ device_activate_cb(struct output_device *device, struct output_session *session,
     {
       DPRINTF(E_WARN, L_PLAYER, "Output device disappeared during startup!\n");
 
-      outputs_status_cb(session, device_lost_cb);
-      outputs_device_stop(session);
+      outputs_device_stop(device, device_lost_cb);
 
       if (retval != -2)
 	retval = -1;
@@ -1623,11 +1620,9 @@ device_activate_cb(struct output_device *device, struct output_session *session,
       goto out;
     }
 
-  device->session = session;
-
   output_sessions++;
 
-  outputs_status_cb(session, device_streaming_cb);
+  outputs_device_set_cb(device, device_streaming_cb);
 
  out:
   /* cur_cmd->ret already set
@@ -1639,12 +1634,12 @@ device_activate_cb(struct output_device *device, struct output_session *session,
 }
 
 static void
-device_probe_cb(struct output_device *device, struct output_session *session, enum output_device_state status)
+device_probe_cb(struct output_device *device, enum output_device_state status)
 {
   int retval;
   int ret;
 
-  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_probe_cb\n", outputs_name(device->type));
+  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_probe_cb (status %d)\n", outputs_name(device->type), status);
 
   retval = commands_exec_returnvalue(cmdbase);
   ret = device_check(device);
@@ -1685,12 +1680,12 @@ device_probe_cb(struct output_device *device, struct output_session *session, en
 }
 
 static void
-device_restart_cb(struct output_device *device, struct output_session *session, enum output_device_state status)
+device_restart_cb(struct output_device *device, enum output_device_state status)
 {
   int retval;
   int ret;
 
-  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_restart_cb\n", outputs_name(device->type));
+  DPRINTF(E_DBG, L_PLAYER, "Callback from %s to device_restart_cb (status %d)\n", outputs_name(device->type), status);
 
   retval = commands_exec_returnvalue(cmdbase);
   ret = device_check(device);
@@ -1698,8 +1693,7 @@ device_restart_cb(struct output_device *device, struct output_session *session, 
     {
       DPRINTF(E_WARN, L_PLAYER, "Output device disappeared during restart!\n");
 
-      outputs_status_cb(session, device_lost_cb);
-      outputs_device_stop(session);
+      outputs_device_stop(device, device_lost_cb);
 
       if (retval != -2)
 	retval = -1;
@@ -1724,10 +1718,8 @@ device_restart_cb(struct output_device *device, struct output_session *session, 
       goto out;
     }
 
-  device->session = session;
-
   output_sessions++;
-  outputs_status_cb(session, device_streaming_cb);
+  outputs_device_set_cb(device, device_streaming_cb);
 
  out:
   commands_exec_end(cmdbase, retval);
@@ -1786,11 +1778,22 @@ playback_timer_stop(void)
   if (ret < 0)
     {
       DPRINTF(E_LOG, L_PLAYER, "Could not disarm playback timer: %s\n", strerror(errno));
-
       return -1;
     }
 
   return 0;
+}
+
+static int
+pb_session_stop(void)
+{
+  int ret;
+
+  ret = playback_timer_stop();
+
+  session_clear(&pb_session);
+
+  return ret;
 }
 
 static void
@@ -1798,7 +1801,7 @@ playback_abort(void)
 {
   outputs_playback_stop();
 
-  playback_timer_stop();
+  pb_session_stop();
 
   source_stop();
 
@@ -1815,9 +1818,9 @@ playback_abort(void)
 static void
 playback_suspend(void)
 {
-  player_flush_pending = outputs_flush2(device_command_cb);
+  player_flush_pending = outputs_flush(device_command_cb);
 
-  playback_timer_stop();
+  pb_session_stop();
 
   status_update(PLAY_PAUSED);
 
@@ -1949,9 +1952,9 @@ playback_stop(void *arg, int *retval)
 
   // We may be restarting very soon, so we don't bring the devices to a full
   // stop just yet; this saves time when restarting, which is nicer for the user
-  *retval = outputs_flush2(device_command_cb);
+  *retval = outputs_flush(device_command_cb);
 
-  playback_timer_stop();
+  pb_session_stop();
 
   ps_playing = source_now_playing();
   if (ps_playing)
@@ -1975,7 +1978,6 @@ playback_stop(void *arg, int *retval)
 static enum command_state
 playback_start_bh(void *arg, int *retval)
 {
-  struct timespec ts;
   int ret;
 
   // initialize the packet timer to the same relative time that we have 
@@ -1988,10 +1990,6 @@ playback_start_bh(void *arg, int *retval)
 
 //  pb_buffer_offset = 0;
   pb_read_deficit = 0;
-
-  ret = clock_gettime_with_res(CLOCK_MONOTONIC, &ts, &player_timer_res);
-  if (ret < 0)
-    goto out_fail;
 
   ret = playback_timer_start();
   if (ret < 0)
@@ -2098,7 +2096,7 @@ playback_start_item(void *arg, int *retval)
     {
       if (device->selected && !device->session)
 	{
-	  ret = outputs_device_start2(device, device_restart_cb);
+	  ret = outputs_device_start(device, device_restart_cb);
 	  if (ret < 0)
 	    {
 	      DPRINTF(E_LOG, L_PLAYER, "Could not start selected %s device '%s'\n", device->type_name, device->name);
@@ -2118,7 +2116,7 @@ playback_start_item(void *arg, int *retval)
 	  continue;
 
 	speaker_select_output(device);
-	ret = outputs_device_start(device, device_restart_cb, TEMP_NEXT_RTPTIME);
+	ret = outputs_device_start(device, device_restart_cb);
 	if (ret < 0)
 	  {
 	    DPRINTF(E_DBG, L_PLAYER, "Could not autoselect %s device '%s'\n", device->type_name, device->name);
@@ -2420,9 +2418,9 @@ playback_pause(void *arg, int *retval)
       return COMMAND_END;
     }
 
-  *retval = outputs_flush2(device_command_cb);
+  *retval = outputs_flush(device_command_cb);
 
-  playback_timer_stop();
+  pb_session_stop();
 
   source_pause(pos);
 
@@ -2530,7 +2528,7 @@ speaker_activate(struct output_device *device)
     {
       DPRINTF(E_DBG, L_PLAYER, "Activating %s device '%s'\n", device->type_name, device->name);
 
-      ret = outputs_device_start2(device, device_activate_cb);
+      ret = outputs_device_start(device, device_activate_cb);
       if (ret < 0)
 	{
 	  DPRINTF(E_LOG, L_PLAYER, "Could not start %s device '%s'\n", device->type_name, device->name);
@@ -2568,8 +2566,7 @@ speaker_deactivate(struct output_device *device)
   if (!device->session)
     return 0;
 
-  outputs_status_cb(device->session, device_shutdown_cb);
-  outputs_device_stop(device->session);
+  outputs_device_stop(device, device_shutdown_cb);
   return 1;
 }
 
@@ -2996,7 +2993,8 @@ playerqueue_plid(void *arg, int *retval)
 
 /* ------------------------------- Player API ------------------------------- */
 
-int
+// TODO no longer part of API
+static int
 player_get_current_pos(uint64_t *pos, struct timespec *ts, int commit)
 {
   uint64_t delta;
@@ -3034,21 +3032,6 @@ player_get_current_pos(uint64_t *pos, struct timespec *ts, int commit)
 #ifdef DEBUG_SYNC
       DPRINTF(E_DBG, L_PLAYER, "Pos: %" PRIu64 " (clock)\n", *pos);
 #endif
-    }
-
-  return 0;
-}
-
-int
-player_get_time(struct timespec *ts)
-{
-  int ret;
-
-  ret = clock_gettime_with_res(CLOCK_MONOTONIC, ts, &player_timer_res);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_PLAYER, "Couldn't get clock: %s\n", strerror(errno));
-      return -1;
     }
 
   return 0;
@@ -3491,7 +3474,6 @@ player(void *arg)
 int
 player_init(void)
 {
-  struct media_quality default_quality = { 44100, 16, 2 };
   uint64_t interval;
   uint32_t rnd;
   int ret;
@@ -3567,8 +3549,6 @@ player_init(void)
       goto evnew_fail;
     }
 
-  session_init(&pb_session, &default_quality);
-
   cmdbase = commands_base_new(evbase_player, NULL);
 
   ret = outputs_init();
@@ -3605,7 +3585,6 @@ player_init(void)
   outputs_deinit();
  outputs_fail:
   commands_base_free(cmdbase);
-  session_deinit(&pb_session);
  evnew_fail:
   event_base_free(evbase_player);
  evbase_fail:
@@ -3638,7 +3617,7 @@ player_deinit(void)
   player_exit = 1;
   commands_base_destroy(cmdbase);
 
-  session_deinit(&pb_session);
+  session_clear(&pb_session);
 
   ret = pthread_join(tid_player, NULL);
   if (ret != 0)

--- a/src/player.c
+++ b/src/player.c
@@ -1106,7 +1106,7 @@ source_read(int *nbytes, int *nsamples, struct media_quality *quality, uint8_t *
     {
       event_metadata_new();
     }
-  else if (flags & INPUT_FLAG_QUALITY)
+  else if (flags & INPUT_FLAG_QUALITY || quality->channels == 0)
     {
       event_read_quality();
     }
@@ -1114,7 +1114,6 @@ source_read(int *nbytes, int *nsamples, struct media_quality *quality, uint8_t *
   if (*nbytes == 0 || quality->channels == 0)
     {
       event_read(0); // This will set start_ts even if source isn't open yet
-      event_read_quality(); // Will poll input for quality since we don't have it
       return 0;
     }
 

--- a/src/player.c
+++ b/src/player.c
@@ -1201,7 +1201,7 @@ playback_cb(int fd, short what, void *arg)
 
       pb_session.read_deficit -= nbytes;
 
-      outputs_write(pb_session.buffer, pb_session.bufsize, &quality, nsamples, &pb_session.pts);
+      outputs_write(pb_session.buffer, nbytes, nsamples, &quality, &pb_session.pts);
 
       if (nbytes < pb_session.bufsize)
 	{

--- a/src/player.c
+++ b/src/player.c
@@ -852,7 +852,7 @@ static inline void
 session_update_read(int nsamples)
 {
   // Did we just complete our first read? Then set the start timestamp
-  if (pb_session.pos == 0)
+  if (pb_session.start_ts.tv_sec == 0)
     {
       clock_gettime_with_res(CLOCK_MONOTONIC, &pb_session.start_ts, &player_timer_res);
       pb_session.pts = pb_session.start_ts;
@@ -1089,7 +1089,10 @@ source_read(int *nbytes, int *nsamples, struct media_quality *quality, uint8_t *
     }
 
   if (*nbytes == 0 || quality->channels == 0)
-    return 0;
+    {
+      event_read(0); // This will set start_ts even if source isn't open yet
+      return 0;
+    }
 
   *nsamples = BTOS(*nbytes, quality->bits_per_sample, quality->channels);
 

--- a/src/player.c
+++ b/src/player.c
@@ -903,7 +903,7 @@ session_update_read_quality(struct media_quality *quality)
 
   CHECK_NULL(L_PLAYER, pb_session.buffer);
 
-  pb_session.reading_now->play_start = pb_session.reading_now->play_start + pb_session.reading_now->output_buffer_samples;
+  pb_session.reading_now->play_start = pb_session.reading_now->read_start + pb_session.reading_now->output_buffer_samples;
 }
 
 static void

--- a/src/player.h
+++ b/src/player.h
@@ -93,9 +93,6 @@ player_speaker_enable(uint64_t id);
 int
 player_speaker_disable(uint64_t id);
 
-void
-player_speaker_status_trigger(void);
-
 int
 player_playback_start(void);
 
@@ -162,6 +159,9 @@ player_raop_verification_kickoff(char **arglist);
 
 void
 player_metadata_send(void *imd, void *omd);
+
+const char *
+player_pmap(void *p);
 
 int
 player_init(void);

--- a/src/player.h
+++ b/src/player.h
@@ -72,13 +72,6 @@ struct player_history
   uint32_t item_id[MAX_HISTORY_COUNT];
 };
 
-
-int
-player_get_current_pos(uint64_t *pos, struct timespec *ts, int commit);
-
-int
-player_get_time(struct timespec *ts);
-
 int
 player_get_status(struct player_status *status);
 

--- a/src/player.h
+++ b/src/player.h
@@ -7,15 +7,6 @@
 
 #include "db.h"
 
-// AirTunes v2 packet interval in ns */
-// (352 samples/packet * 1e9 ns/s) / 44100 samples/s = 7981859 ns/packet
-#define AIRTUNES_V2_STREAM_PERIOD 7981859
-
-// AirTunes v2 number of samples per packet
-// Probably using this value because 44100/352 and 48000/352 has good 32 byte
-// alignment, which improves performance of some encoders
-#define AIRTUNES_V2_PACKET_SAMPLES  352
-
 // Maximum number of previously played songs that are remembered
 #define MAX_HISTORY_COUNT 20
 
@@ -84,6 +75,9 @@ struct player_history
 
 int
 player_get_current_pos(uint64_t *pos, struct timespec *ts, int commit);
+
+int
+player_get_time(struct timespec *ts);
 
 int
 player_get_status(struct player_status *status);

--- a/src/player.h
+++ b/src/player.h
@@ -76,7 +76,7 @@ int
 player_get_status(struct player_status *status);
 
 int
-player_now_playing(uint32_t *id);
+player_playing_now(uint32_t *id);
 
 void
 player_speaker_enumerate(spk_enum_cb cb, void *arg);

--- a/src/player.h
+++ b/src/player.h
@@ -7,14 +7,16 @@
 
 #include "db.h"
 
-/* AirTunes v2 packet interval in ns */
-/* (352 samples/packet * 1e9 ns/s) / 44100 samples/s = 7981859 ns/packet */
-# define AIRTUNES_V2_STREAM_PERIOD 7981859
+// AirTunes v2 packet interval in ns */
+// (352 samples/packet * 1e9 ns/s) / 44100 samples/s = 7981859 ns/packet
+#define AIRTUNES_V2_STREAM_PERIOD 7981859
 
-/* AirTunes v2 number of samples per packet */
+// AirTunes v2 number of samples per packet
+// Probably using this value because 44100/352 and 48000/352 has good 32 byte
+// alignment, which improves performance of some encoders
 #define AIRTUNES_V2_PACKET_SAMPLES  352
 
-/* Maximum number of previously played songs that are remembered */
+// Maximum number of previously played songs that are remembered
 #define MAX_HISTORY_COUNT 20
 
 enum play_status {

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -1007,7 +1007,7 @@ logged_out(sp_session *sess)
 static int music_delivery(sp_session *sess, const sp_audioformat *format,
                           const void *frames, int num_frames)
 {
-  struct input_quality quality = { 0 };
+  struct media_quality quality = { 0 };
   size_t size;
   int ret;
 
@@ -1021,6 +1021,7 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
 
   quality.sample_rate = format->sample_rate;
   quality.bits_per_sample = 16;
+  quality.channels = format->channels;
 
   // Audio discontinuity, e.g. seek
   if (num_frames == 0)

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -719,7 +719,7 @@ playback_eot(void *arg, int *retval)
   g_state = SPOTIFY_STATE_STOPPING;
 
   // TODO 1) This will block for a while, but perhaps ok?
-  input_write(spotify_audio_buffer, INPUT_FLAG_EOF);
+  input_write(spotify_audio_buffer, 0, 0, INPUT_FLAG_EOF);
 
   *retval = 0;
   return COMMAND_END;
@@ -1011,9 +1011,9 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
   int ret;
 
   /* No support for resampling right now */
-  if ((format->sample_rate != 44100) || (format->channels != 2))
+  if ((format->sample_type != SP_SAMPLETYPE_INT16_NATIVE_ENDIAN) || (format->channels != 2))
     {
-      DPRINTF(E_LOG, L_SPOTIFY, "Got music with unsupported samplerate or channels, stopping playback\n");
+      DPRINTF(E_LOG, L_SPOTIFY, "Got music with unsupported sample format or number of channels, stopping playback\n");
       spotify_playback_stop_nonblock();
       return num_frames;
     }
@@ -1037,7 +1037,7 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
   // The input buffer only accepts writing when it is approaching depletion, and
   // because we use NONBLOCK it will just return if this is not the case. So in
   // most cases no actual write is made and spotify_audio_buffer will just grow.
-  input_write(spotify_audio_buffer, INPUT_FLAG_NONBLOCK);
+  input_write(spotify_audio_buffer, format->sample_rate, 16, INPUT_FLAG_NONBLOCK);
 
   return num_frames;
 }

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -718,7 +718,6 @@ playback_eot(void *arg, int *retval)
 
   g_state = SPOTIFY_STATE_STOPPING;
 
-  // TODO 1) This will block for a while, but perhaps ok?
   input_write(spotify_audio_buffer, NULL, INPUT_FLAG_EOF);
 
   *retval = 0;
@@ -1042,7 +1041,7 @@ static int music_delivery(sp_session *sess, const sp_audioformat *format,
   // The input buffer only accepts writing when it is approaching depletion, and
   // because we use NONBLOCK it will just return if this is not the case. So in
   // most cases no actual write is made and spotify_audio_buffer will just grow.
-  input_write(spotify_audio_buffer, &quality, INPUT_FLAG_NONBLOCK);
+  input_write(spotify_audio_buffer, &quality, 0);
 
   return num_frames;
 }

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -387,8 +387,8 @@ make_wav_header(struct encode_ctx *ctx, struct decode_ctx *src_ctx, off_t *est_s
   else
     duration = 3 * 60 * 1000; /* 3 minutes, in ms */
 
-  bps = av_get_bits_per_sample(ctx->settings.audio_codec);
-  wav_len = ctx->settings.channels * (bps / 8) * ctx->settings.sample_rate * (duration / 1000);
+  bps = av_get_bytes_per_sample(ctx->settings.sample_format);
+  wav_len = ctx->settings.channels * bps * ctx->settings.sample_rate * (duration / 1000);
 
   if (est_size)
     *est_size = wav_len + sizeof(ctx->header);
@@ -400,9 +400,9 @@ make_wav_header(struct encode_ctx *ctx, struct decode_ctx *src_ctx, off_t *est_s
   add_le16(ctx->header + 20, 1);
   add_le16(ctx->header + 22, ctx->settings.channels);     /* channels */
   add_le32(ctx->header + 24, ctx->settings.sample_rate);  /* samplerate */
-  add_le32(ctx->header + 28, ctx->settings.sample_rate * ctx->settings.channels * (bps / 8)); /* byte rate */
-  add_le16(ctx->header + 32, ctx->settings.channels * (bps / 8));                             /* block align */
-  add_le16(ctx->header + 34, bps);                                                            /* bits per sample */
+  add_le32(ctx->header + 28, ctx->settings.sample_rate * ctx->settings.channels * bps); /* byte rate */
+  add_le16(ctx->header + 32, ctx->settings.channels * bps);                             /* block align */
+  add_le16(ctx->header + 34, 8 * bps);                                                  /* bits per sample */
   memcpy(ctx->header + 36, "data", 4);
   add_le32(ctx->header + 40, wav_len);
 }
@@ -1281,8 +1281,8 @@ transcode_encode_setup(enum transcode_profile profile, struct decode_ctx *src_ct
 
   if (ctx->settings.icy && src_ctx->data_kind == DATA_KIND_HTTP)
     {
-      bps = av_get_bits_per_sample(ctx->settings.audio_codec);
-      ctx->icy_interval = METADATA_ICY_INTERVAL * ctx->settings.channels * (bps / 8) * ctx->settings.sample_rate;
+      bps = av_get_bytes_per_sample(ctx->settings.sample_format);
+      ctx->icy_interval = METADATA_ICY_INTERVAL * ctx->settings.channels * bps * ctx->settings.sample_rate;
     }
 
   return ctx;

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -340,7 +340,8 @@ make_wav_header(struct encode_ctx *ctx, struct decode_ctx *src_ctx, off_t *est_s
   bps = av_get_bits_per_sample(ctx->settings.audio_codec);
   wav_len = ctx->settings.channels * (bps / 8) * ctx->settings.sample_rate * (duration / 1000);
 
-  *est_size = wav_len + sizeof(ctx->header);
+  if (est_size)
+    *est_size = wav_len + sizeof(ctx->header);
 
   memcpy(ctx->header, "RIFF", 4);
   add_le32(ctx->header + 4, 36 + wav_len);

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -216,6 +216,16 @@ init_settings(struct settings_ctx *settings, enum transcode_profile profile)
 	settings->sample_format = AV_SAMPLE_FMT_S16;
 	break;
 
+      case XCODE_PCM16_96000:
+	settings->encode_audio = 1;
+	settings->format = "s16le";
+	settings->audio_codec = AV_CODEC_ID_PCM_S16LE;
+	settings->sample_rate = 96000;
+	settings->channel_layout = AV_CH_LAYOUT_STEREO;
+	settings->channels = 2;
+	settings->sample_format = AV_SAMPLE_FMT_S16;
+	break;
+
       case XCODE_PCM24_44100:
 	settings->encode_audio = 1;
 	settings->format = "s24le";
@@ -231,6 +241,46 @@ init_settings(struct settings_ctx *settings, enum transcode_profile profile)
 	settings->format = "s24le";
 	settings->audio_codec = AV_CODEC_ID_PCM_S24LE;
 	settings->sample_rate = 48000;
+	settings->channel_layout = AV_CH_LAYOUT_STEREO;
+	settings->channels = 2;
+	settings->sample_format = AV_SAMPLE_FMT_S32;
+	break;
+
+      case XCODE_PCM24_96000:
+	settings->encode_audio = 1;
+	settings->format = "s24le";
+	settings->audio_codec = AV_CODEC_ID_PCM_S24LE;
+	settings->sample_rate = 96000;
+	settings->channel_layout = AV_CH_LAYOUT_STEREO;
+	settings->channels = 2;
+	settings->sample_format = AV_SAMPLE_FMT_S32;
+	break;
+
+      case XCODE_PCM32_44100:
+	settings->encode_audio = 1;
+	settings->format = "s32le";
+	settings->audio_codec = AV_CODEC_ID_PCM_S32LE;
+	settings->sample_rate = 44100;
+	settings->channel_layout = AV_CH_LAYOUT_STEREO;
+	settings->channels = 2;
+	settings->sample_format = AV_SAMPLE_FMT_S32;
+	break;
+
+      case XCODE_PCM32_48000:
+	settings->encode_audio = 1;
+	settings->format = "s32le";
+	settings->audio_codec = AV_CODEC_ID_PCM_S32LE;
+	settings->sample_rate = 48000;
+	settings->channel_layout = AV_CH_LAYOUT_STEREO;
+	settings->channels = 2;
+	settings->sample_format = AV_SAMPLE_FMT_S32;
+	break;
+
+      case XCODE_PCM32_96000:
+	settings->encode_audio = 1;
+	settings->format = "s32le";
+	settings->audio_codec = AV_CODEC_ID_PCM_S32LE;
+	settings->sample_rate = 96000;
 	settings->channel_layout = AV_CH_LAYOUT_STEREO;
 	settings->channels = 2;
 	settings->sample_format = AV_SAMPLE_FMT_S32;
@@ -1198,17 +1248,19 @@ transcode_encode_setup(enum transcode_profile profile, struct decode_ctx *src_ct
   ctx->settings.width = width;
   ctx->settings.height = height;
 
+  // Profile does not specify a sample rate -> use same as source
   if (!ctx->settings.sample_rate && ctx->settings.encode_audio)
     ctx->settings.sample_rate = src_ctx->audio_stream.codec->sample_rate;
 
+  // Profile does not specify a sample format -> use same as source
   if (!ctx->settings.sample_format && ctx->settings.encode_audio)
     {
-      bps = av_get_bits_per_sample(src_ctx->audio_stream.codec->codec_id);
-      if (bps >= 24)
+      bps = av_get_bytes_per_sample(src_ctx->audio_stream.codec->sample_fmt);
+      if (bps == 4)
 	{
 	  ctx->settings.sample_format = AV_SAMPLE_FMT_S32;
-	  ctx->settings.audio_codec = AV_CODEC_ID_PCM_S24LE;
-	  ctx->settings.format = "s24le";
+	  ctx->settings.audio_codec = AV_CODEC_ID_PCM_S32LE;
+	  ctx->settings.format = "s32le";
 	}
       else
 	{
@@ -1579,6 +1631,10 @@ transcode_frame_new(void *data, size_t size, int nsamples, int sample_rate, int 
       f->format = AV_SAMPLE_FMT_S16;
     }
   else if (bits_per_sample == 24)
+    {
+      f->format = AV_SAMPLE_FMT_S32;
+    }
+  else if (bits_per_sample == 32)
     {
       f->format = AV_SAMPLE_FMT_S32;
     }

--- a/src/transcode.h
+++ b/src/transcode.h
@@ -17,8 +17,13 @@ enum transcode_profile
   // Decodes/resamples the best audio stream (no wav headers)
   XCODE_PCM16_44100,
   XCODE_PCM16_48000,
+  XCODE_PCM16_96000,
   XCODE_PCM24_44100,
   XCODE_PCM24_48000,
+  XCODE_PCM24_96000,
+  XCODE_PCM32_44100,
+  XCODE_PCM32_48000,
+  XCODE_PCM32_96000,
   // Transcodes the best audio stream into MP3
   XCODE_MP3,
   // Transcodes the best audio stream into OPUS

--- a/src/transcode.h
+++ b/src/transcode.h
@@ -8,12 +8,17 @@
 
 enum transcode_profile
 {
-  // Decodes/resamples the best audio stream into 44100 PCM16 (does not add wav header)
-  XCODE_PCM16_NOHEADER,
-  // Decodes/resamples the best audio stream into 44100 PCM16 (with wav header)
-  XCODE_PCM16_HEADER,
+  // Used for errors
+  XCODE_UNKNOWN = 0,
   // Decodes the best audio stream into PCM16 or PCM24, no resampling (does not add wav header)
   XCODE_PCM_NATIVE,
+  // Decodes/resamples the best audio stream into 44100 PCM16 (with wav header)
+  XCODE_PCM16_HEADER,
+  // Decodes/resamples the best audio stream (no wav headers)
+  XCODE_PCM16_44100,
+  XCODE_PCM16_48000,
+  XCODE_PCM24_44100,
+  XCODE_PCM24_48000,
   // Transcodes the best audio stream into MP3
   XCODE_MP3,
   // Transcodes the best audio stream into OPUS
@@ -44,7 +49,7 @@ struct transcode_ctx *
 transcode_setup(enum transcode_profile profile, enum data_kind data_kind, const char *path, uint32_t song_length, off_t *est_size);
 
 struct decode_ctx *
-transcode_decode_setup_raw(void);
+transcode_decode_setup_raw(enum transcode_profile profile);
 
 int
 transcode_needed(const char *user_agent, const char *client_codecs, char *file_codectype);
@@ -100,13 +105,17 @@ transcode(struct evbuffer *evbuf, int *icy_timer, struct transcode_ctx *ctx, int
  * transcode_encode() function. It does not copy, so if you free the data the
  * frame will become invalid.
  *
- * @in  profile    Tells the function what kind of frame to create
  * @in  data       Buffer with raw data
  * @in  size       Size of buffer
+ * @in  nsamples   Number of samples in the buffer
+ * @in  sample_rate
+ *                 Sample rate
+ * @in  bits_per_sample
+ *                 BPS must be either 16 or 24
  * @return         Opaque pointer to frame if OK, otherwise NULL
  */
 transcode_frame *
-transcode_frame_new(enum transcode_profile profile, void *data, size_t size);
+transcode_frame_new(void *data, size_t size, int nsamples, int sample_rate, int bits_per_sample);
 void
 transcode_frame_free(transcode_frame *frame);
 

--- a/src/transcode.h
+++ b/src/transcode.h
@@ -8,10 +8,12 @@
 
 enum transcode_profile
 {
-  // Transcodes the best audio stream into PCM16 (does not add wav header)
+  // Decodes/resamples the best audio stream into 44100 PCM16 (does not add wav header)
   XCODE_PCM16_NOHEADER,
-  // Transcodes the best audio stream into PCM16 (with wav header)
+  // Decodes/resamples the best audio stream into 44100 PCM16 (with wav header)
   XCODE_PCM16_HEADER,
+  // Decodes the best audio stream into PCM16 or PCM24, no resampling (does not add wav header)
+  XCODE_PCM_NATIVE,
   // Transcodes the best audio stream into MP3
   XCODE_MP3,
   // Transcodes the best audio stream into OPUS
@@ -23,7 +25,11 @@ enum transcode_profile
 
 struct decode_ctx;
 struct encode_ctx;
-struct transcode_ctx;
+struct transcode_ctx
+{
+  struct decode_ctx *decode_ctx;
+  struct encode_ctx *encode_ctx;
+};
 
 typedef void transcode_frame;
 
@@ -121,6 +127,16 @@ transcode_seek(struct transcode_ctx *ctx, int ms);
  */
 int
 transcode_decode_query(struct decode_ctx *ctx, const char *query);
+
+/* Query for information (e.g. sample rate) about the output being produced by
+ * the transcoding
+ *
+ * @in  ctx        Encode context
+ * @in  query      Query - see implementation for supported queries
+ * @return         Negative if error, otherwise query dependent
+ */
+int
+transcode_encode_query(struct encode_ctx *ctx, const char *query);
 
 // Metadata
 struct http_icy_metadata *


### PR DESCRIPTION
@chme, I think my refactoring of the player, incl. input and output, is now in a state where a review makes sense. It is a rather large change, but if you are up to it it would be great.

There are (at least) two major issues I couldn't solve, and if you have ideas on what to do about them it would be great. The first is gapless playback - it doesn't work, and the reason seems to be that ffmpeg/transcode isn't providing the audio gapless. I haven't found the root cause of that. The second is Airplay sync: It is not as good as iTunes does it between my ATV4 and Sony receiver. It is not worse than current master, but I thought I could improve it with this change, since the sync packets are now exactly like those from iTunes (they weren't before), and like how you suggested they should be. Well of course they aren't quite like iTunes, since sync isn't as good, but I could find neither a difference nor a root cause.

Here is an overview of the changes:

1. The input source will be opened earlier, so that the stream to the output is not interrupted while we open the source. “earlier” means that it gets opened when the input buffer has free space.
2. The input serves audio in an endless stream via the input buffer. When a track ends there is just a marker that gets set, the audio stream itself should be uninterrupted.
3. It should be possible to pause internet streams now. After 10 minutes a timer will convert a pause to a stop, so that we don't keep the input source open forever. The issue with rewinding during the last 2 seconds of a track should also be solved.
4. Introduction of a “quality” attribute, which is sample rate, bits per sample and number of channels (yes, in principle forked-daapd now supports more than 2 channels! – but that is completely untested).
5. The player always gets the audio in native quality of the source, so the player and input do no resampling. This also means that calculation of elapsed playback time and buffer sizes is more complicated, since the relationship between number of samples and time isn’t fixed.
6. The output module (outputs.c) always serves the native quality to the output backend. If the backend cannot support that quality then it can subscribe to another quality, and the output module will then also serve that quality level to the backend, i.e. it will resample for the backend.
7. The player now has the concept of a playback session. This is an object that holds all information about what is playing, quality, playback position and so on. It has reading_now and playing_now that are similar to the previous cur_streaming and cur_playing, except playing_now is now just a pointer at reading_prev, reading_now or reading_next. During playback it should never be null.
8. It was my intention that a session should not have multiple qualities, so that calculating elapsed times/positions would be easy within a session. If the input quality changed the session should then be reset. However, that was difficult in practice, so I abandoned it.
9. I have changed ALSA so it plays back in the native rate, if the device supports it. Otherwise it defaults to 44100/16/2.
10. MP3 encoding/streaming also uses the native rate now.
11. All callbacks from the output backends are now deferred, which outputs.c takes care of. So the backend itself does not need events and callbacks for that.
12. I have abolished “outputs_playback_start”, because it was used inconsistently. A bit of a long story, but the gist is that now backends have to prepare as much as they can in device_start, and then the first write equals playback start (where they can then for instance set start timestamps).

If there is stuff that is hard to understand please add a note so I can add some comments, or maybe make the code more explanatory.

There is still a bunch of testing and todo's. Before merging, I plan to make a release, since I would say the current code base is pretty stable. Here are some of the todo's:

* RTP based Chromecast (which was really the reason I even started on this)
* Legacy ffmpeg (not sure if want to do that, but I can see Travis uses legacy)
* Airplay metadata needs fixing up
* ALSA sync (I tried to improve the existing sync by using ALSA timestamps, but none of my devices seem to support ALSA timestamps, so it was hard to complete)
* Pulseaudio (build with –without-pulseaudio in the meantime)
* remove mapping/logging of player callbacks
* buffer management (don't copy buffers so much)
* And testing, especially various source qualities