### PR TITLE
[smartpl] generate dynamic dates for SMARTPL queries

### DIFF
--- a/README_SMARTPL.md
+++ b/README_SMARTPL.md
@@ -150,6 +150,8 @@ One example of a valid date is a date in yyyy-mm-dd format:
 There are also some special date keywords:
 * `today`, `yesterday`, `last week`, `last month`, `last year`
 
+These dates refer to the _start_ of that period; `today` means 00:00hrs of today, `last week` means the previous Monday 00:00hrs, `last month` is the first day of the previous month at 00:00hrs etc.
+
 A valid date can also be made by applying an interval to a date. Intervals can be defined as `days`, `weeks`, `months`, `years`.
 As an example, a valid date might be:
 
@@ -173,7 +175,11 @@ This matches all songs added in the last 2 weeks.
 }
 ```
 
-This matches all audiobooks played in the last week.
+This matches all audiobooks played since the start of the last Monday 00:00AM.
+
+All dates, except for `YYYY-DD-HH`, are relative to the day of when `forked-daapd` evaluates the smartpl query; `time_added after today` run on a Monday would match against items added since Monday 00:00hrs and evaluating the same smartpl on Friday would only match against added on Friday 00:00hrs.
+
+Note that `time_added after 4 weeks ago` and `time_added after last month` are subtly different; the former is exactly 4 weeks ago (from today) whereas the latter is the first day of the previous month.
 
 
 ## Differences to mt-daapd smart playlists

--- a/src/SMARTPL2SQL.g
+++ b/src/SMARTPL2SQL.g
@@ -38,6 +38,34 @@ options {
 }
 
 @members {
+    static void interval_date(pANTLR3_STRING result, pANTLR3_UINT8 interval, pANTLR3_UINT8 datval, char beforeorafter)
+    {
+            if (strcmp((char *)datval, "yesterday") == 0)
+            {
+                result->append8(result, "strftime('\%s', datetime('now', 'start of day', '-1 day', ");
+            }
+            else if (strcmp((char *)datval, "last week") == 0)
+            {
+                result->append8(result, "strftime('\%s', datetime('now', 'start of day', 'weekday 0', '-13 days', ");
+            }
+            else if (strcmp((char *)datval, "last month") == 0)
+            {
+                result->append8(result, "strftime('\%s', datetime('now', 'start of month', '-1 month', ");
+            }
+            else if (strcmp((char *)datval, "last year") == 0)
+            {
+                result->append8(result, "strftime('\%s', datetime('now', 'start of year', '-1 year', ");
+            }
+            else
+            {
+                result->append8(result, "strftime('\%s', datetime('now', 'start of day', ");
+            }
+
+            result->addc(result, '\'');
+            result->addc(result, beforeorafter);
+            result->append8(result, (const char *)interval);
+            result->append8(result, "', 'localtime'))");
+    }
 }
 
 playlist	returns [ pANTLR3_STRING title, pANTLR3_STRING query, pANTLR3_STRING orderby, pANTLR3_STRING having, int limit ]
@@ -346,69 +374,13 @@ dateval		returns [ pANTLR3_STRING result ]
 		}
 	|	interval BEFORE DATE
 		{
-			pANTLR3_UINT8 datval;
-
-			datval = $DATE.text->chars;
-
 			$result = $DATE.text->factory->newRaw($DATE.text->factory);
-			
-			if (strcmp((char *)datval, "yesterday") == 0)
-			{
-                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 day', ");
-			}
-			else if (strcmp((char *)datval, "last week") == 0)
-			{
-			    $result->append8($result, "strftime('\%s', datetime('now', 'start of day', 'weekday 0', '-13 days', ");
-			}
-			else if (strcmp((char *)datval, "last month") == 0)
-			{
-                            $result->append8($result, "strftime('\%s', datetime('now', 'start of month', '-1 month', ");
-			}
-			else if (strcmp((char *)datval, "last year") == 0)
-			{
-                            $result->append8($result, "strftime('\%s', datetime('now', 'start of year', '-1 year', ");
-			}
-			else
-			{
-                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', ");
-			}
-
-                        $result->append8($result, "'-");
-                        $result->append8($result, (const char *)$interval.result->chars);
-                        $result->append8($result, "', 'localtime'))");
+                        interval_date($result, $interval.result->chars, $DATE.text->chars, '-');
                 }
 	|	interval AFTER DATE
 		{
-			pANTLR3_UINT8 datval;
-			
-			datval = $DATE.text->chars;
-			
 			$result = $DATE.text->factory->newRaw($DATE.text->factory);
-
-			if (strcmp((char *)datval, "yesterday") == 0)
-			{
-                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 day', ");
-			}
-			else if (strcmp((char *)datval, "last week") == 0)
-			{
-			    $result->append8($result, "strftime('\%s', datetime('now', 'start of day', 'weekday 0', '-13 days', ");
-			}
-			else if (strcmp((char *)datval, "last month") == 0)
-			{
-                            $result->append8($result, "strftime('\%s', datetime('now', 'start of month', '-1 month', ");
-			}
-			else if (strcmp((char *)datval, "last year") == 0)
-			{
-                            $result->append8($result, "strftime('\%s', datetime('now', 'start of year', '-1 year', ");
-			}
-			else
-			{
-                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', ");
-			}
-			
-                        $result->append8($result, "'+");
-                        $result->append8($result, (const char *)$interval.result->chars);
-                        $result->append8($result, "', 'localtime'))");
+                        interval_date($result, $interval.result->chars, $DATE.text->chars, '+');
                 }
 	|	interval AGO
 		{

--- a/src/SMARTPL2SQL.g
+++ b/src/SMARTPL2SQL.g
@@ -310,7 +310,7 @@ ordertag	returns [ pANTLR3_STRING result ]
 	;
 
 dateval		returns [ pANTLR3_STRING result ]
-@init { $result = 0; }
+@init { $result = NULL; }
 	:	DATE
 		{
 			pANTLR3_UINT8 datval;
@@ -347,10 +347,8 @@ dateval		returns [ pANTLR3_STRING result ]
 	|	interval BEFORE DATE
 		{
 			pANTLR3_UINT8 datval;
-                        char str[15];
 
 			datval = $DATE.text->chars;
-                        sprintf(str, "\%d", $interval.result);
 
 			$result = $DATE.text->factory->newRaw($DATE.text->factory);
 			
@@ -376,16 +374,14 @@ dateval		returns [ pANTLR3_STRING result ]
 			}
 
                         $result->append8($result, "'-");
-                        $result->append8($result, str);
-                        $result->append8($result, " seconds', 'localtime'))");
+                        $result->append8($result, (const char *)$interval.result->chars);
+                        $result->append8($result, "', 'localtime'))");
                 }
 	|	interval AFTER DATE
 		{
 			pANTLR3_UINT8 datval;
-                        char str[15];
 			
 			datval = $DATE.text->chars;
-                        sprintf(str, "\%d", $interval.result);
 			
 			$result = $DATE.text->factory->newRaw($DATE.text->factory);
 
@@ -411,52 +407,29 @@ dateval		returns [ pANTLR3_STRING result ]
 			}
 			
                         $result->append8($result, "'+");
-                        $result->append8($result, str);
-                        $result->append8($result, " seconds', 'localtime'))");
+                        $result->append8($result, (const char *)$interval.result->chars);
+                        $result->append8($result, "', 'localtime'))");
                 }
 	|	interval AGO
 		{
-                        char str[15];
-                        sprintf(str, "\%d", $interval.result);
-
 			$result = $AGO.text->factory->newRaw($AGO.text->factory);
 
                         $result->append8($result, "strftime('\%s', datetime('now', 'start of day', ");
                         $result->append8($result, "'-");
-                        $result->append8($result, str);
-                        $result->append8($result, " seconds', 'localtime'))");
+                        $result->append8($result, (const char *)$interval.result->chars);
+                        $result->append8($result, "', 'localtime'))");
 		}
 	;
 
-interval	returns [ int result ]
-@init { $result = 0; }
+interval	returns [ pANTLR3_STRING result ]
+@init { $result = NULL; }
 	:	INT DATINTERVAL
 		{
-			pANTLR3_UINT8 interval;
-			
-			$result = atoi((const char *)$INT.text->chars);
-			interval = $DATINTERVAL.text->chars;
-			
-			if (strcmp((char *)interval, "days") == 0)
-			{
-				$result = $result * 24 * 3600;
-			}
-			else if (strcmp((char *)interval, "weeks") == 0)
-			{
-				$result = $result * 24 * 3600 * 7;
-			}
-			else if (strcmp((char *)interval, "months") == 0)
-			{
-				$result = $result * 24 * 3600 * 30;
-			}
-			else if (strcmp((char *)interval, "weeks") == 0)
-			{
-				$result = $result * 24 * 3600 * 365;
-			}
-			else
-			{
-				$result = 0;
-			}
+			$result = $DATINTERVAL.text->factory->newRaw($DATINTERVAL.text->factory);
+			$result->append8($result, (const char *)$INT.text->chars);
+			$result->append8($result, " ");
+			$result->append8($result, (const char *)$DATINTERVAL.text->chars);
+			return $result;
 		}
 	;
 

--- a/src/SMARTPL2SQL.g
+++ b/src/SMARTPL2SQL.g
@@ -38,19 +38,6 @@ options {
 }
 
 @members {
-    static time_t startoftoday()
-    {
-        struct tm tm;
-        time_t now;
-
-        time(&now);
-        localtime_r(&now, &tm);
-        tm.tm_sec  = 0;
-        tm.tm_min  = 0;
-        tm.tm_hour = 0;
-
-	return mktime(&tm);
-    }
 }
 
 playlist	returns [ pANTLR3_STRING title, pANTLR3_STRING query, pANTLR3_STRING orderby, pANTLR3_STRING having, int limit ]
@@ -213,25 +200,19 @@ expression	returns [ pANTLR3_STRING result, pANTLR3_STRING orderby, pANTLR3_STRI
 		}
 	|	DATETAG AFTER dateval
 		{
-			char str[15];
-			sprintf(str, "\%d", $dateval.result);
-			
 			$result = $DATETAG.text->factory->newRaw($DATETAG.text->factory);
 			$result->append8($result, "f.");
 			$result->appendS($result, $DATETAG.text->toUTF8($DATETAG.text));
 			$result->append8($result, " > ");
-			$result->append8($result, str);
+			$result->append8($result, (const char*)$dateval.result->chars);
 		}
 	|	DATETAG BEFORE dateval
 		{
-			char str[15];
-			sprintf(str, "\%d", $dateval.result);
-			
 			$result = $DATETAG.text->factory->newRaw($DATETAG.text->factory);
 			$result->append8($result, "f.");
 			$result->appendS($result, $DATETAG.text->toUTF8($DATETAG.text));
 			$result->append8($result, " < ");
-			$result->append8($result, str);
+			$result->append8($result, (const char*)$dateval.result->chars);
 		}
 	|	ENUMTAG IS ENUMVAL
 		{
@@ -328,118 +309,122 @@ ordertag	returns [ pANTLR3_STRING result ]
 		}
 	;
 
-dateval		returns [ int result ]
+dateval		returns [ pANTLR3_STRING result ]
 @init { $result = 0; }
 	:	DATE
 		{
 			pANTLR3_UINT8 datval;
 			
 			datval = $DATE.text->chars;
-			
+
+			$result = $DATE.text->factory->newRaw($DATE.text->factory);
+
 			if (strcmp((char *)datval, "today") == 0)
 			{
-				$result = startoftoday();
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', 'localtime'))");
 			}
 			else if (strcmp((char *)datval, "yesterday") == 0)
 			{
-				$result = startoftoday() - 24 * 3600;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 day', 'localtime'))");
 			}
 			else if (strcmp((char *)datval, "last week") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 7;
+			    $result->append8($result, "strftime('\%s', datetime('now', 'start of day', 'weekday 0', '-13 days', 'localtime'))");
 			}
 			else if (strcmp((char *)datval, "last month") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 30;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of month', '-1 month', 'localtime'))");
 			}
 			else if (strcmp((char *)datval, "last year") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 365;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of year', '-1 year', 'localtime'))");
 			}
 			else
 			{
-				struct tm tm;
-				char year[5];
-				char month[3];
-				char day[3];
-				
-				memset((void*)&tm,0,sizeof(tm));
-				memset(year, 0, sizeof(year));
-				memset(month, 0, sizeof(month));
-				memset(day, 0, sizeof(day));
-
-				strncpy(year, (const char *)datval, 4);
-				strncpy(month, (const char *)datval + 5, 2);
-				strncpy(day, (const char *)datval + 8, 2);
-				
-				tm.tm_year = atoi(year) - 1900;
-				tm.tm_mon = atoi(month) - 1;
-				tm.tm_mday = atoi(day);
-				
-				$result = mktime(&tm);
+                            $result->append8($result, "strftime('\%s', datetime('YYYY-MM-DD', (char*)dateval, 'localtime'))");
 			}
 		}
 	|	interval BEFORE DATE
 		{
 			pANTLR3_UINT8 datval;
-			
+                        char str[15];
+
 			datval = $DATE.text->chars;
+                        sprintf(str, "\%d", $interval.result);
+
+			$result = $DATE.text->factory->newRaw($DATE.text->factory);
 			
 			if (strcmp((char *)datval, "yesterday") == 0)
 			{
-				$result = startoftoday() - 24 * 3600;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 day', ");
 			}
 			else if (strcmp((char *)datval, "last week") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 7;
+			    $result->append8($result, "strftime('\%s', datetime('now', 'start of day', 'weekday 0', '-13 days', ");
 			}
 			else if (strcmp((char *)datval, "last month") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 30;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of month', '-1 month', ");
 			}
 			else if (strcmp((char *)datval, "last year") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 365;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of year', '-1 year', ");
 			}
 			else
 			{
-				$result = startoftoday(NULL);
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', ");
 			}
-			
-			$result = $result - $interval.result;
-		}
+
+                        $result->append8($result, "'-");
+                        $result->append8($result, str);
+                        $result->append8($result, " seconds', 'localtime'))");
+                }
 	|	interval AFTER DATE
 		{
 			pANTLR3_UINT8 datval;
+                        char str[15];
 			
 			datval = $DATE.text->chars;
+                        sprintf(str, "\%d", $interval.result);
 			
+			$result = $DATE.text->factory->newRaw($DATE.text->factory);
+
 			if (strcmp((char *)datval, "yesterday") == 0)
 			{
-				$result = startoftoday() - 24 * 3600;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', '-1 day', ");
 			}
 			else if (strcmp((char *)datval, "last week") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 7;
+			    $result->append8($result, "strftime('\%s', datetime('now', 'start of day', 'weekday 0', '-13 days', ");
 			}
 			else if (strcmp((char *)datval, "last month") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 30;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of month', '-1 month', ");
 			}
 			else if (strcmp((char *)datval, "last year") == 0)
 			{
-				$result = startoftoday() - 24 * 3600 * 365;
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of year', '-1 year', ");
 			}
 			else
 			{
-				$result = startoftoday();
+                            $result->append8($result, "strftime('\%s', datetime('now', 'start of day', ");
 			}
 			
-			$result = $result + $interval.result;
-		}
+                        $result->append8($result, "'+");
+                        $result->append8($result, str);
+                        $result->append8($result, " seconds', 'localtime'))");
+                }
 	|	interval AGO
 		{
-			$result = startoftoday() - $interval.result;
+                        char str[15];
+                        sprintf(str, "\%d", $interval.result);
+
+			$result = $AGO.text->factory->newRaw($AGO.text->factory);
+
+                        $result->append8($result, "strftime('\%s', datetime('now', 'start of day', ");
+                        $result->append8($result, "'-");
+                        $result->append8($result, str);
+                        $result->append8($result, " seconds', 'localtime'))");
 		}
 	;
 

--- a/src/SMARTPL2SQL.g
+++ b/src/SMARTPL2SQL.g
@@ -425,10 +425,27 @@ interval	returns [ pANTLR3_STRING result ]
 @init { $result = NULL; }
 	:	INT DATINTERVAL
 		{
+		        pANTLR3_UINT8 interval;
+			int intval;
+			char buf[25];
+
 			$result = $DATINTERVAL.text->factory->newRaw($DATINTERVAL.text->factory);
-			$result->append8($result, (const char *)$INT.text->chars);
-			$result->append8($result, " ");
-			$result->append8($result, (const char *)$DATINTERVAL.text->chars);
+
+			// SQL doesnt have a modifer for 'week' but for day/hr/min/sec/month/yr
+			interval = $DATINTERVAL.text->chars;
+			if (strcmp((char *)interval, "weeks") == 0)
+			{
+			    intval = atoi((const char *)$INT.text->chars) * 7;
+			    snprintf(buf, sizeof(buf), "\%d days", intval);
+
+			    $result->append8($result, buf);
+			}
+			else
+			{
+			    $result->append8($result, (const char *)$INT.text->chars);
+			    $result->append8($result, " ");
+			    $result->append8($result, (const char *)$DATINTERVAL.text->chars);
+			}
 			return $result;
 		}
 	;


### PR DESCRIPTION
For dates that require context (ie today, yesterday, N days ago etc) we want the underlying SQL to respect the current time when running query;  a query that requests items for 'today' should only find matches for the time it was run.

Current implementation would generated a fixed date, `time_t` for use in comparisons, at the time the SMARTPL is inserted into db  playlist table.  This PR generates a `datetime` query for SMARTPL dates such as `today` etc and results in a SQL fragment that provides the `time_t`/unixtime at the point of execution.

ie `today` results in SQL fragment: `strftime('%s', datetime('now', 'start of day', 'localtime'))`

Closes https://github.com/ejurgensen/forked-daapd/issues/770