### PR TITLE
[smartpl] generate dynamic dates for SMARTPL queries

### DIFF
--- a/src/SMARTPL2SQL.g
+++ b/src/SMARTPL2SQL.g
@@ -38,19 +38,6 @@ options {
 }
 
 @members {
-    static time_t startoftoday()
-    {
-        struct tm tm;
-        time_t now;
-
-        time(&now);
-        localtime_r(&now, &tm);
-        tm.tm_sec  = 0;
-        tm.tm_min  = 0;
-        tm.tm_hour = 0;
-
-	return mktime(&tm);
-    }
 }
 
 playlist	returns [ pANTLR3_STRING title, pANTLR3_STRING query, pANTLR3_STRING orderby, pANTLR3_STRING having, int limit ]
@@ -213,25 +200,18 @@ expression	returns [ pANTLR3_STRING result, pANTLR3_STRING orderby, pANTLR3_STRI
 		}
 	|	DATETAG AFTER dateval
 		{
-			char str[15];
-			sprintf(str, "\%d", $dateval.result);
-			
 			$result = $DATETAG.text->factory->newRaw($DATETAG.text->factory);
 			$result->append8($result, "f.");
 			$result->appendS($result, $DATETAG.text->toUTF8($DATETAG.text));
 			$result->append8($result, " > ");
-			$result->append8($result, str);
+			$result->appendS($result, $dateval.result);
 		}
 	|	DATETAG BEFORE dateval
 		{
-			char str[15];
-			sprintf(str, "\%d", $dateval.result);
-			
-			$result = $DATETAG.text->factory->newRaw($DATETAG.text->factory);
 			$result->append8($result, "f.");
 			$result->appendS($result, $DATETAG.text->toUTF8($DATETAG.text));
 			$result->append8($result, " < ");
-			$result->append8($result, str);
+			$result->appendS($result, $dateval.result);
 		}
 	|	ENUMTAG IS ENUMVAL
 		{
@@ -328,118 +308,122 @@ ordertag	returns [ pANTLR3_STRING result ]
 		}
 	;
 
-dateval		returns [ int result ]
+dateval		returns [ pANTLR3_STRING result ]
 @init { $result = 0; }
 	:	DATE
 		{
 			pANTLR3_UINT8 datval;
 			
 			datval = $DATE.text->chars;
-			
+
+			$result = $DATE.text->factory->newRaw($DATE.text->factory);
+
 			if (strcmp((char *)datval, "today") == 0)
 			{
-				$result = startoftoday();
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', 'localtime'))");
 			}
 			else if (strcmp((char *)datval, "yesterday") == 0)
 			{
-				$result = startoftoday() - 24 * 3600;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 day', 'localtime'))");
 			}
 			else if (strcmp((char *)datval, "last week") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 7;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-7 days', 'localtime'))");
 			}
 			else if (strcmp((char *)datval, "last month") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 30;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 month', 'localtime'))");
 			}
 			else if (strcmp((char *)datval, "last year") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 365;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 year', 'localtime'))");
 			}
 			else
 			{
-				struct tm tm;
-				char year[5];
-				char month[3];
-				char day[3];
-				
-				memset((void*)&tm,0,sizeof(tm));
-				memset(year, 0, sizeof(year));
-				memset(month, 0, sizeof(month));
-				memset(day, 0, sizeof(day));
-
-				strncpy(year, (const char *)datval, 4);
-				strncpy(month, (const char *)datval + 5, 2);
-				strncpy(day, (const char *)datval + 8, 2);
-				
-				tm.tm_year = atoi(year) - 1900;
-				tm.tm_mon = atoi(month) - 1;
-				tm.tm_mday = atoi(day);
-				
-				$result = mktime(&tm);
+                            $result->append8($result, "strftime('\%s', datetime('YYYY-MM-DD', (char*)dateval, 'localtime'))");
 			}
 		}
 	|	interval BEFORE DATE
 		{
 			pANTLR3_UINT8 datval;
-			
+                        char str[15];
+
 			datval = $DATE.text->chars;
+                        sprintf(str, "\%d", $interval.result);
+
+			$result = $DATE.text->factory->newRaw($DATE.text->factory);
 			
 			if (strcmp((char *)datval, "yesterday") == 0)
 			{
-				$result = startoftoday() - 24 * 3600;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 day', ");
 			}
 			else if (strcmp((char *)datval, "last week") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 7;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-7 days', ");
 			}
 			else if (strcmp((char *)datval, "last month") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 30;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 month', ");
 			}
 			else if (strcmp((char *)datval, "last year") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 365;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 year', ");
 			}
 			else
 			{
-				$result = startoftoday(NULL);
+                            $result->append8($result, "strftime('\%s', datetime('now', ");
 			}
-			
-			$result = $result - $interval.result;
-		}
+
+                        $result->append8($result, "'-");
+                        $result->append8($result, str);
+                        $result->append8($result, " seconds', 'localtime'))");
+                }
 	|	interval AFTER DATE
 		{
 			pANTLR3_UINT8 datval;
+                        char str[15];
 			
 			datval = $DATE.text->chars;
+                        sprintf(str, "\%d", $interval.result);
 			
+			$result = $DATE.text->factory->newRaw($DATE.text->factory);
+
 			if (strcmp((char *)datval, "yesterday") == 0)
 			{
-				$result = startoftoday() - 24 * 3600;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 day', ");
 			}
 			else if (strcmp((char *)datval, "last week") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 7;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-7 days', ");
 			}
 			else if (strcmp((char *)datval, "last month") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 30;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 month', ");
 			}
 			else if (strcmp((char *)datval, "last year") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 365;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 year', ");
 			}
 			else
 			{
-				$result = startoftoday();
+                            $result->append8($result, "strftime('\%s', datetime('now', ");
 			}
 			
-			$result = $result + $interval.result;
-		}
+                        $result->append8($result, "'+");
+                        $result->append8($result, str);
+                        $result->append8($result, " seconds', 'localtime'))");
+                }
 	|	interval AGO
 		{
-			$result = startoftoday() - $interval.result;
+                        char str[15];
+                        sprintf(str, "\%d", $interval.result);
+
+			$result = $AGO.text->factory->newRaw($AGO.text->factory);
+
+                        $result->append8($result, "strftime('\%s', datetime('now', 'start of day', ");
+                        $result->append8($result, "'-");
+                        $result->append8($result, str);
+                        $result->append8($result, " seconds', 'localtime'))");
 		}
 	;
 


### PR DESCRIPTION
For dates that require context (ie today, yesterday, N days ago etc) we want the
underlying SQL to respect the current time when running query;  a query that
requests items for 'today' should only find matches for the time it was run.
Current implementation would generated a fixed date (at the time the SMARTPL is
inserted into db) in the playlist table where as this commit understands the
context of the date.

Fixes https://github.com/ejurgensen/forked-daapd/issues/770