### PR TITLE
[web] now playing page add "stop" and "fast skip" buttons

### DIFF
--- a/web-src/src/components/PlayerButtonPlayStop.vue
+++ b/web-src/src/components/PlayerButtonPlayStop.vue
@@ -1,0 +1,34 @@
+<template>
+  <a v-on:click="toggle_play_stop">
+    <span class="icon"><i class="mdi" v-bind:class="[icon_style, { 'mdi-play': is_stopped, 'mdi-stop': !is_stopped }]"></i></span>
+  </a>
+</template>
+
+<script>
+import webapi from '@/webapi'
+
+export default {
+  name: 'PlayerButtonPlayStop',
+
+  props: ['icon_style'],
+
+  computed: {
+    is_stopped () {
+      return this.$store.state.player.state === 'stop'
+    }
+  },
+
+  methods: {
+    toggle_play_stop: function () {
+      if (this.is_stopped) {
+        webapi.player_play()
+      } else {
+        webapi.player_stop()
+      }
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/web-src/src/components/PlayerButtonSkipBack.vue
+++ b/web-src/src/components/PlayerButtonSkipBack.vue
@@ -1,6 +1,11 @@
 <template>
   <a v-on:click="play_skip_back">
-    <span class="icon"><i class="mdi mdi-replay"></i></span>
+    <i v-if="is_skip_allowed">
+      <span class="icon"><i class="mdi mdi-replay"></i></span>
+    </i>
+    <i v-else>
+      <span class="icon has-text-grey-light"><i class="mdi mdi-replay"></i></span>
+    </i>
   </a>
 </template>
 
@@ -11,9 +16,15 @@ export default {
   name: 'PlayerButtonSkipBack',
   props: [ 'when_ms' ],
 
+  computed: {
+    is_skip_allowed () {
+      return this.$store.state.player.state !== 'stop' && this.$store.getters.now_playing && this.$store.getters.now_playing.data_kind !== 'url' && this.$store.getters.now_playing.data_kind !== 'pipe'
+    }
+  },
+
   methods: {
     play_skip_back: function () {
-      if (this.$store.state.player.state !== 'stop') {
+      if (this.is_skip_allowed) {
         webapi.player_seek(this.when_ms - 10000)
       }
     }

--- a/web-src/src/components/PlayerButtonSkipBack.vue
+++ b/web-src/src/components/PlayerButtonSkipBack.vue
@@ -1,0 +1,25 @@
+<template>
+  <a v-on:click="play_skip_back">
+    <span class="icon"><i class="mdi mdi-replay"></i></span>
+  </a>
+</template>
+
+<script>
+import webapi from '@/webapi'
+
+export default {
+  name: 'PlayerButtonSkipBack',
+  props: [ 'when_ms' ],
+
+  methods: {
+    play_skip_back: function () {
+      if (this.$store.state.player.state !== 'stop') {
+        webapi.player_seek(this.when_ms - 10000)
+      }
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/web-src/src/components/PlayerButtonSkipFwd.vue
+++ b/web-src/src/components/PlayerButtonSkipFwd.vue
@@ -1,6 +1,11 @@
 <template>
   <a v-on:click="play_skip_fwd">
-    <span class="icon"><i class="mdi mdi-flip-h mdi-replay"></i></span>
+    <i v-if="is_skip_allowed">
+      <span class="icon"><i class="mdi mdi-flip-h mdi-replay"></i></span>
+    </i>
+    <i v-else>
+      <span class="icon has-text-grey-light"><i class="mdi mdi-flip-h mdi-replay"></i></span>
+    </i>
   </a>
 </template>
 
@@ -11,9 +16,15 @@ export default {
   name: 'PlayerButtonSkipFwd',
   props: [ 'when_ms' ],
 
+  computed: {
+    is_skip_allowed () {
+      return this.$store.state.player.state !== 'stop' && this.$store.getters.now_playing && this.$store.getters.now_playing.data_kind !== 'url' && this.$store.getters.now_playing.data_kind !== 'pipe'
+    }
+  },
+
   methods: {
     play_skip_fwd: function () {
-      if (this.$store.state.player.state !== 'stop') {
+      if (this.is_skip_allowed) {
         webapi.player_seek(this.when_ms + 10000)
       }
     }

--- a/web-src/src/components/PlayerButtonSkipFwd.vue
+++ b/web-src/src/components/PlayerButtonSkipFwd.vue
@@ -1,0 +1,25 @@
+<template>
+  <a v-on:click="play_skip_fwd">
+    <span class="icon"><i class="mdi mdi-flip-h mdi-replay"></i></span>
+  </a>
+</template>
+
+<script>
+import webapi from '@/webapi'
+
+export default {
+  name: 'PlayerButtonSkipFwd',
+  props: [ 'when_ms' ],
+
+  methods: {
+    play_skip_fwd: function () {
+      if (this.$store.state.player.state !== 'stop') {
+        webapi.player_seek(this.when_ms + 10000)
+      }
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -56,7 +56,7 @@
 
 <script>
 import ModalDialogQueueItem from '@/components/ModalDialogQueueItem'
-import PlayerButtonPlayPause from '@/components/PlayerButtonPlayPause'
+import PlayerButtonPlayStop from '@/components/PlayerButtonPlayStop'
 import PlayerButtonNext from '@/components/PlayerButtonNext'
 import PlayerButtonPrevious from '@/components/PlayerButtonPrevious'
 import PlayerButtonShuffle from '@/components/PlayerButtonShuffle'
@@ -68,7 +68,7 @@ import * as types from '@/store/mutation_types'
 
 export default {
   name: 'PageNowPlaying',
-  components: { ModalDialogQueueItem, PlayerButtonPlayPause, PlayerButtonNext, PlayerButtonPrevious, PlayerButtonShuffle, PlayerButtonConsume, PlayerButtonRepeat, RangeSlider },
+  components: { ModalDialogQueueItem, PlayerButtonPlayStop, PlayerButtonNext, PlayerButtonPrevious, PlayerButtonShuffle, PlayerButtonConsume, PlayerButtonRepeat, RangeSlider },
 
   data () {
     return {

--- a/web-src/src/pages/PageNowPlaying.vue
+++ b/web-src/src/pages/PageNowPlaying.vue
@@ -40,13 +40,25 @@
         <p class="content">
           <span>{{ item_progress_ms | duration }} / {{ now_playing.length_ms | duration }}</span>
         </p>
-        <div class="buttons has-addons is-centered">
-          <player-button-previous class="button is-medium"></player-button-previous>
-          <player-button-play-pause class="button is-medium" icon_style="mdi-36px"></player-button-play-pause>
-          <player-button-next class="button is-medium"></player-button-next>
-          <player-button-repeat class="button is-medium is-light"></player-button-repeat>
-          <player-button-shuffle class="button is-medium is-light"></player-button-shuffle>
-          <player-button-consume class="button is-medium is-light"></player-button-consume>
+        <div class="buttons has-addons is-centered" style="margin-bottom: 0;">
+          <div>
+            <player-button-skip-back class="button is-small is-rounded is-white" :when_ms="item_progress_ms"></player-button-skip-back>
+          </div>
+          <div>
+            <player-button-previous class="button is-medium is-rounded is-white"></player-button-previous>
+            <player-button-play-stop class="button is-medium is-rounded is-white" icon_style="mdi-24px"></player-button-play-stop>
+            <player-button-next class="button is-medium is-rounded is-white"></player-button-next>
+          </div>
+          <div>
+            <player-button-skip-fwd class="button is-small is-rounded is-white" :when_ms="item_progress_ms"></player-button-skip-fwd>
+          </div>
+        </div>
+        <div class="buttons is-centered">
+          <div>
+            <player-button-repeat class="button is-small is-rounded is-light"></player-button-repeat>
+            <player-button-shuffle class="button is-small is-rounded is-light"></player-button-shuffle>
+            <player-button-consume class="button is-small is-rounded is-light"></player-button-consume>
+          </div>
         </div>
       </div>
       <modal-dialog-queue-item :show="show_details_modal" :item="selected_item" @close="show_details_modal = false" />
@@ -62,13 +74,15 @@ import PlayerButtonPrevious from '@/components/PlayerButtonPrevious'
 import PlayerButtonShuffle from '@/components/PlayerButtonShuffle'
 import PlayerButtonConsume from '@/components/PlayerButtonConsume'
 import PlayerButtonRepeat from '@/components/PlayerButtonRepeat'
+import PlayerButtonSkipBack from '@/components/PlayerButtonSkipBack'
+import PlayerButtonSkipFwd from '@/components/PlayerButtonSkipFwd'
 import RangeSlider from 'vue-range-slider'
 import webapi from '@/webapi'
 import * as types from '@/store/mutation_types'
 
 export default {
   name: 'PageNowPlaying',
-  components: { ModalDialogQueueItem, PlayerButtonPlayStop, PlayerButtonNext, PlayerButtonPrevious, PlayerButtonShuffle, PlayerButtonConsume, PlayerButtonRepeat, RangeSlider },
+  components: { ModalDialogQueueItem, PlayerButtonPlayStop, PlayerButtonNext, PlayerButtonPrevious, PlayerButtonShuffle, PlayerButtonConsume, PlayerButtonRepeat, PlayerButtonSkipBack, PlayerButtonSkipFwd, RangeSlider },
 
   data () {
     return {


### PR DESCRIPTION
Two small functionality updates for `now playing` page.

* replace duplicate `pause` button with `stop` on main page (the other `pause` button is in the footer, bottom right) so that we can put the server in a `stopped` play state
* add `fast skip` (10sec fwd or back) buttons - useful for long podcasts where moving the playhead is not accurate on smartphone screen
* restyling of buttons to be less 'clunky' which has IOS misrendering the right edge of the `next` button

![Screenshot from 2019-04-25 15-22-22](https://user-images.githubusercontent.com/18466811/56743178-00dc1e80-676e-11e9-8ddf-70e7ff84774e.png)
