### PR TITLE
[db,jsonapi] case insensitive directory/file listing

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -418,7 +418,7 @@ static const char *sort_clause[] =
     "f.composer_sort",
     "f.disc",
     "f.track",
-    "LOWER(f.virtual_path)",
+    "f.virtual_path COLLATE NOCASE",
     "pos",
     "shuffle_pos",
   };
@@ -3890,7 +3890,7 @@ db_directory_id_bypath(const char *path)
 int
 db_directory_enum_start(struct directory_enum *de)
 {
-#define Q_TMPL "SELECT * FROM directories WHERE disabled = 0 AND parent_id = %d ORDER BY LOWER(virtual_path);"
+#define Q_TMPL "SELECT * FROM directories WHERE disabled = 0 AND parent_id = %d ORDER BY virtual_path COLLATE NOCASE;"
   sqlite3_stmt *stmt;
   char *query;
   int ret;

--- a/src/db.c
+++ b/src/db.c
@@ -418,7 +418,6 @@ static const char *sort_clause[] =
     "f.composer_sort",
     "f.disc",
     "f.track",
-    "f.virtual_path",
     "LOWER(f.virtual_path)",
     "pos",
     "shuffle_pos",

--- a/src/db.c
+++ b/src/db.c
@@ -419,6 +419,7 @@ static const char *sort_clause[] =
     "f.disc",
     "f.track",
     "f.virtual_path",
+    "LOWER(f.virtual_path)",
     "pos",
     "shuffle_pos",
   };
@@ -3890,7 +3891,7 @@ db_directory_id_bypath(const char *path)
 int
 db_directory_enum_start(struct directory_enum *de)
 {
-#define Q_TMPL "SELECT * FROM directories WHERE disabled = 0 AND parent_id = %d ORDER BY virtual_path;"
+#define Q_TMPL "SELECT * FROM directories WHERE disabled = 0 AND parent_id = %d ORDER BY LOWER(virtual_path);"
   sqlite3_stmt *stmt;
   char *query;
   int ret;

--- a/src/db.h
+++ b/src/db.h
@@ -28,6 +28,7 @@ enum sort_type {
   S_DISC,
   S_TRACK,
   S_VPATH,
+  S_VPATH_CI,  // case insensitive
   S_POS,
   S_SHUFFLE_POS,
 };

--- a/src/db.h
+++ b/src/db.h
@@ -28,7 +28,6 @@ enum sort_type {
   S_DISC,
   S_TRACK,
   S_VPATH,
-  S_VPATH_CI,  // case insensitive
   S_POS,
   S_SHUFFLE_POS,
 };

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3166,7 +3166,7 @@ jsonapi_reply_library_files(struct httpd_request *hreq)
     goto error;
 
   query_params.type = Q_ITEMS;
-  query_params.sort = S_VPATH_CI;
+  query_params.sort = S_VPATH;
   query_params.filter = db_mprintf("(f.directory_id = %d)", directory_id);
 
   ret = fetch_tracks(&query_params, tracks_items, &total);
@@ -3191,7 +3191,7 @@ jsonapi_reply_library_files(struct httpd_request *hreq)
     goto error;
 
   query_params.type = Q_PL;
-  query_params.sort = S_VPATH_CI;
+  query_params.sort = S_VPATH;
   query_params.filter = db_mprintf("(f.directory_id = %d)", directory_id);
 
   ret = fetch_playlists(&query_params, playlists_items, &total);

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3166,7 +3166,7 @@ jsonapi_reply_library_files(struct httpd_request *hreq)
     goto error;
 
   query_params.type = Q_ITEMS;
-  query_params.sort = S_VPATH;
+  query_params.sort = S_VPATH_CI;
   query_params.filter = db_mprintf("(f.directory_id = %d)", directory_id);
 
   ret = fetch_tracks(&query_params, tracks_items, &total);

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3191,7 +3191,7 @@ jsonapi_reply_library_files(struct httpd_request *hreq)
     goto error;
 
   query_params.type = Q_PL;
-  query_params.sort = S_PLAYLIST;
+  query_params.sort = S_VPATH_CI;
   query_params.filter = db_mprintf("(f.directory_id = %d)", directory_id);
 
   ret = fetch_playlists(&query_params, playlists_items, &total);


### PR DESCRIPTION
Web interface allows retrieving a files/directory view but currently the ordering of directories and files are strictly on `virtual_path` which leads to separation uppercase and lowercase directory names:

ie the directories: `A, B, C, D, a, z` would be listing in this order whilst a user would expect them to be listed as `A, a, B, C, D, z`.  Similar comment for files which appear as a block under the directory list.

This simple PR provides case insensitive ordering on queries related to the json `/api/library/files` endpoint