### PR TITLE
Seekable http streams

### DIFF
--- a/src/inputs/file_http.c
+++ b/src/inputs/file_http.c
@@ -121,6 +121,15 @@ seek(struct input_source *source, int seek_ms)
 }
 
 static int
+seek_http(struct input_source *source, int seek_ms)
+{
+  // stream is live/unknown length so obvs can't seek
+  if (source->len_ms == 0)
+    return -1;
+  return transcode_seek(source->input_ctx, seek_ms);
+}
+
+static int
 metadata_get_http(struct input_metadata *metadata, struct input_source *source)
 {
   struct http_icy_metadata *m;
@@ -168,4 +177,5 @@ struct input_definition input_http =
   .play = play,
   .stop = stop,
   .metadata_get = metadata_get_http,
+  .seek = seek_http
 };

--- a/web-src/src/components/PlayerButtonPlayPause.vue
+++ b/web-src/src/components/PlayerButtonPlayPause.vue
@@ -18,7 +18,10 @@ export default {
     },
 
     is_pause_allowed () {
-      return this.$store.getters.now_playing && this.$store.getters.now_playing.data_kind !== 'url' && this.$store.getters.now_playing.data_kind !== 'pipe'
+      return this.$store.getters.now_playing &&
+        (this.$store.getters.now_playing.data_kind === 'file' ||
+          ((this.$store.getters.now_playing.data_kind === 'url' && this.$store.state.player.item_length_ms !== 0) && this.$store.getters.now_playing.data_kind !== 'pipe')
+        )
     }
   },
 


### PR DESCRIPTION
some http streams (such as ones that mp3 files hosted on the web) are seekable whilst others (live internet radio sterams) are not.

Seekable determined if we have non-zero length