### PR TITLE
[web-src] save queue playlist

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -191,6 +191,16 @@ library {
 	# (played or skipped). Both results are combined with a mix-factor of 0.75:
 	# new rating = 0.75 * stable rating + 0.25 * rolling rating)
 #	rating_updates = false
+
+	# Allows creating, deleting and modifying m3u playlists in the library directories.
+	# Defaults to being disabled.
+#	allow_modifying_stored_playlists = false
+
+	# A directory in one of the library directories that will be used as the default
+	# playlist directory. forked-dapd creates new playlists in this directory if only
+	# a playlist name is provided by the mpd client (requires "allow_modify_stored_playlists"
+	# set to true).
+#	default_playlist_directory = ""
 }
 
 # Local audio output
@@ -320,16 +330,6 @@ mpd {
 	# the playlist like MPD does. Note that some dacp clients do not show
 	# the playqueue if playback is stopped.
 #	clear_queue_on_stop_disable = false
-
-	# Allows creating, deleting and modifying m3u playlists in the library directories.
-	# Defaults to being disabled.
-#	allow_modifying_stored_playlists = false
-
-	# A directory in one of the library directories that will be used as the default
-	# playlist directory. forked-dapd creates new playlists in this directory if only
-	# a playlist name is provided by the mpd client (requires "allow_modify_stored_playlists"
-	# set to true).
-#	default_playlist_directory = ""
 }
 
 # SQLite configuration (allows to modify the operation of the SQLite databases)

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -103,6 +103,8 @@ static cfg_opt_t sec_library[] =
     CFG_INT("pipe_sample_rate", 44100, CFGF_NONE),
     CFG_INT("pipe_bits_per_sample", 16, CFGF_NONE),
     CFG_BOOL("rating_updates", cfg_false, CFGF_NONE),
+    CFG_BOOL("allow_modifying_stored_playlists", cfg_false, CFGF_NONE),
+    CFG_STR("default_playlist_directory", NULL, CFGF_NONE),
     CFG_END()
   };
 
@@ -178,8 +180,6 @@ static cfg_opt_t sec_mpd[] =
     CFG_INT("port", 6600, CFGF_NONE),
     CFG_INT("http_port", 0, CFGF_NONE),
     CFG_BOOL("clear_queue_on_stop_disable", cfg_false, CFGF_NONE),
-    CFG_BOOL("allow_modifying_stored_playlists", cfg_false, CFGF_NONE),
-    CFG_STR("default_playlist_directory", NULL, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4843,8 +4843,8 @@ int mpd_init(void)
 	}
     }
 
-  allow_modifying_stored_playlists = cfg_getbool(cfg_getsec(cfg, "mpd"), "allow_modifying_stored_playlists");
-  pl_dir = cfg_getstr(cfg_getsec(cfg, "mpd"), "default_playlist_directory");
+  allow_modifying_stored_playlists = cfg_getbool(cfg_getsec(cfg, "library"), "allow_modifying_stored_playlists");
+  pl_dir = cfg_getstr(cfg_getsec(cfg, "library"), "default_playlist_directory");
   if (pl_dir)
     default_pl_dir = safe_asprintf("/file:%s", pl_dir);
 

