### PR TITLE
[travis-ci] Build forked-daapd in the latest Ubuntu LTS docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,40 @@
+# Builds forked-daapd in the latest Ubuntu LTS docker container
+# Configuration based on https://romanvm.pythonanywhere.com/post/using-docker-travis-continuous-integration-25/
+
 language: c
 sudo: required
 dist: xenial
+
+services:
+  - docker
+
 env:
   matrix:
-    - CFG="--disable-verification"
-    - CFG="--enable-lastfm --disable-verification"
-    - CFG="--enable-spotify --disable-verification"
-    - CFG="--enable-chromecast --disable-verification"
-    - CFG="--with-pulseaudio --disable-verification"
-
-script:
-  - autoreconf -fi
-  - ./configure $CFG
-  - make
-  - make clean
-  - scan-build --status-bugs -disable-checker deadcode.DeadStores make
+    - SH="docker exec -t ubuntu-lts bash -c" CFG=""
+    - SH="docker exec -t ubuntu-lts bash -c" CFG="--enable-lastfm --disable-verification"
+    - SH="docker exec -t ubuntu-lts bash -c" CFG="--enable-spotify --disable-verification"
+    - SH="docker exec -t ubuntu-lts bash -c" CFG="--enable-chromecast --disable-verification"
+    - SH="docker exec -t ubuntu-lts bash -c" CFG="--with-pulseaudio --disable-verification"
 
 before_install:
-  - wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
-  - sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/jessie.list
-  - sudo apt-get -qq update
-  - sudo apt-get install -y build-essential clang git autotools-dev autoconf libtool gettext gawk gperf antlr3 libantlr3c-dev libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libmxml-dev libgcrypt11-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libcurl4-openssl-dev libjson-c-dev libspotify-dev libgnutls-dev libprotobuf-c0-dev libpulse-dev cmake
-  - wget -q -O - https://github.com/warmcat/libwebsockets/archive/v2.0.3.tar.gz | tar -xvzf -
-  - mkdir ./libwebsockets-2.0.3/build
-  - cd ./libwebsockets-2.0.3/build
-  - cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
-  - make
-  - sudo make install
-  - cd ../..
-  
+  - docker run -d --name ubuntu-lts -v $(pwd):/travis -w /travis ubuntu:latest tail -f /dev/null
+  - docker ps
+
+install:
+  - $SH "apt-get -qq update"
+  - $SH "apt-get install -y wget gnupg2"
+  - $SH "wget -q -O - https://apt.mopidy.com/mopidy.gpg | apt-key add -"
+  - $SH "wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/stretch.list"
+  - $SH "apt-get -qq update"
+  - $SH "apt-get install -y build-essential clang clang-tools git autotools-dev autoconf libtool gettext gawk gperf antlr3 libantlr3c-dev libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libmxml-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libsodium-dev libcurl4-openssl-dev libjson-c-dev libprotobuf-c-dev libpulse-dev libwebsockets-dev libgnutls28-dev libspotify-dev"
+
+script:
+  - $SH "autoreconf -fi"
+  - $SH "./configure $CFG"
+  - $SH "make"
+  - $SH "make clean"
+  - $SH "scan-build --status-bugs -disable-checker deadcode.DeadStores make"
+
 # Disable email notification
 notifications:
   email: false


### PR DESCRIPTION
This updates the travis-ci build environment from Ubuntu Xenial (16.04) to Bionic (18.04).
Instead of relying on the distributions provided by travis-ci, forked-daapd is now build in the latest Ubuntu LTS docker image. 