### PR TITLE
Support relative seeking 

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -288,6 +288,7 @@ PUT /api/player/seek
 | Parameter       | Value                                                       |
 | --------------- | ----------------------------------------------------------- |
 | position_ms     | The new position in milliseconds to seek to                 |
+| seek_ms         | A relative amount of milliseconds to seek to                 |
 
 
 **Response**
@@ -296,10 +297,17 @@ On success returns the HTTP `204 No Content` success status response code.
 
 **Example**
 
+Seek to position:
+
 ```shell
 curl -X PUT "http://localhost:3689/api/player/seek?position_ms=2000"
 ```
 
+Relative seeking (skip 30 seconds backwards):
+
+```shell
+curl -X PUT "http://localhost:3689/api/player/seek?seek_ms=-30000"
+```
 
 
 ## Outputs / Speakers

--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -549,7 +549,7 @@ seek_timer_cb(int fd, short what, void *arg)
 
   DPRINTF(E_DBG, L_DACP, "Seek timer expired, target %d ms\n", seek_target);
 
-  ret = player_playback_seek(seek_target);
+  ret = player_playback_seek(seek_target, PLAYER_SEEK_POSITION);
   if (ret < 0)
     {
       DPRINTF(E_LOG, L_DACP, "Player failed to seek to %d ms\n", seek_target);

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1829,7 +1829,7 @@ jsonapi_reply_player_seek(struct httpd_request *hreq)
       if (ret < 0)
 	return HTTP_BADREQUEST;
 
-      ret = player_playback_seek(position_ms);
+      ret = player_playback_seek(position_ms, PLAYER_SEEK_POSITION);
     }
   else
     {
@@ -1837,7 +1837,7 @@ jsonapi_reply_player_seek(struct httpd_request *hreq)
       if (ret < 0)
 	return HTTP_BADREQUEST;
 
-      ret = player_playback_seek_rel(seek_ms);
+      ret = player_playback_seek(seek_ms, PLAYER_SEEK_RELATIVE);
     }
 
   if (ret < 0)

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1812,29 +1812,46 @@ jsonapi_reply_player_previous(struct httpd_request *hreq)
 static int
 jsonapi_reply_player_seek(struct httpd_request *hreq)
 {
-  const char *param;
+  const char *param_pos;
+  const char *param_seek;
   int position_ms;
+  int seek_ms;
   int ret;
 
-  param = evhttp_find_header(hreq->query, "position_ms");
-  if (!param)
+  param_pos = evhttp_find_header(hreq->query, "position_ms");
+  param_seek = evhttp_find_header(hreq->query, "seek_ms");
+  if (!param_pos && !param_seek)
     return HTTP_BADREQUEST;
 
-  ret = safe_atoi32(param, &position_ms);
-  if (ret < 0)
-    return HTTP_BADREQUEST;
+  if (param_pos)
+    {
+      ret = safe_atoi32(param_pos, &position_ms);
+      if (ret < 0)
+	return HTTP_BADREQUEST;
 
-  ret = player_playback_seek(position_ms);
+      ret = player_playback_seek(position_ms);
+    }
+  else
+    {
+      ret = safe_atoi32(param_seek, &seek_ms);
+      if (ret < 0)
+	return HTTP_BADREQUEST;
+
+      ret = player_playback_seek_rel(seek_ms);
+    }
+
   if (ret < 0)
     {
-      DPRINTF(E_LOG, L_WEB, "Error seeking to position %d.\n", position_ms);
+      DPRINTF(E_LOG, L_WEB, "Error seeking (position_ms=%s, seek_ms=%s).\n",
+	      (param_pos ? param_pos : ""), (param_seek ? param_seek : ""));
       return HTTP_INTERNAL;
     }
 
   ret = player_playback_start();
   if (ret < 0)
     {
-      DPRINTF(E_LOG, L_WEB, "Error starting playback after seeking to position %d.\n", position_ms);
+      DPRINTF(E_LOG, L_WEB, "Error starting playback after seeking (position_ms=%s, seek_ms=%s).\n",
+	      (param_pos ? param_pos : ""), (param_seek ? param_seek : ""));
       return HTTP_INTERNAL;
     }
 

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -1521,7 +1521,7 @@ mpd_command_seek(struct evbuffer *evbuf, int argc, char **argv, char **errmsg, s
   seek_target_sec = strtof(argv[2], NULL);
   seek_target_msec = seek_target_sec * 1000;
 
-  ret = player_playback_seek(seek_target_msec);
+  ret = player_playback_seek(seek_target_msec, PLAYER_SEEK_POSITION);
 
   if (ret < 0)
     {
@@ -1571,7 +1571,7 @@ mpd_command_seekid(struct evbuffer *evbuf, int argc, char **argv, char **errmsg,
   seek_target_sec = strtof(argv[2], NULL);
   seek_target_msec = seek_target_sec * 1000;
 
-  ret = player_playback_seek(seek_target_msec);
+  ret = player_playback_seek(seek_target_msec, PLAYER_SEEK_POSITION);
 
   if (ret < 0)
     {
@@ -1604,7 +1604,7 @@ mpd_command_seekcur(struct evbuffer *evbuf, int argc, char **argv, char **errmsg
   seek_target_msec = seek_target_sec * 1000;
 
   // TODO If prefixed by '+' or '-', then the time is relative to the current playing position.
-  ret = player_playback_seek(seek_target_msec);
+  ret = player_playback_seek(seek_target_msec, PLAYER_SEEK_POSITION);
 
   if (ret < 0)
     {

--- a/src/player.c
+++ b/src/player.c
@@ -2244,20 +2244,17 @@ seek_calc_position_ms(struct db_queue_item **queue_item, int *position_ms, struc
     {
       // Seeking in the current queue item
       seek_queue_item = db_queue_fetch_byitemid(pb_session.playing_now->item_id);
+
+      if (!seek_queue_item)
+	{
+	  DPRINTF(E_LOG, L_PLAYER, "Error fetching queue item for seek command (seek_ms=%d, seek_mode=%d)\n", seek_param->ms, seek_param->mode);
+	  return -1;
+	}
     }
 
-  if (!seek_queue_item)
-    {
-      DPRINTF(E_LOG, L_PLAYER, "Error fetching queue item for seek command (seek_ms=%d, seek_mode=%d)\n", seek_param->ms, seek_param->mode);
-      return -1;
-    }
 
-  if (seek_ms < 0)
-    {
-      DPRINTF(E_LOG, L_PLAYER, "Error calculating new seek position for seek command (seek_ms=%d, seek_mode=%d)\n", seek_param->ms, seek_param->mode);
-      free_queue_item(seek_queue_item, 0);
-      return -1;
-    }
+  DPRINTF(E_DBG, L_PLAYER, "Seek position for seek command (seek_ms=%d, seek_mode=%d) is: seek_ms=%d, queue item id=%d\n",
+	  seek_param->ms, seek_param->mode, seek_ms, seek_queue_item->id);
 
   *queue_item = seek_queue_item;
   *position_ms = seek_ms;

--- a/src/player.h
+++ b/src/player.h
@@ -22,6 +22,11 @@ enum repeat_mode {
   REPEAT_ALL  = 2,
 };
 
+enum player_seek_mode {
+  PLAYER_SEEK_POSITION = 1,
+  PLAYER_SEEK_RELATIVE = 2,
+};
+
 struct player_speaker_info {
   uint64_t id;
   char name[255];
@@ -109,10 +114,7 @@ int
 player_playback_pause(void);
 
 int
-player_playback_seek(int ms);
-
-int
-player_playback_seek_rel(int ms);
+player_playback_seek(int seek_ms, enum player_seek_mode seek_mode);
 
 int
 player_playback_next(void);

--- a/src/player.h
+++ b/src/player.h
@@ -112,6 +112,9 @@ int
 player_playback_seek(int ms);
 
 int
+player_playback_seek_rel(int ms);
+
+int
 player_playback_next(void);
 
 int


### PR DESCRIPTION
For podcasts and audiobooks it would be good to have the ability to skip a number of seconds forward and backward (ref #729). This draft adds this functionality to the player as a new player command (`player_playback_seek_rel(...)`). The JSON API exposes this by supporting a new parameter for the `/api/player/seek` that expects the amount of milliseconds that should be skipped forward (positive value given) or backward (negative value given) from the current playback position.

The current implementation in this draft also switches tracks, if the new position is outside of the now playing track (not so useful for podcasts, but useful for audiobooks consisting of multiple tracks). I am not yet settled, if this is the best way to handle it. Another option, i am considering is for the backward skip to start the current track and only if another skip happens to switch to the previous track (similar for the forward skip, start the next track from the beginning and not skipping further ahead).

@ejurgensen I would appreciate, if you can take a look at this. Needs more testing, so 