### PR TITLE
[library] support forced metadata scan of library

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,9 @@ Now you can make a cron job that runs this command:
 When forked-daapd detects a file with filename ending .init-rescan it will
 perform a bulk scan similar to the startup scan.
 
+Alternatively, you can force a metadata scan of the library even if the
+files have not changed by creating a filename ending `.meta-rescan`.
+
 
 ### Troubleshooting library issues
 

--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -1658,7 +1658,7 @@ curl -X PUT "http://localhost:3689/api/update"
 }
 ```
 
-### Trigger meta rescan
+### Trigger metadata rescan
 
 Trigger a library metadata rescan even if files have not been updated.  Maintenence method.
 

--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -723,6 +723,7 @@ curl -X PUT "http://localhost:3689/api/queue/items/2"
 | GET       | [/api/library/count](#get-count-of-tracks-artists-and-albums) | Get count of tracks, artists and albums |
 | GET       | [/api/library/files](#list-local-directories)               | Get list of directories in the local library    |
 | GET       | [/api/update](#trigger-rescan)                              | Trigger a library rescan             |
+| GET       | [/api/update/meta](#trigger-meta-rescan)                    | Trigger a library metadata rescan    |
 
 
 
@@ -1657,6 +1658,25 @@ curl -X GET "http://localhost:3689/api/update"
 }
 ```
 
+### Trigger meta rescan
+
+Trigger a library metadata rescan even if files have not been updated.  Maintenence method.
+
+**Endpoint**
+
+```http
+GET /api/update/meta
+```
+
+**Response**
+
+On success returns the HTTP `204 No Content` success status response code.
+
+**Example**
+
+```shell
+curl -X GET "http://localhost:3689/api/update/meta"
+```
 
 
 ## Search

