### PR TITLE
[httpd] memleak fix for exitev

### DIFF
--- a/src/httpd.c
+++ b/src/httpd.c
@@ -1900,5 +1900,7 @@ httpd_deinit(void)
   close(exit_pipe[1]);
 #endif
   evhttp_free(evhttpd);
+  event_del(exitev);
+  event_free(exitev);
   event_base_free(evbase_httpd);
 }


### PR DESCRIPTION
valgrind shows this as a leak after I hit the web ui and then control-C the process.  Output before patch
```
$ valgrind --leak-check=full --show-leak-kinds=definite $(pwd)/forked-daapd -f -c /etc/forked-daapd.conf -d 3
...
==19891== 
==19891== HEAP SUMMARY:
==19891==     in use at exit: 58,406 bytes in 315 blocks
==19891==   total heap usage: 110,653 allocs, 110,338 frees, 25,304,676 bytes allocated
==19891== 
==19891== 128 bytes in 1 blocks are definitely lost in loss record 250 of 292
==19891==    at 0x483880B: malloc (vg_replace_malloc.c:309)
==19891==    by 0x638E769: event_new (in /usr/lib64/libevent-2.1.so.6.0.2)
==19891==    by 0x4281C9: httpd_init (httpd.c:1731)
==19891==    by 0x40C90E: main (main.c:818)
==19891== 
==19891== LEAK SUMMARY:
==19891==    definitely lost: 128 bytes in 1 blocks
==19891==    indirectly lost: 0 bytes in 0 blocks
==19891==      possibly lost: 1,352 bytes in 18 blocks
==19891==    still reachable: 56,926 bytes in 296 blocks
==19891==                       of which reachable via heuristic:
==19891==                         newarray           : 1,536 bytes in 16 blocks
==19891==         suppressed: 0 bytes in 0 blocks
==19891== Reachable blocks (those to which a pointer was found) are not shown.
```

