### PR TITLE
[db] genre: introduce filecount for genre  album/artist/track count info

### DIFF
--- a/src/db.h
+++ b/src/db.h
@@ -33,6 +33,7 @@ enum sort_type {
 };
 
 #define Q_F_BROWSE (1 << 15)
+#define Q_F_BROWSE_COUNT ((1 << 14) | Q_F_BROWSE)
 
 enum query_type {
   Q_ITEMS            = 1,
@@ -55,6 +56,9 @@ enum query_type {
   Q_BROWSE_TRACKS    = Q_F_BROWSE | 7,
   Q_BROWSE_VPATH     = Q_F_BROWSE | 8,
   Q_BROWSE_PATH      = Q_F_BROWSE | 9,
+
+  // Supplementary, not incl in browse_clause[]
+  Q_BROWSE_GENRES_WITH_COUNT = Q_F_BROWSE_COUNT | Q_BROWSE_GENRES,
 };
 
 #define ARTWORK_UNKNOWN   0
@@ -394,6 +398,15 @@ struct watch_enum {
   void *stmt;
 };
 
+struct db_browse_info {
+  const char *string;
+  const char *sortstring;
+  uint32_t count;
+  uint64_t length;
+  uint32_t artist_count;
+  uint32_t album_count;
+};
+
 struct filecount_info {
   uint32_t count;
   uint64_t length;
@@ -565,6 +578,9 @@ db_query_fetch_string(struct query_params *qp, char **string);
 
 int
 db_query_fetch_string_sort(struct query_params *qp, char **string, char **sortstring);
+
+int
+db_query_fetch_browse(struct query_params *qp, struct db_browse_info *browse_info);
 
 /* Files */
 int


### PR DESCRIPTION
`Genre` page brings back `albums` matching genre.  On the `PageGenres` we have the ability to list all tracks for the said genre.

This PR adds ability to bring back `artists` matching genre on `PageGenres`

![genre-artists](https://user-images.githubusercontent.com/18466811/54438914-a0e66700-472f-11e9-83c7-794a5d2d83d9.png)
* Left hand side shows the landing page `PageGenres` (ie `http://localhost:3689/#/music/genres/Jazz`) with `artists | albums | tracks` showing the list of albums matching the genre.
* Right hand side would be the click-through via `artists` link to give the traditional `artists` view but only for this genre.

Migrate db handling to pull `genres` info to dedicated method which also brings back counts for `album`, `artists` and `tracks` for each genre.  