### PR TITLE
[web-src] genre page ux improvements

### DIFF
--- a/web-src/src/components/ModalDialogGenre.vue
+++ b/web-src/src/components/ModalDialogGenre.vue
@@ -7,19 +7,19 @@
           <div class="card">
             <div class="card-content">
               <p class="title is-4">
-                <a class="has-text-link" @click="open_genre">{{ genre.name }}</a>
+                <a class="has-text-link" @click="open_albums">{{ genre.name }}</a>
               </p>
               <p>
                 <span class="heading">Albums</span>
-                <span class="title is-6">{{ genre.album_count }}</span>
+                <a class="has-text-link is-6" @click="open_albums">{{ genre.album_count }}</a>
               </p>
               <p>
                 <span class="heading">Artists</span>
-                <span class="title is-6">{{ genre.artist_count }}</span>
+                <a class="has-text-link is-6" @click="open_artists">{{ genre.artist_count }}</a>
               </p>
               <p>
                 <span class="heading">Tracks</span>
-                <span class="title is-6">{{ genre.track_count }}</span>
+                <a class="has-text-link is-6" @click="open_tracks">{{ genre.track_count }}</a>
               </p>
             </div>
             <footer class="card-footer">
@@ -64,9 +64,19 @@ export default {
       webapi.queue_expression_add_next('genre is "' + this.genre.name + '" and media_kind is music')
     },
 
-    open_genre: function () {
+    open_albums: function () {
       this.$emit('close')
       this.$router.push({ name: 'Genre', params: { genre: this.genre.name } })
+    },
+
+    open_tracks: function () {
+      this.show_details_modal = false
+      this.$router.push({ name: 'GenreTracks', params: { genre: this.genre.name } })
+    },
+
+    open_artists: function () {
+      this.show_details_modal = false
+      this.$router.push({ name: 'GenreArtists', params: { genre: this.genre.name } })
     }
   }
 }

--- a/web-src/src/components/ModalDialogGenre.vue
+++ b/web-src/src/components/ModalDialogGenre.vue
@@ -9,6 +9,18 @@
               <p class="title is-4">
                 <a class="has-text-link" @click="open_genre">{{ genre.name }}</a>
               </p>
+              <p>
+                <span class="heading">Albums</span>
+                <span class="title is-6">{{ genre.album_count }}</span>
+              </p>
+              <p>
+                <span class="heading">Artists</span>
+                <span class="title is-6">{{ genre.artist_count }}</span>
+              </p>
+              <p>
+                <span class="heading">Tracks</span>
+                <span class="title is-6">{{ genre.track_count }}</span>
+              </p>
             </div>
             <footer class="card-footer">
               <a class="card-footer-item has-text-dark" @click="queue_add">

--- a/web-src/src/pages/PageGenre.vue
+++ b/web-src/src/pages/PageGenre.vue
@@ -74,7 +74,7 @@ export default {
   computed: {
     index_list () {
       return [...new Set(this.genre_albums.items
-        .map(album => album.name.charAt(0).toUpperCase()))]
+        .map(album => album.name_sort.charAt(0).toUpperCase()))]
     }
   },
 

--- a/web-src/src/pages/PageGenre.vue
+++ b/web-src/src/pages/PageGenre.vue
@@ -18,7 +18,7 @@
         </div>
       </template>
       <template slot="content">
-        <p class="heading has-text-centered-mobile">{{ genre_albums.total }} albums | <a class="has-text-link" @click="open_tracks">tracks</a></p>
+        <p class="heading has-text-centered-mobile"><a class="has-text-link" @click="open_artists">artists</a> | {{ genre_albums.total }} albums | <a class="has-text-link" @click="open_tracks">tracks</a></p>
         <list-item-albums v-for="album in genre_albums.items" :key="album.id" :album="album" @click="open_album(album)">
           <template slot="actions">
             <a @click="open_dialog(album)">
