### PR TITLE
request for comment: [httpd] MT httpd dispatch

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3440,6 +3440,24 @@ search_playlists(json_object *reply, struct httpd_request *hreq, const char *par
   return ret;
 }
 
+
+static int
+jsonapi_reply_block(struct httpd_request *hreq)
+{
+  const char *param;
+  long zzz = 5;
+  int ret = 0;
+
+  if ((param = evhttp_find_header(hreq->query, "zzz")))
+    {
+      zzz = atol(param);
+    }
+  DPRINTF(E_LOG, L_WEB, "blocking %d seconds\n", zzz);
+  sleep(zzz);
+
+  return HTTP_OK;
+}
+
 static int
 jsonapi_reply_search(struct httpd_request *hreq)
 {
@@ -3595,6 +3613,8 @@ static struct httpd_uri_map adm_handlers[] =
     { EVHTTP_REQ_GET,    "^/api/library/files$",                         jsonapi_reply_library_files },
 
     { EVHTTP_REQ_GET,    "^/api/search$",                                jsonapi_reply_search },
+
+    { EVHTTP_REQ_PUT,    "^/api/block$",                                 jsonapi_reply_block},
 
     { 0, NULL, NULL }
   };

--- a/src/httpd_streaming.c
+++ b/src/httpd_streaming.c
@@ -520,7 +520,7 @@ streaming_write(struct output_buffer *obuf)
     }
 }
 
-int
+void
 streaming_request(struct evhttp_request *req, struct httpd_uri_parsed *uri_parsed)
 {
   struct streaming_session *session;
@@ -539,7 +539,7 @@ streaming_request(struct evhttp_request *req, struct httpd_uri_parsed *uri_parse
       DPRINTF(E_LOG, L_STREAMING, "Got MP3 streaming request, but cannot encode to MP3\n");
 
       evhttp_send_error(req, HTTP_NOTFOUND, "Not Found");
-      return -1;
+      return;
     }
 
   evcon = evhttp_request_get_connection(req);
@@ -577,7 +577,7 @@ streaming_request(struct evhttp_request *req, struct httpd_uri_parsed *uri_parse
       DPRINTF(E_LOG, L_STREAMING, "Out of memory for streaming request\n");
 
       evhttp_send_error(req, HTTP_SERVUNAVAIL, "Internal Server Error");
-      return -1;
+      return;
     }
 
   pthread_mutex_lock(&streaming_sessions_lck);
@@ -597,8 +597,6 @@ streaming_request(struct evhttp_request *req, struct httpd_uri_parsed *uri_parse
   pthread_mutex_unlock(&streaming_sessions_lck);
 
   evhttp_connection_set_closecb(evcon, streaming_close_cb, session);
-
-  return 0;
 }
 
 int

--- a/src/httpd_streaming.h
+++ b/src/httpd_streaming.h
@@ -14,7 +14,7 @@
 void
 streaming_write(struct output_buffer *obuf);
 
-int
+void
 streaming_request(struct evhttp_request *req, struct httpd_uri_parsed *uri_parsed);
 
 int


### PR DESCRIPTION
https://github.com/ejurgensen/forked-daapd/issues/793#issuecomment-525720916

@ejurgensen @chme 

I would greatly appreciate feedback on this approach for non blocking `httpd` daemon thread.  To avoid blocking in one http request (ie db lookup via jsonapi) impacting another (ie mp3 streaming) the actual work is delegated to separate thread via a worker/request Q.

Nothing groundbraking here and an implementation I used before successfully in my old day jobs.  The areas I'd like to bring attention:
* implementation is `pthread` primatives only
* this relies on `evhttp_send_reply` being thread safe with multiple concurrent calls occuring in the worker threads

I've tested this with streaming and web UI usage and everything works as expected in these cases.