### PR TITLE
[configure] dynamically generate VERSION based on git tag/hash

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,8 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([forked-daapd], [26.5])
+AC_INIT([forked-daapd], m4_esyscmd([git describe --tags --dirty --always | tr -d '\n']))
+
 
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
The server's `VERSION` (shown in the log `Forked Media Server Version ... taking off` and provided to the web ui) is currently generated manually by modifying `configure.ac` but this value is only updated for mjr updates; this makes it difficult to look at log files to determine which (git) version has been used.

This PR will generate `VERSION` based on the git repo tag and last commit hash, ie: `26.3-257-g8e474dfd`;  not further manual commits to `configure.ac`

This relies on tags, update and pushed to repo and enforces good tagging process.  Currently the repo has `VERSION=26.5` but tag is out of sync as `26.3`