### PR TITLE
show media quality info now playing

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1632,6 +1632,12 @@ jsonapi_reply_player(struct httpd_request *hreq)
 	}
     }
 
+  json_object_object_add(reply, "sample_rate", json_object_new_int(status.quality.sample_rate));
+  json_object_object_add(reply, "bits_per_sample", json_object_new_int(status.quality.bits_per_sample));
+  json_object_object_add(reply, "channels", json_object_new_int(status.quality.channels));
+  json_object_object_add(reply, "bit_rate", json_object_new_int(status.quality.bit_rate));
+  safe_json_add_string(reply, "codec", status.quality.codec);
+
   CHECK_ERRNO(L_WEB, evbuffer_add_printf(hreq->reply, "%s", json_object_to_json_string(reply)));
 
   jparse_free(reply);

--- a/src/inputs/file_http.c
+++ b/src/inputs/file_http.c
@@ -44,6 +44,9 @@ setup(struct input_source *source)
   source->quality.bits_per_sample = transcode_encode_query(ctx->encode_ctx, "bits_per_sample");
   source->quality.channels = transcode_encode_query(ctx->encode_ctx, "channels");
 
+  source->quality.bit_rate = transcode_decode_query(ctx->decode_ctx, "audio_bit_rate");
+  source->quality.codec = transcode_decode_codec(ctx->decode_ctx);
+
   source->input_ctx = ctx;
 
   return 0;

--- a/src/inputs/file_http.c
+++ b/src/inputs/file_http.c
@@ -45,7 +45,7 @@ setup(struct input_source *source)
   source->quality.channels = transcode_encode_query(ctx->encode_ctx, "channels");
 
   source->quality.bit_rate = transcode_decode_query(ctx->decode_ctx, "audio_bit_rate");
