### PR TITLE
Allow reading of collaborative/shared Spotify playlists

### DIFF
--- a/htdocs/admin.html
+++ b/htdocs/admin.html
@@ -213,6 +213,7 @@
           </div>
           <div v-show="spotify.webapi_token_valid">
             <p><b>Spotify Web API</b>: access authorized for <b>{{ spotify.webapi_user }}</b></p>
+            <p v-if="spotify_missing_scope.length > 0" class="help is-danger">Please reauthorize Web API access to grant forked-daapd the following additional access rights: <b>{{ spotify_missing_scope | join }}</b></p>
             <a class="button" v-bind:href="spotify.oauth_uri">Reauthorize Web API access</a>
           </div>
         </div>

--- a/htdocs/admin/js/forked-daapd.js
+++ b/htdocs/admin/js/forked-daapd.js
@@ -24,6 +24,15 @@ var app = new Vue({
     this.loadLastfm();
   },
 
+  computed: {
+    spotify_missing_scope () {
+      if (this.spotify.webapi_token_valid && this.spotify.webapi_granted_scope && this.spotify.webapi_required_scope) {
+        return this.spotify.webapi_required_scope.split(' ').filter(scope => this.spotify.webapi_granted_scope.indexOf(scope) < 0)
+      }
+      return []
+    }
+  },
+
   methods: {
     loadConfig: function() {
       axios.get('/api/config').then(response => {

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -850,6 +850,8 @@ jsonapi_reply_spotify(struct httpd_request *hreq)
   json_object_object_add(jreply, "webapi_token_valid", json_object_new_boolean(webapi_info.token_valid));
   safe_json_add_string(jreply, "webapi_user", webapi_info.user);
   safe_json_add_string(jreply, "webapi_country", webapi_info.country);
+  safe_json_add_string(jreply, "webapi_granted_scope", webapi_info.granted_scope);
+  safe_json_add_string(jreply, "webapi_required_scope", webapi_info.required_scope);
 
   spotifywebapi_access_token_get(&webapi_token);
   safe_json_add_string(jreply, "webapi_token", webapi_token.token);

--- a/src/spotify_webapi.h
+++ b/src/spotify_webapi.h
@@ -31,6 +31,8 @@ struct spotifywebapi_status_info
   bool token_valid;
   char user[100];
   char country[3]; // ISO 3166-1 alpha-2 country code
+  char granted_scope[250];
+  char required_scope[250];
 };
 
 struct spotifywebapi_access_token


### PR DESCRIPTION
Fixes #780

Requires to reauthorize forked-daapd to access the Spotify web API (with the additional scope `playlist-read-collaborative`).

The JSON API now exposes the required and granted scopes and the admin web interface displays a message, if reauthorization is necessary.