### PR TITLE
[web-src] add 'top tracks' page for artist and genre

### DIFF
--- a/web-src/src/components/ModalDialogTopTracks.vue
+++ b/web-src/src/components/ModalDialogTopTracks.vue
@@ -1,0 +1,57 @@
+<template>
+  <div>
+    <transition name="fade">
+      <div class="modal is-active" v-if="show">
+        <div class="modal-background" @click="$emit('close')"></div>
+        <div class="modal-content fd-modal-card">
+          <div class="card">
+            <div class="card-content">
+              <span class="heading">Top Tracks</span>
+            </div>
+            <footer class="card-footer">
+              <a class="card-footer-item has-text-dark" @click="queue_add">
+                <span class="icon"><i class="mdi mdi-playlist-plus"></i></span> <span class="is-size-7">Add</span>
+              </a>
+              <a class="card-footer-item has-text-dark" @click="queue_add_next">
+                <span class="icon"><i class="mdi mdi-playlist-play"></i></span> <span class="is-size-7">Add Next</span>
+              </a>
+              <a class="card-footer-item has-text-dark" @click="play">
+                <span class="icon"><i class="mdi mdi-play"></i></span> <span class="is-size-7">Play</span>
+              </a>
+            </footer>
+          </div>
+        </div>
+        <button class="modal-close is-large" aria-label="close" @click="$emit('close')"></button>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+import webapi from '@/webapi'
+
+export default {
+  name: 'ModalDialogTopTracks',
+  props: [ 'show', 'tracks' ],
+
+  methods: {
+    play: function () {
+      this.$emit('close')
+      webapi.player_play_uri(this.tracks.items.map(a => a.uri).join(','), true)
+    },
+
+    queue_add: function () {
+      this.$emit('close')
+      webapi.queue_add(this.tracks.items.map(a => a.uri).join(','))
+    },
+
+    queue_add_next: function () {
+      this.$emit('close')
+      webapi.queue_add_next(this.tracks.items.map(a => a.uri).join(','))
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/web-src/src/pages/PageArtist.vue
+++ b/web-src/src/pages/PageArtist.vue
@@ -15,6 +15,7 @@
     </template>
     <template slot="content">
       <p class="heading has-text-centered-mobile">{{ artist.album_count }} albums | <a class="has-text-link" @click="open_tracks">{{ artist.track_count }} tracks</a></p>
+      <p class="heading has-text-centered-mobile"><a class="has-text-link" @click="open_toptracks">top tracks</a></p>
       <list-item-album v-for="album in albums.items" :key="album.id" :album="album" @click="open_album(album)">
         <template slot="actions">
           <a @click="open_dialog(album)">
@@ -68,6 +69,11 @@ export default {
   },
 
   methods: {
+    open_toptracks: function () {
+      this.show_details_modal = false
+      this.$router.push({ name: 'TopArtistTracks', params: { condition: 'songartistid is "' + this.artist.id + '" and media_kind is music', id: this.artist.name } })
+    },
+
     open_tracks: function () {
       this.$router.push({ path: '/music/artists/' + this.artist.id + '/tracks' })
     },

--- a/web-src/src/pages/PageGenre.vue
+++ b/web-src/src/pages/PageGenre.vue
@@ -19,6 +19,7 @@
       </template>
       <template slot="content">
         <p class="heading has-text-centered-mobile">{{ genre_albums.total }} albums | <a class="has-text-link" @click="open_tracks">tracks</a></p>
+        <p class="heading has-text-centered-mobile"><a class="has-text-link" @click="open_toptracks">top tracks</a></p>
         <list-item-albums v-for="album in genre_albums.items" :key="album.id" :album="album" @click="open_album(album)">
           <template slot="actions">
             <a @click="open_dialog(album)">
@@ -82,6 +83,11 @@ export default {
     open_tracks: function () {
       this.show_details_modal = false
       this.$router.push({ name: 'GenreTracks', params: { genre: this.name } })
+    },
+
+    open_toptracks: function () {
+      this.show_details_modal = false
+      this.$router.push({ name: 'TopGenreTracks', params: { condition: 'genre is "' + this.name + '" and media_kind is music', id: this.name } })
     },
 
     play: function () {

--- a/web-src/src/pages/PageGenreTracks.vue
+++ b/web-src/src/pages/PageGenreTracks.vue
@@ -19,6 +19,7 @@
       </template>
       <template slot="content">
         <p class="heading has-text-centered-mobile"><a class="has-text-link" @click="open_genre">albums</a> | {{ tracks.total }} tracks</p>
+        <p class="heading has-text-centered-mobile"><a class="has-text-link" @click="open_toptracks">top tracks</a></p>
         <list-item-track v-for="(track, index) in tracks.items" :key="track.id" :track="track" @click="play_track(index)">
           <template slot="actions">
             <a @click="open_dialog(track)">
@@ -81,6 +82,11 @@ export default {
     open_genre: function () {
       this.show_details_modal = false
       this.$router.push({ name: 'Genre', params: { genre: this.genre } })
+    },
+
+    open_toptracks: function () {
+      this.show_details_modal = false
+      this.$router.push({ name: 'TopGenreTracks', params: { condition: 'genre is "' + this.name + '" and media_kind is music', id: this.name } })
     },
 
     play: function () {

--- a/web-src/src/router/index.js
+++ b/web-src/src/router/index.js
@@ -22,6 +22,7 @@ import PageAudiobook from '@/pages/PageAudiobook'
 import PagePlaylists from '@/pages/PagePlaylists'
 import PagePlaylist from '@/pages/PagePlaylist'
 import PageFiles from '@/pages/PageFiles'
+import PageTopTracks from '@/pages/PageTopTracks'
 import PageSearch from '@/pages/PageSearch'
 import PageAbout from '@/pages/PageAbout'
 import SpotifyPageBrowse from '@/pages/SpotifyPageBrowse'
@@ -120,6 +121,30 @@ export const router = new VueRouter({
       name: 'GenreTracks',
       component: PageGenreTracks,
       meta: { show_progress: true, has_index: true }
+    },
+    {
+      path: '/music/arists/:artist_id/top',
+      name: 'TopArtistTracks',
+      component: PageTopTracks,
+      meta: { show_progress: true, has_tabs: true, has_index: true }
+    },
+    {
+      path: '/music/genres/:genre/top',
+      name: 'TopGenreTracks',
+      component: PageTopTracks,
+      meta: { show_progress: true, has_tabs: true, has_index: true }
+    },
+    {
+      path: '/music/arists/:artist_id/top',
+      name: 'TopArtistTracks',
+      component: PageTopTracks,
+      meta: { show_progress: true, has_tabs: true, has_index: true }
+    },
+    {
+      path: '/music/genres/:genre/top',
+      name: 'TopGenreTracks',
+      component: PageTopTracks,
+      meta: { show_progress: true, has_tabs: true, has_index: true }
     },
     {
       path: '/podcasts',


### PR DESCRIPTION
PR to add dynamically generated "top 10" of most `played tracks` for a given `artist` or `genre` on web ui.

New "top 10" tracks page linked from `Artist` and `Genre` pages respectively - uses SMARPL query to generate the top 10 tracks.