-  source->quality.codec = transcode_decode_codec(ctx->decode_ctx);
+  source->quality.codec = transcode_decode_query_codec(ctx->decode_ctx);
 
   source->input_ctx = ctx;
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -31,6 +31,8 @@ struct media_quality {
   int sample_rate;
   int bits_per_sample;
   int channels;
+  int bit_rate;
+  const char *codec;  // not owned, do NOT free
 };
 
 struct onekeyval {

--- a/src/misc.h
+++ b/src/misc.h
@@ -32,7 +32,7 @@ struct media_quality {
   int bits_per_sample;
   int channels;
   int bit_rate;
-  const char *codec;  // not owned, do NOT free
+  const char *codec;
 };
 
 struct onekeyval {

--- a/src/player.c
+++ b/src/player.c
@@ -1678,6 +1678,17 @@ get_status(void *arg, int *retval)
 
   status->plid = cur_plid;
 
+  if (pb_session.playing_now == NULL)
+    memset(&status->quality, 0, sizeof(struct media_quality));
+  else
+    {
+      status->quality.sample_rate     = pb_session.playing_now->quality.sample_rate;
+      status->quality.bits_per_sample = pb_session.playing_now->quality.bits_per_sample;
+      status->quality.channels        = pb_session.playing_now->quality.channels;
+      status->quality.bit_rate        = pb_session.playing_now->quality.bit_rate;
+      status->quality.codec           = pb_session.playing_now->quality.codec;
+    }
+
   switch (player_state)
     {
       case PLAY_STOPPED:

--- a/src/player.c
+++ b/src/player.c
@@ -1678,23 +1678,13 @@ get_status(void *arg, int *retval)
 
   status->plid = cur_plid;
 
-  if (pb_session.playing_now == NULL)
-    memset(&status->quality, 0, sizeof(struct media_quality));
-  else
-    {
-      status->quality.sample_rate     = pb_session.playing_now->quality.sample_rate;
-      status->quality.bits_per_sample = pb_session.playing_now->quality.bits_per_sample;
-      status->quality.channels        = pb_session.playing_now->quality.channels;
-      status->quality.bit_rate        = pb_session.playing_now->quality.bit_rate;
-      status->quality.codec           = pb_session.playing_now->quality.codec;
-    }
-
   switch (player_state)
     {
       case PLAY_STOPPED:
 	DPRINTF(E_DBG, L_PLAYER, "Player status: stopped\n");
 
 	status->status  = PLAY_STOPPED;
+
 	break;
 
       case PLAY_PAUSED:
@@ -1706,6 +1696,8 @@ get_status(void *arg, int *retval)
 
 	status->pos_ms  = pb_session.playing_now->pos_ms;
 	status->len_ms  = pb_session.playing_now->len_ms;
+
+	status->quality = pb_session.playing_now->quality;
 
 	break;
 
@@ -1728,6 +1720,8 @@ get_status(void *arg, int *retval)
 
 	status->pos_ms  = pb_session.playing_now->pos_ms;
 	status->len_ms  = pb_session.playing_now->len_ms;
+
+	status->quality = pb_session.playing_now->quality;
 
 	break;
     }

--- a/src/player.h
+++ b/src/player.h
@@ -55,6 +55,8 @@ struct player_status {
   uint32_t pos_ms;
   /* Length in ms of playing item */
   uint32_t len_ms;
+
+  struct media_quality quality;
 };
 
 typedef void (*spk_enum_cb)(struct player_speaker_info *spk, void *arg);

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -1757,8 +1757,8 @@ transcode_decode_query(struct decode_ctx *ctx, const char *query)
 const char*
 transcode_decode_codec(struct decode_ctx *ctx)
 {
-  if (ctx->audio_stream.stream && ctx->audio_stream.stream->codec)
-    return avcodec_get_name(ctx->audio_stream.stream->codec->codec_id);
+  if (ctx->audio_stream.stream && ctx->audio_stream.stream->codecpar)
+    return avcodec_get_name(ctx->audio_stream.stream->codecpar->codec_id);
   else
     return "<unknown>";
 }

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -730,7 +730,12 @@ open_decoder(unsigned int *stream_index, struct decode_ctx *ctx, enum AVMediaTyp
   if ((*stream_index < 0) || (!decoder))
     {
       if (!ctx->settings.silent)
-	DPRINTF(E_LOG, L_XCODE, "No stream data or decoder for '%s'\n", ctx->ifmt_ctx->filename);
+	DPRINTF(E_LOG, L_XCODE, "No stream data or decoder for '%s'\n",
+#if LIBAVFORMAT_VERSION_MAJOR < 58 
+		ctx->ifmt_ctx->filename);
+#else
+		ctx->ifmt_ctx->url);
+#endif
       return NULL;
     }
 

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -1194,7 +1194,6 @@ transcode_encode_setup(enum transcode_profile profile, struct media_quality *qua
   int bps;
 
   CHECK_NULL(L_XCODE, ctx = calloc(1, sizeof(struct encode_ctx)));
-  memset(ctx, 0, sizeof(struct encode_ctx));
   CHECK_NULL(L_XCODE, ctx->filt_frame = av_frame_alloc());
   CHECK_NULL(L_XCODE, ctx->encoded_pkt = av_packet_alloc());
 
@@ -1295,7 +1294,6 @@ transcode_decode_setup_raw(enum transcode_profile profile, struct media_quality 
   int ret;
 
   CHECK_NULL(L_XCODE, ctx = calloc(1, sizeof(struct decode_ctx)));
-  memset(ctx, 0, sizeof(struct decode_ctx));
 
   if (init_settings(&ctx->settings, profile, quality) < 0)
     {
@@ -1755,7 +1753,7 @@ transcode_decode_query(struct decode_ctx *ctx, const char *query)
 }
 
 const char*
-transcode_decode_codec(struct decode_ctx *ctx)
+transcode_decode_query_codec(struct decode_ctx *ctx)
 {
   if (ctx->audio_stream.stream && ctx->audio_stream.stream->codecpar)
     return avcodec_get_name(ctx->audio_stream.stream->codecpar->codec_id);

--- a/src/transcode.h
+++ b/src/transcode.h
@@ -144,6 +144,14 @@ transcode_decode_query(struct decode_ctx *ctx, const char *query);
 int
 transcode_encode_query(struct encode_ctx *ctx, const char *query);
 
+/* string representation of the codec
+ *
+ * @in  ctx        decode context
+ * @return         static char* - never NULL, caller does NOT own
+ */
+const char*
+transcode_decode_codec(struct decode_ctx *ctx);
+
 // Metadata
 struct http_icy_metadata *
 transcode_metadata(struct transcode_ctx *ctx, int *changed);

--- a/src/transcode.h
+++ b/src/transcode.h
@@ -144,13 +144,13 @@ transcode_decode_query(struct decode_ctx *ctx, const char *query);
 int
 transcode_encode_query(struct encode_ctx *ctx, const char *query);
 
-/* string representation of the codec
+/* Name of the codec
  *
  * @in  ctx        decode context
- * @return         static char* - never NULL, caller does NOT own
+ * @return         static char* from ffmpeg - never NULL
  */
 const char*
-transcode_decode_codec(struct decode_ctx *ctx);
+transcode_decode_query_codec(struct decode_ctx *ctx);
 
 // Metadata
 struct http_icy_metadata *

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -24,6 +24,11 @@
         <span class="icon has-text-grey-light"><i class="mdi mdi-information-outline"></i></span>
       </a>
     </div>
+    <div class="container has-text-centered">
+      <div class="subtitle has-text-grey is-7" v-show="quality_sample_rate > 0">
+      {{ quality_codec}} {{ quality_sample_rate }} Hz | {{ quality_channels }} | {{ quality_bit_rate }} Kb/s
+      </div>
+    </div>
     <div class="hero-foot fd-has-padding-left-right">
       <div class="container has-text-centered fd-has-margin-bottom">
         <p class="control has-text-centered fd-progress-now-playing">
@@ -111,6 +116,22 @@ export default {
         return this.now_playing.artwork_url + '?maxwidth=600&maxheight=600'
       }
       return this.now_playing.artwork_url
+    },
+
+    quality_sample_rate: function () {
+      return this.state.sample_rate
+    },
+    quality_bits_per_sample: function () {
+      return this.state.bits_per_sample
+    },
+    quality_channels: function () {
+      return this.state.channels === 2 ? 'stereo' : this.state.channels + ' channel'
+    },
+    quality_bit_rate: function () {
+      return this.state.bit_rate / 1000
+    },
+    quality_codec: function () {
+      return this.state.codec
     }
   },
 

--- a/web-src/src/store/index.js
+++ b/web-src/src/store/index.js
@@ -29,7 +29,12 @@ export default new Vuex.Store({
       'volume': 0,
       'item_id': 0,
       'item_length_ms': 0,
-      'item_progress_ms': 0
+      'item_progress_ms': 0,
+      'sample_rate': 0,
+      'bits_per_sample': 0,
+      'channels': 0,
+      'bit_rate': 0,
+      'codec': ''
     },
     queue: {
       'version': 0,


### PR DESCRIPTION
With recent `player` changes, the server plays audio in their native formats / not locked at 44.1/16/2 and some users will want to know the input src being played.

This PR adds source `bit_rate` and input codec (ie mp3/flac/etc) to `media_quality` - this data is exposed in `player_status` which is displayed on `now playing` screen above the scrub head.

![media quality](https://user-images.githubusercontent.com/18466811/56081207-aaccba00-5e02-11e9-8dce-499a12bc4e1e.png)