--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -722,7 +722,7 @@ curl -X PUT "http://localhost:3689/api/queue/items/2"
 | GET       | [/api/library/genres](#list-genres)                         | Get list of genres                   |
 | GET       | [/api/library/count](#get-count-of-tracks-artists-and-albums) | Get count of tracks, artists and albums |
 | GET       | [/api/library/files](#list-local-directories)               | Get list of directories in the local library    |
-| GET       | [/api/update](#trigger-rescan)                              | Trigger a library rescan             |
+| PUT       | [/api/update](#trigger-rescan)                              | Trigger a library rescan             |
 | PUT       | [/api/rescan](#trigger-meta-rescan)                         | Trigger a library metadata rescan    |
 
 
@@ -1633,7 +1633,7 @@ Trigger a library rescan
 **Endpoint**
 
 ```http
-GET /api/update
+PUT /api/update
 ```
 
 **Response**
@@ -1643,7 +1643,7 @@ On success returns the HTTP `204 No Content` success status response code.
 **Example**
 
 ```shell
-curl -X GET "http://localhost:3689/api/update"
+curl -X PUT "http://localhost:3689/api/update"
 ```
 
 ```json

--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -723,7 +723,7 @@ curl -X PUT "http://localhost:3689/api/queue/items/2"
 | GET       | [/api/library/count](#get-count-of-tracks-artists-and-albums) | Get count of tracks, artists and albums |
 | GET       | [/api/library/files](#list-local-directories)               | Get list of directories in the local library    |
 | GET       | [/api/update](#trigger-rescan)                              | Trigger a library rescan             |
-| GET       | [/api/update/meta](#trigger-meta-rescan)                    | Trigger a library metadata rescan    |
+| PUT       | [/api/rescan](#trigger-meta-rescan)                         | Trigger a library metadata rescan    |
 
 
 
@@ -1665,7 +1665,7 @@ Trigger a library metadata rescan even if files have not been updated.  Maintene
 **Endpoint**
 
 ```http
-GET /api/update/meta
+PUT /api/rescan
 ```
 
 **Response**
@@ -1675,7 +1675,7 @@ On success returns the HTTP `204 No Content` success status response code.
 **Example**
 
 ```shell
-curl -X GET "http://localhost:3689/api/update/meta"
+curl -X PUT "http://localhost:3689/api/rescan"
 ```
 
 

--- a/htdocs/admin.html
+++ b/htdocs/admin.html
@@ -97,6 +97,8 @@
       <div class="column is-7 content">
         <a class="button" v-on:click="update" v-show="!library.updating">Update library</a>
         <p v-show="library.updating">Update in progress ...</p>
+        <a class="button" v-on:click="update_meta" v-show="!library.updating">Rescan library meta</a>
+        <p v-show="library.updating">Rescan in progress ...</p>
       </div>
     </div>
 

--- a/htdocs/admin.html
+++ b/htdocs/admin.html
@@ -97,8 +97,7 @@
       <div class="column is-7 content">
         <a class="button" v-on:click="update" v-show="!library.updating">Update library</a>
         <p v-show="library.updating">Update in progress ...</p>
-        <a class="button" v-on:click="update_meta" v-show="!library.updating">Rescan library meta</a>
-        <p v-show="library.updating">Rescan in progress ...</p>
+        <a class="button" v-on:click="update_meta" v-show="!library.updating">Rescan library</a>
       </div>
     </div>
 

--- a/htdocs/admin/js/forked-daapd.js
+++ b/htdocs/admin/js/forked-daapd.js
@@ -53,7 +53,7 @@ var app = new Vue({
 
     update: function() {
       this.library.updating = true;
-      axios.get('/api/update').then(console.log('Library is updating'));
+      axios.put('/api/update').then(console.log('Library is updating'));
     },
 
     update_meta: function() {

--- a/htdocs/admin/js/forked-daapd.js
+++ b/htdocs/admin/js/forked-daapd.js
@@ -58,7 +58,7 @@ var app = new Vue({
 
     update_meta: function() {
       this.library.updating = true;
-      axios.get('/api/update/meta').then(console.log('Library is rescanning meta'));
+      axios.put('/api/rescan').then(console.log('Library is rescanning meta'));
     },
 
     kickoffPairing: function() {

--- a/htdocs/admin/js/forked-daapd.js
+++ b/htdocs/admin/js/forked-daapd.js
@@ -56,6 +56,11 @@ var app = new Vue({
       axios.get('/api/update').then(console.log('Library is updating'));
     },
 
+    update_meta: function() {
+      this.library.updating = true;
+      axios.get('/api/update/meta').then(console.log('Library is rescanning meta'));
+    },
+
     kickoffPairing: function() {
       axios.post('/api/pairing', this.pairing_req).then(response => {
         console.log('Kicked off pairing');

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -787,6 +787,14 @@ jsonapi_reply_update(struct httpd_request *hreq)
   return HTTP_NOCONTENT;
 }
 
+static int
+jsonapi_reply_meta_update(struct httpd_request *hreq)
+{
+  library_metarescan();
+  return HTTP_NOCONTENT;
+}
+
+
 /*
  * Endpoint to retrieve information about the spotify integration
  *
@@ -3510,6 +3518,7 @@ static struct httpd_uri_map adm_handlers[] =
     { EVHTTP_REQ_GET,    "^/api/config$",                                jsonapi_reply_config },
     { EVHTTP_REQ_GET,    "^/api/library$",                               jsonapi_reply_library },
     { EVHTTP_REQ_GET,    "^/api/update$",                                jsonapi_reply_update },
+    { EVHTTP_REQ_GET,    "^/api/update/meta$",                           jsonapi_reply_meta_update },
     { EVHTTP_REQ_POST,   "^/api/spotify-login$",                         jsonapi_reply_spotify_login },
     { EVHTTP_REQ_GET,    "^/api/spotify$",                               jsonapi_reply_spotify },
     { EVHTTP_REQ_GET,    "^/api/pairing$",                               jsonapi_reply_pairing_get },

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3517,7 +3517,8 @@ static struct httpd_uri_map adm_handlers[] =
   {
     { EVHTTP_REQ_GET,    "^/api/config$",                                jsonapi_reply_config },
     { EVHTTP_REQ_GET,    "^/api/library$",                               jsonapi_reply_library },
-    { EVHTTP_REQ_GET,    "^/api/update$",                                jsonapi_reply_update },
+    { EVHTTP_REQ_GET |
+      EVHTTP_REQ_PUT,    "^/api/update$",                                jsonapi_reply_update },
     { EVHTTP_REQ_PUT,    "^/api/rescan$",                                jsonapi_reply_meta_rescan },
     { EVHTTP_REQ_POST,   "^/api/spotify-login$",                         jsonapi_reply_spotify_login },
     { EVHTTP_REQ_GET,    "^/api/spotify$",                               jsonapi_reply_spotify },

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -788,7 +788,7 @@ jsonapi_reply_update(struct httpd_request *hreq)
 }
 
 static int
-jsonapi_reply_meta_update(struct httpd_request *hreq)
+jsonapi_reply_meta_rescan(struct httpd_request *hreq)
 {
   library_metarescan();
   return HTTP_NOCONTENT;
@@ -3518,7 +3518,7 @@ static struct httpd_uri_map adm_handlers[] =
     { EVHTTP_REQ_GET,    "^/api/config$",                                jsonapi_reply_config },
     { EVHTTP_REQ_GET,    "^/api/library$",                               jsonapi_reply_library },
     { EVHTTP_REQ_GET,    "^/api/update$",                                jsonapi_reply_update },
-    { EVHTTP_REQ_GET,    "^/api/update/meta$",                           jsonapi_reply_meta_update },
+    { EVHTTP_REQ_PUT,    "^/api/rescan$",                                jsonapi_reply_meta_rescan },
     { EVHTTP_REQ_POST,   "^/api/spotify-login$",                         jsonapi_reply_spotify_login },
     { EVHTTP_REQ_GET,    "^/api/spotify$",                               jsonapi_reply_spotify },
     { EVHTTP_REQ_GET,    "^/api/pairing$",                               jsonapi_reply_pairing_get },

--- a/src/library.h
+++ b/src/library.h
@@ -62,6 +62,11 @@ struct library_source
   int (*rescan)(void);
 
   /*
+   * Run a metadata rescan of library even if files not changed (called from the library thread)
+   */
+  int (*metarescan)(void);
+
+  /*
    * Run a full rescan (purge library entries and rescan) (called from the library thread)
    */
   int (*fullrescan)(void);
@@ -98,6 +103,9 @@ library_queue_add(const char *path, int position, int *count, int *new_item_id);
 
 void
 library_rescan();
+
+void
+library_metarescan();
 
 void
 library_fullrescan();

--- a/web-src/src/pages/PageAbout.vue
+++ b/web-src/src/pages/PageAbout.vue
@@ -24,8 +24,9 @@
                 </div>
 
                 <!-- Right side -->
-                <div class="level-right">
+                <div class="level-right buttons">
                   <a class="button is-small is-outlined is-link" :class="{ 'is-loading': library.updating }" @click="update">Update</a>
+                  <a class="button is-small is-outlined is-link" :class="{ 'is-loading': library.updating }" @click="update_meta">Force Meta Rescan</a>
                 </div>
               </nav>
 
@@ -95,6 +96,10 @@ export default {
   methods: {
     update: function () {
       webapi.library_update()
+    },
+
+    update_meta: function () {
+      webapi.library_update_meta()
     }
   },
 

--- a/web-src/src/pages/PageAbout.vue
+++ b/web-src/src/pages/PageAbout.vue
@@ -99,7 +99,7 @@ export default {
     },
 
     update_meta: function () {
-      webapi.library_update_meta()
+      webapi.library_rescan()
     }
   },
 

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -21,6 +21,10 @@ export default {
     return axios.get('/api/update')
   },
 
+  library_update_meta () {
+    return axios.get('/api/update/meta')
+  },
+
   library_count (expression) {
     return axios.get('/api/library/count?expression=' + expression)
   },

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -21,7 +21,7 @@ export default {
     return axios.put('/api/update')
   },
 
-  library_update_meta () {
+  library_rescan() {
     return axios.put('/api/rescan')
   },
 

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -22,7 +22,7 @@ export default {
   },
 
   library_update_meta () {
-    return axios.get('/api/update/meta')
+    return axios.put('/api/rescan')
   },
 
   library_count (expression) {

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -18,7 +18,7 @@ export default {
   },
 
   library_update () {
-    return axios.get('/api/update')
+    return axios.put('/api/update')
   },
 
   library_update_meta () {


### PR DESCRIPTION
Provide a 1/2 way house between `.init-rescan` (relies on new files or files that have changed but not picked up by server) or the `.full-scan` which drops `forked-daapd` generated/maintained data from the `files` table such as `play_count` etc.

This is useful in situations where the server supports more metadata (such as 35a585c23eab873a22aeb41232aaaabbfb24ae5e now supporting MusicBrainz tags) but we want to maintain generated meta in library that would get killed otherwise/having to manually touch/update individual files to force a normal meta-rescan 