### PR TITLE
[alsa] asoundlib.h should be alsa/asoundlib.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,7 +238,7 @@ AC_CHECK_SIZEOF([void *])
 dnl --- Begin configuring the options ---
 dnl ALSA
 FORK_ARG_WITH_CHECK([FORKED_OPTS], [ALSA support], [alsa], [ALSA],
-	[alsa], [snd_mixer_open], [asoundlib.h])
+	[alsa], [snd_mixer_open], [alsa/asoundlib.h])
 AM_CONDITIONAL([COND_ALSA], [[test "x$with_alsa" = "xyes"]])
 
 dnl PULSEAUDIO

--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 
-#include <asoundlib.h>
+#include <alsa/asoundlib.h>
 
 #include "misc.h"
 #include "conffile.h"


### PR DESCRIPTION
Compiling on Fedora 30 doesn't appear to include /usr/include/sys by default, so the long deprecated sys/asoundlib.h isn't found on a build with ALSA.  It appears that asoundlib.h has been in alsa/asoundlib.h for well over 10 years, and other projects all just include <alsa/asoundlib.h>, so this patch does exactly that. :)
