### PR TITLE
[conf] Gracefully handle the change of config options for modifying playlists

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,7 @@ FORK_FUNC_REQUIRE([COMMON], [GNU libunistring], [LIBUNISTRING], [unistring],
 		[unistring], [u8_strconv_from_locale], [uniconv.h])])
 
 FORK_MODULES_CHECK([FORKED], [ZLIB], [zlib], [deflate], [zlib.h])
-FORK_MODULES_CHECK([FORKED], [CONFUSE], [libconfuse], [cfg_init], [confuse.h])
+FORK_MODULES_CHECK([FORKED], [CONFUSE], [libconfuse >= 3.0.0], [cfg_init], [confuse.h])
 FORK_MODULES_CHECK([FORKED], [MINIXML], [mxml], [mxmlNewElement], [mxml.h],
 	[AC_CHECK_FUNCS([mxmlGetOpaque] [mxmlGetText] [mxmlGetType] [mxmlGetFirstChild])])
 

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -193,13 +193,13 @@ library {
 #	rating_updates = false
 
 	# Allows creating, deleting and modifying m3u playlists in the library directories.
+	# Only supported by the player web interface and some mpd clients
 	# Defaults to being disabled.
 #	allow_modifying_stored_playlists = false
 
 	# A directory in one of the library directories that will be used as the default
 	# playlist directory. forked-dapd creates new playlists in this directory if only
-	# a playlist name is provided by the mpd client (requires "allow_modify_stored_playlists"
-	# set to true).
+	# a playlist name is provided (requires "allow_modify_stored_playlists" set to true).
 #	default_playlist_directory = ""
 }
 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -180,6 +180,8 @@ static cfg_opt_t sec_mpd[] =
     CFG_INT("port", 6600, CFGF_NONE),
     CFG_INT("http_port", 0, CFGF_NONE),
     CFG_BOOL("clear_queue_on_stop_disable", cfg_false, CFGF_NONE),
+    CFG_BOOL("allow_modifying_stored_playlists", cfg_false, CFGF_NODEFAULT | CFGF_DEPRECATED),
+    CFG_STR("default_playlist_directory", NULL, CFGF_NODEFAULT | CFGF_DEPRECATED),
     CFG_END()
   };
 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -206,6 +206,19 @@ uid_t runas_uid;
 gid_t runas_gid;
 
 
+static void
+logger_confuse(cfg_t *cfg, const char *format, va_list args)
+{
+  char fmt[80];
+
+  if (cfg && cfg->name && cfg->line)
+    snprintf(fmt, sizeof(fmt), "[%s:%d] %s\n", cfg->name, cfg->line, format);
+  else
+    snprintf(fmt, sizeof(fmt), "%s\n", format);
+
+  DVPRINTF(E_LOG, L_CONF, fmt, args);
+}
+
 static int
 cb_loglevel(cfg_t *cfg, cfg_opt_t *opt, const char *value, void *result)
 {
@@ -354,6 +367,8 @@ conffile_load(char *file)
   int ret;
 
   cfg = cfg_init(toplvl_cfg, CFGF_NONE);
+
+  cfg_set_error_function(cfg, logger_confuse);
 
   ret = cfg_parse(cfg, file);
 

--- a/src/logger.c
+++ b/src/logger.c
@@ -175,6 +175,17 @@ DPRINTF(int severity, int domain, const char *fmt, ...)
 }
 
 void
+DVPRINTF(int severity, int domain, const char *fmt, va_list ap)
+{
+  // If domain and severity do not match the current log configuration, return early to
+  // safe some unnecessary code execution (tiny performance gain)
+  if (logger_initialized && (!((1 << domain) & logdomains) || (severity > threshold)))
+    return;
+
+  vlogger(severity, domain, fmt, ap);
+}
+
+void
 logger_ffmpeg(void *ptr, int level, const char *fmt, va_list ap)
 {
   int severity;

--- a/src/logger.h
+++ b/src/logger.h
@@ -53,6 +53,9 @@ void
 DPRINTF(int severity, int domain, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 
 void
+DVPRINTF(int severity, int domain, const char *fmt, va_list ap);
+
+void
 logger_ffmpeg(void *ptr, int level, const char *fmt, va_list ap);
 
 void

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -4848,6 +4848,21 @@ int mpd_init(void)
   if (pl_dir)
     default_pl_dir = safe_asprintf("/file:%s", pl_dir);
 
+  /* Handle deprecated config options */
+  if (0 < cfg_opt_size(cfg_getopt(cfg_getsec(cfg, "mpd"), "allow_modifying_stored_playlists")))
+    {
+      DPRINTF(E_LOG, L_MPD, "Found deprecated option 'allow_modifying_stored_playlists' in section 'mpd', please update configuration file (move option to section 'library').\n");
+      allow_modifying_stored_playlists = cfg_getbool(cfg_getsec(cfg, "mpd"), "allow_modifying_stored_playlists");
+    }
+  if (0 < cfg_opt_size(cfg_getopt(cfg_getsec(cfg, "mpd"), "default_playlist_directory")))
+    {
+      DPRINTF(E_LOG, L_MPD, "Found deprecated option 'default_playlist_directory' in section 'mpd', please update configuration file (move option to section 'library').\n");
+      free(default_pl_dir);
+      pl_dir = cfg_getstr(cfg_getsec(cfg, "mpd"), "default_playlist_directory");
+      if (pl_dir)
+        default_pl_dir = safe_asprintf("/file:%s", pl_dir);
+    }
+
   DPRINTF(E_INFO, L_MPD, "mpd thread init\n");
 
   ret = pthread_create(&tid_mpd, NULL, mpd, NULL);


### PR DESCRIPTION
@ejurgensen I think it would be best not to break existing config files. This pr readds the old options in the 'mpd' section and displays a deprecation error in the log if they are present.

In a future version the deprecated options could then be dropped completely.