### PR TITLE
[streaming/xcode] configurable MP3 streaming bitrate

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -382,4 +382,9 @@ streaming {
  
 	# Set the MP3 streaming bit rate (in kbps), valid options: 64 / 96 / 128 / 192 / 320
 #	bit_rate = 192
+
+	# Byte interval to send metadata to client, if requested.  Should avoid
+        # low values to avoid audiable/stuttering problems with small input-
+        # bufffer clients.
+#	icy_metaint = 16384
 }

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -374,17 +374,6 @@ streaming {
 	# Sample rate, typically 44100 or 48000
 #	sample_rate = 44100
  
-	# BPS, 16/24/32
-#	bits_per_sample = 16
-
-	# Channels
-#	channels = 2
- 
 	# Set the MP3 streaming bit rate (in kbps), valid options: 64 / 96 / 128 / 192 / 320
 #	bit_rate = 192
-
-	# Byte interval to send metadata to client, if requested.  Should avoid
-        # low values to avoid audiable/stuttering problems with small input-
-        # bufffer clients.
-#	icy_metaint = 16384
 }

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -374,6 +374,9 @@ streaming {
 	# Sample rate, typically 44100 or 48000
 #	sample_rate = 44100
  
+	# BPS, 16/24/32
+#	bits_per_sample = 16
+
 	# Channels
 #	channels = 2
  

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -367,3 +367,16 @@ sqlite {
 	# but may reduce database size). Default is yes.
 #	vacuum = yes
 }
+
+
+# Streaming audio settings for remote connections (ie stream.mp3)
+streaming {
+	# Sample rate, typically 44100 or 48000
+#	sample_rate = 44100
+ 
+	# Channels
+#	channels = 2
+ 
+	# Set the MP3 streaming bit rate (in kbps), valid options: 64 / 96 / 128 / 192 / 320
+#	bit_rate = 192
+}

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -60,7 +60,6 @@ static cfg_opt_t sec_general[] =
 #else
     CFG_BOOL("high_resolution_clock", cfg_true, CFGF_NONE),
 #endif
-    CFG_INT("streaming_bitrate", 192, CFGF_NONE),
     // Hidden options
     CFG_INT("db_pragma_cache_size", -1, CFGF_NONE),
     CFG_STR("db_pragma_journal_mode", NULL, CFGF_NONE),

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -191,8 +191,6 @@ static cfg_opt_t sec_mpd[] =
 static cfg_opt_t sec_streaming[] =
   {
     CFG_INT("sample_rate", 44100, CFGF_NONE),
-    CFG_INT("bits_per_sample", 16, CFGF_NONE),
-    CFG_INT("channels", 2, CFGF_NONE),
     CFG_INT("bit_rate", 192, CFGF_NONE),
     CFG_INT("icy_metaint", 16384, CFGF_NONE),
     CFG_END()

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -60,6 +60,7 @@ static cfg_opt_t sec_general[] =
 #else
     CFG_BOOL("high_resolution_clock", cfg_true, CFGF_NONE),
 #endif
+    CFG_INT("streaming_bitrate", 192, CFGF_NONE),
     // Hidden options
     CFG_INT("db_pragma_cache_size", -1, CFGF_NONE),
     CFG_STR("db_pragma_journal_mode", NULL, CFGF_NONE),
@@ -186,6 +187,15 @@ static cfg_opt_t sec_mpd[] =
     CFG_END()
   };
 
+/* streaming section structure */
+static cfg_opt_t sec_streaming[] =
+  {
+    CFG_INT("sample_rate", 44100, CFGF_NONE),
+    CFG_INT("channels", 2, CFGF_NONE),
+    CFG_INT("bit_rate", 192, CFGF_NONE),
+    CFG_END()
+  };
+
 /* Config file structure */
 static cfg_opt_t toplvl_cfg[] =
   {
@@ -198,6 +208,7 @@ static cfg_opt_t toplvl_cfg[] =
     CFG_SEC("spotify", sec_spotify, CFGF_NONE),
     CFG_SEC("sqlite", sec_sqlite, CFGF_NONE),
     CFG_SEC("mpd", sec_mpd, CFGF_NONE),
+    CFG_SEC("streaming", sec_streaming, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -191,6 +191,7 @@ static cfg_opt_t sec_mpd[] =
 static cfg_opt_t sec_streaming[] =
   {
     CFG_INT("sample_rate", 44100, CFGF_NONE),
+    CFG_INT("bits_per_sample", 16, CFGF_NONE),
     CFG_INT("channels", 2, CFGF_NONE),
     CFG_INT("bit_rate", 192, CFGF_NONE),
     CFG_END()

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -194,6 +194,7 @@ static cfg_opt_t sec_streaming[] =
     CFG_INT("bits_per_sample", 16, CFGF_NONE),
     CFG_INT("channels", 2, CFGF_NONE),
     CFG_INT("bit_rate", 192, CFGF_NONE),
+    CFG_INT("icy_metaint", 16384, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -1034,7 +1034,7 @@ httpd_request_parse(struct evhttp_request *req, struct httpd_uri_parsed *uri_par
 void
 httpd_stream_file(struct evhttp_request *req, int id)
 {
-  struct media_quality quality = { HTTPD_STREAM_SAMPLE_RATE, HTTPD_STREAM_BPS, HTTPD_STREAM_CHANNELS };
+  struct media_quality quality = { HTTPD_STREAM_SAMPLE_RATE, HTTPD_STREAM_BPS, HTTPD_STREAM_CHANNELS, 0 };
   struct media_file_info *mfi;
   struct stream_ctx *st;
   void (*stream_cb)(int fd, short event, void *arg);

--- a/src/httpd_streaming.c
+++ b/src/httpd_streaming.c
@@ -625,24 +625,16 @@ int
 streaming_init(void)
 {
   int ret;
-  cfg_t*  cfgsec;
+  cfg_t *cfgsec;
   int val;
 
   cfgsec = cfg_getsec(cfg, "streaming");
 
   val = cfg_getint(cfgsec, "sample_rate");
-  if (val%11025 > 0 && val%12000 > 0 && val%8000)
+  if (val%11025 > 0 && val%12000 > 0 && val%8000 > 0)
     DPRINTF(E_LOG, L_STREAMING, "non standard streaming sample_rate=%d, defaulting\n", val);
   else
     streaming_quality_out.sample_rate = val;
-
-  val = cfg_getint(cfgsec, "bits_per_sample");
-  if (val > 0)
-    streaming_quality_out.bits_per_sample = val;
-
-  val = cfg_getint(cfgsec, "channels");
-  if (val > 0)
-    streaming_quality_out.channels = val;
 
   val = cfg_getint(cfgsec, "bit_rate");
   switch (val)

--- a/src/httpd_streaming.c
+++ b/src/httpd_streaming.c
@@ -88,7 +88,13 @@ static int streaming_meta[2];
 
 #define STREAMING_ICY_METALEN_MAX      4080  // 255*16 incl header/footer (16bytes)
 #define STREAMING_ICY_METATITLELEN_MAX 4064  // STREAMING_ICY_METALEN_MAX -16 (not incl header/footer)
-static const short STREAMING_ICY_METAINT = 8192;
+
+/* As streaming quality goes up, we send more data to the remote client.  With a
+ * smaller ICY_METAINT value we have to splice metadata more frequently - on 
+ * some devices with small input buffers, a higher quality stream and low 
+ * ICY_METAINT can lead to stuttering as observed on a Roku Soundbridge
+ */
+static const short STREAMING_ICY_METAINT = 16384;
 static unsigned streaming_icy_clients;
 static char *streaming_icy_title;
 

--- a/src/httpd_streaming.c
+++ b/src/httpd_streaming.c
@@ -631,7 +631,7 @@ streaming_init(void)
   cfgsec = cfg_getsec(cfg, "streaming");
 
   val = cfg_getint(cfgsec, "sample_rate");
-  if (val%44100 > 0 && val%48000 > 0)
+  if (val%11025 > 0 && val%12000 > 0 && val%8000)
     DPRINTF(E_LOG, L_STREAMING, "non standard streaming sample_rate=%d, defaulting\n", val);
   else
     streaming_quality_out.sample_rate = val;

--- a/src/misc.h
+++ b/src/misc.h
@@ -31,6 +31,7 @@ struct media_quality {
   int sample_rate;
   int bits_per_sample;
   int channels;
+  int bit_rate;
 };
 
 struct onekeyval {

--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -139,7 +139,7 @@ static int alsa_latency_history_size;
 
 // We will try to play the music with the source quality, but if the card
 // doesn't support that we resample to the fallback quality
-static struct media_quality alsa_fallback_quality = { 44100, 16, 2 };
+static struct media_quality alsa_fallback_quality = { 44100, 16, 2, 0 };
 static struct media_quality alsa_last_quality;
 
 

--- a/src/outputs/cast.c
+++ b/src/outputs/cast.c
@@ -446,7 +446,7 @@ static struct cast_session *cast_sessions;
 static struct cast_master_session *cast_master_session;
 //static struct timeval heartbeat_timeout = { HEARTBEAT_TIMEOUT, 0 };
 static struct timeval reply_timeout = { REPLY_TIMEOUT, 0 };
-static struct media_quality cast_quality_default = { CAST_QUALITY_SAMPLE_RATE_DEFAULT, CAST_QUALITY_BITS_PER_SAMPLE_DEFAULT, CAST_QUALITY_CHANNELS_DEFAULT };
+static struct media_quality cast_quality_default = { CAST_QUALITY_SAMPLE_RATE_DEFAULT, CAST_QUALITY_BITS_PER_SAMPLE_DEFAULT, CAST_QUALITY_CHANNELS_DEFAULT, 0 };
 
 
 /* ------------------------------- MISC HELPERS ----------------------------- */

--- a/src/outputs/fifo.c
+++ b/src/outputs/fifo.c
@@ -61,7 +61,7 @@ struct fifo_buffer
 
 static struct fifo_buffer buffer;
 
-static struct media_quality fifo_quality = { 44100, 16, 2 };
+static struct media_quality fifo_quality = { 44100, 16, 2, 0 };
 
 
 static void

--- a/src/outputs/pulse.c
+++ b/src/outputs/pulse.c
@@ -86,7 +86,7 @@ static struct pulse_session *sessions;
 static uint32_t pulse_known_devices[PULSE_MAX_DEVICES];
 
 static struct media_quality pulse_last_quality;
-static struct media_quality pulse_fallback_quality = { 44100, 16, 2 };
+static struct media_quality pulse_fallback_quality = { 44100, 16, 2, 0 };
 
 // Converts from 0 - 100 to Pulseaudio's scale
 static inline pa_volume_t

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -738,7 +738,7 @@ open_decoder(unsigned int *stream_index, struct decode_ctx *ctx, enum AVMediaTyp
   if ((*stream_index < 0) || (!decoder))
     {
       if (!ctx->settings.silent)
-       DPRINTF(E_LOG, L_XCODE, "No stream data or decoder for stream #%d\n", *stream_index);
+	DPRINTF(E_LOG, L_XCODE, "No stream data or decoder for stream #%d\n", *stream_index);
       return NULL;
     }
 

--- a/src/transcode.c
+++ b/src/transcode.c
@@ -79,6 +79,7 @@ struct settings_ctx
   int sample_rate;
   uint64_t channel_layout;
   int channels;
+  int bit_rate;
   enum AVSampleFormat sample_format;
   bool wavheader;
   bool icy;
@@ -262,6 +263,11 @@ init_settings(struct settings_ctx *settings, enum transcode_profile profile, str
       settings->channel_layout = av_get_default_channel_layout(quality->channels);
     }
 
+  if (quality && quality->bit_rate)
+    {
+      settings->bit_rate    = quality->bit_rate;
+    }
+
   if (quality && quality->bits_per_sample && (quality->bits_per_sample != 8 * av_get_bytes_per_sample(settings->sample_format)))
     {
       DPRINTF(E_LOG, L_XCODE, "Bug! Mismatch between profile and media quality\n");
@@ -281,6 +287,7 @@ stream_settings_set(struct stream_ctx *s, struct settings_ctx *settings, enum AV
       s->codec->channels       = settings->channels;
       s->codec->sample_fmt     = settings->sample_format;
       s->codec->time_base      = (AVRational){1, settings->sample_rate};
+      s->codec->bit_rate       = settings->bit_rate;
     }
   else if (type == AVMEDIA_TYPE_VIDEO)
     {
@@ -731,7 +738,7 @@ open_decoder(unsigned int *stream_index, struct decode_ctx *ctx, enum AVMediaTyp
   if ((*stream_index < 0) || (!decoder))
     {
       if (!ctx->settings.silent)
-	DPRINTF(E_LOG, L_XCODE, "No stream data or decoder for stream #%d\n", *stream_index);
+       DPRINTF(E_LOG, L_XCODE, "No stream data or decoder for stream #%d\n", *stream_index);
       return NULL;
     }
 


### PR DESCRIPTION
MP3 streaming is set to 44.1k/16/2 with a bit rate of 128kbps.

Streaming bandwidth on an internal (home) networks are likely to be be able to support higher bitrates than 128kbps and it is desirable to have to ability to adjust upwards the bitrate, particularly if the endpoint feeds into a DAC.

This PR adds the `library.streaming_bitrate` configuration value to allow users to select 128/192/320 bitrates.

Closes https://github.com/ejurgensen/forked-daapd/issues/503

We extend `struct media_quality` to incl `bit_rate` which is normally `0` unless we require a specific bitrate for the transcode.  Currently the transcode's `AVCodecContext::bit_rate` is defaulted to 128000 and there is no impact on setting this to 0 since it looks like `bit_rate` field is ignored during the encode side (prep'ing the write to generate PCM)

```
$ ffmpeg -hide_banner -i http://localhost:3689/stream.mp3 -f pulse "output stream"
Input #0, mp3, from 'http://localhost:3689/stream.mp3':
  Metadata:
    icy-name        : My Music on rz4UOJ9JspE
    StreamTitle     : 太阳 - PikA 好声音
  Duration: N/A, start: 0.000000, bitrate: 192 kb/s
    Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 192 kb/s
Stream mapping:
  Stream #0:0 -> #0:0 (mp3 (mp3float) -> pcm_s16le (native))
Press [q] to stop, [?] for help
Output #0, pulse, to 'stream name':
  Metadata:
    icy-name        : My Music on rz4UOJ9JspE
    StreamTitle     : 太阳 - PikA 好声音
    encoder         : Lavf58.20.100
    Stream #0:0: Audio: pcm_s16le, 44100 Hz, stereo, s16, 1411 kb/s
    Metadata:
      encoder         : Lavc58.35.100 pcm_s16le
size=N/A time=00:00:06.47 bitrate=N/A speed=1.25x
```