### PR TITLE
[web-src] missing modal display for URL stream (20c36cb48)

### DIFF
--- a/web-src/src/pages/PageQueue.vue
+++ b/web-src/src/pages/PageQueue.vue
@@ -58,6 +58,7 @@
           </list-item-queue-item>
       </draggable>
       <modal-dialog-queue-item :show="show_details_modal" :item="selected_item" @close="show_details_modal = false" />
+      <modal-dialog-add-url-stream :show="show_url_modal" @close="show_url_modal = false" />
     </template>
   </content-with-heading>
 </template>


### PR DESCRIPTION
Previous PR missing the display of the modal to enter URL stream - was in my integration branch but got missed on the submitted PR