--- a/web-src/src/components/ModalDialogPlaylistSave.vue
+++ b/web-src/src/components/ModalDialogPlaylistSave.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <transition name="fade">
+      <div class="modal is-active" v-if="show">
+        <div class="modal-background" @click="$emit('close')"></div>
+        <div class="modal-card">
+          <section class="modal-card-body">
+            <form v-on:submit.prevent="save">
+              <div class="field">
+                <p class="control is-expanded has-icons-left">
+                  <input class="input is-rounded is-shadowless" type="text" placeholder="playlist name" v-model="pls_name" ref="pls_name_field">
+                  <span class="icon is-left">
+                    <i class="mdi mdi-file-music"></i>
+                  </span>
+                </p>
+              </div>
+            </form>
+          </section>
+          <footer class="modal-card-foot">
+            <button class="button is-success" @click="save" :disabled="pls_name.length < 3">Save</button>
+            <button class="button" @click="$emit('close')">Cancel</button>
+          </footer>
+        </div>
+        <button class="modal-close is-large" aria-label="close" @click="$emit('close')"></button>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+import webapi from '@/webapi'
+
+export default {
+  name: 'ModalDialogPlaylistSave',
+  props: [ 'show' ],
+
+  data () {
+    return {
+      pls_name: ''
+    }
+  },
+
+  methods: {
+    save: function () {
+      this.$emit('close')
+      webapi.queue_save_playlist(this.pls_name)
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/web-src/src/pages/PageQueue.vue
+++ b/web-src/src/pages/PageQueue.vue
@@ -38,6 +38,12 @@
           </span>
           <span>Clear</span>
         </a>
+        <a class="button is-small" v-show="queue_items.length > 1" @click="save_dialog">
+          <span class="icon">
+            <i class="mdi mdi-content-save"></i>
+          </span>
+          <span>Save</span>
+        </a>
       </div>
     </template>
     <template slot="content">
@@ -58,6 +64,7 @@
           </list-item-queue-item>
       </draggable>
       <modal-dialog-queue-item :show="show_details_modal" :item="selected_item" @close="show_details_modal = false" />
+      <modal-dialog-playlist-save :show="show_pls_save_modal" @close="show_pls_save_modal = false" />
     </template>
   </content-with-heading>
 </template>
@@ -67,13 +74,14 @@ import ContentWithHeading from '@/templates/ContentWithHeading'
 import ListItemQueueItem from '@/components/ListItemQueueItem'
 import ModalDialogQueueItem from '@/components/ModalDialogQueueItem'
 import ModalDialogAddUrlStream from '@/components/ModalDialogAddUrlStream'
+import ModalDialogPlaylistSave from '@/components/ModalDialogPlaylistSave'
 import webapi from '@/webapi'
 import * as types from '@/store/mutation_types'
 import draggable from 'vuedraggable'
 
 export default {
   name: 'PageQueue',
-  components: { ContentWithHeading, ListItemQueueItem, draggable, ModalDialogQueueItem, ModalDialogAddUrlStream },
+  components: { ContentWithHeading, ListItemQueueItem, draggable, ModalDialogQueueItem, ModalDialogAddUrlStream, ModalDialogPlaylistSave },
 
   data () {
     return {
@@ -81,6 +89,7 @@ export default {
 
       show_details_modal: false,
       show_url_modal: false,
+      show_pls_save_modal: false,
       selected_item: {}
     }
   },
@@ -134,6 +143,10 @@ export default {
 
     add_stream_dialog: function (item) {
       this.show_url_modal = true
+    },
+
+    save_dialog: function (item) {
+      this.show_pls_save_modal = true
     }
   }
 }

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -83,6 +83,13 @@ export default {
     })
   },
 
+  queue_save_playlist (name) {
+    return axios.post('/api/queue/save', undefined, { params: { 'name': name } }).then((response) => {
+      store.dispatch('add_notification', { text: 'playlist saved', type: 'info', timeout: 2000 })
+      return Promise.resolve(response)
+    })
+  },
+
   player_status () {
     return axios.get('/api/player')
   },


### PR DESCRIPTION
This PR allows the server's play `queue` to be serialised to a `.pls` playlist file, under a configurable `playlist save directory` - a modal is used allow user to enter playlist name which is used as the filename.

![qplssave](https://user-images.githubusercontent.com/18466811/57161626-ecd69380-6de3-11e9-93a3-67e1647c87f2.png)

The `playlist save directory` is separate to the `directories` cfg option - if the `playlist save directory`path  is also included in `directories`, the server will add it to the library and user reselectable as a known playlist. 

A new REST endpoint `api/queue/save` to implement functionality to save Q to .pls file.

The `PageQueue` has also the `TabsMusic` banner added - this is an usability feature to let users get to albums/artist/genres *quickly* without the intermediary jump to `/music` which has a delay/incurrs extra db calls (recently added/recently played)