@@ -45,7 +45,7 @@ import webapi from '@/webapi'
 
 const genreData = {
   load: function (to) {
-    return webapi.library_genre(to.params.genre)
+    return webapi.library_genre_albums(to.params.genre)
   },
 
   set: function (vm, response) {
@@ -82,6 +82,11 @@ export default {
     open_tracks: function () {
       this.show_details_modal = false
       this.$router.push({ name: 'GenreTracks', params: { genre: this.name } })
+    },
+
+    open_artists: function () {
+      this.show_details_modal = false
+      this.$router.push({ name: 'GenreArtists', params: { genre: this.name } })
     },
 
     play: function () {

--- a/web-src/src/pages/PageGenreArtists.vue
+++ b/web-src/src/pages/PageGenreArtists.vue
@@ -1,0 +1,112 @@
+<template>
+  <div>
+    <content-with-heading>
+      <template slot="options">
+        <index-button-list :index="index_list"></index-button-list>
+      </template>
+      <template slot="heading-left">
+        <p class="title is-4">{{ genre }}</p>
+      </template>
+      <template slot="heading-right">
+        <div class="buttons is-centered">
+          <a class="button is-small is-light is-rounded" @click="show_genre_details_modal = true">
+            <span class="icon"><i class="mdi mdi-dots-horizontal mdi-18px"></i></span>
+          </a>
+          <a class="button is-small is-dark is-rounded" @click="play">
+            <span class="icon"><i class="mdi mdi-shuffle"></i></span> <span>Shuffle</span>
+          </a>
+        </div>
+      </template>
+      <template slot="content">
+        <p class="heading has-text-centered-mobile">{{ artists.total }} artists | <a class="has-text-link" @click="open_albums">albums</a> | <a class="has-text-link" @click="open_tracks">tracks</a></p>
+        <list-item-artist v-for="artist in artists.items" :key="artist.id" :artist="artist" @click="open_artist(artist)">
+          <template slot="actions">
+            <a @click="open_dialog(artist)">
+              <span class="icon has-text-dark"><i class="mdi mdi-dots-vertical mdi-18px"></i></span>
+            </a>
+          </template>
+        </list-item-artist>
+        <modal-dialog-artist :show="show_details_modal" :artist="selected_artist" @close="show_details_modal = false" />
+        <modal-dialog-genre :show="show_genre_details_modal" :genre="{ 'name': genre }" @close="show_genre_details_modal = false" />
+      </template>
+    </content-with-heading>
+  </div>
+</template>
+
+<script>
+import { LoadDataBeforeEnterMixin } from './mixin'
+import ContentWithHeading from '@/templates/ContentWithHeading'
+import IndexButtonList from '@/components/IndexButtonList'
+import ListItemArtist from '@/components/ListItemArtist'
+import ModalDialogArtist from '@/components/ModalDialogArtist'
+import ModalDialogGenre from '@/components/ModalDialogGenre'
+import webapi from '@/webapi'
+
+const artistsData = {
+  load: function (to) {
+    return webapi.library_genre_artists(to.params.genre)
+  },
+
+  set: function (vm, response) {
+    vm.genre = vm.$route.params.genre
+    vm.artists = response.data.artists
+  }
+}
+
+export default {
+  name: 'PageGenreArtists',
+  mixins: [ LoadDataBeforeEnterMixin(artistsData) ],
+  components: { ContentWithHeading, ListItemArtist, IndexButtonList, ModalDialogArtist, ModalDialogGenre },
+
+  data () {
+    return {
+      artists: { items: [] },
+      genre: '',
+
+      show_details_modal: false,
+      selected_artist: {},
+
+      show_genre_details_modal: false
+    }
+  },
+
+  computed: {
+    index_list () {
+      return [...new Set(this.artists.items
+        .map(artist => artist.name_sort.charAt(0).toUpperCase()))]
+    }
+  },
+
+  methods: {
+    open_albums: function () {
+      this.show_details_modal = false
+      this.$router.push({ name: 'Genre', params: { genre: this.genre } })
+    },
+
+    open_tracks: function () {
+      this.show_details_modal = false
+      this.$router.push({ name: 'GenreTracks', params: { genre: this.genre } })
+    },
+
+    open_artist: function (artist) {
+      this.$router.push({ path: '/music/artists/' + artist.id })
+    },
+
+    play: function () {
+      webapi.player_play_expression('genre is "' + this.genre + '" and media_kind is music', true)
+    },
+
+    play_artist: function (position) {
+      webapi.player_play_expression('genre is "' + this.genre + '" and media_kind is music', false, position)
+    },
+
+    open_dialog: function (artist) {
+      this.selected_artist = artist
+      this.show_details_modal = true
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/web-src/src/pages/PageGenres.vue
+++ b/web-src/src/pages/PageGenres.vue
@@ -60,7 +60,7 @@ export default {
   computed: {
     index_list () {
       return [...new Set(this.genres.items
-        .map(genre => genre.name.charAt(0).toUpperCase()))]
+        .map(genre => genre.name_sort.charAt(0).toUpperCase()))]
     }
   },
 

--- a/web-src/src/router/index.js
+++ b/web-src/src/router/index.js
@@ -13,6 +13,7 @@ import PageAlbums from '@/pages/PageAlbums'
 import PageAlbum from '@/pages/PageAlbum'
 import PageGenres from '@/pages/PageGenres'
 import PageGenre from '@/pages/PageGenre'
+import PageGenreArtists from '@/pages/PageGenreArtists'
 import PageGenreTracks from '@/pages/PageGenreTracks'
 import PageArtistTracks from '@/pages/PageArtistTracks'
 import PagePodcasts from '@/pages/PagePodcasts'
@@ -114,6 +115,12 @@ export const router = new VueRouter({
       path: '/music/genres/:genre',
       name: 'Genre',
       component: PageGenre,
+      meta: { show_progress: true, has_index: true }
+    },
+    {
+      path: '/music/genres/:genre/artists',
+      name: 'GenreArtists',
+      component: PageGenreArtists,
       meta: { show_progress: true, has_index: true }
     },
     {

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -217,9 +217,20 @@ export default {
     return axios.get('/api/library/genres')
   },
 
-  library_genre (genre) {
+  library_genre_albums (genre) {
     var genreParams = {
       'type': 'albums',
+      'media_kind': 'music',
+      'expression': 'genre is "' + genre + '"'
+    }
+    return axios.get('/api/search', {
+      params: genreParams
+    })
+  },
+
+  library_genre_artists (genre) {
+    var genreParams = {
+      'type': 'artists',
       'media_kind': 'music',
       'expression': 'genre is "' + genre + '"'
     }


### PR DESCRIPTION
sister to https://github.com/ejurgensen/forked-daapd/pull/709 - requires changes to json api to work

Adds to `genre` functionality:
* modal to incl track/artist/album counts which act as links to those new pages
* 2x new genre pages to show artists / tracks matching genre
* genre pages links to artist/album/track pages matching genre 