### PR TITLE
[streaming] mem leak fix on client initiated disconnect

### DIFF
--- a/src/httpd_streaming.c
+++ b/src/httpd_streaming.c
@@ -139,6 +139,10 @@ streaming_close_cb(struct evhttp_connection *evcon, void *arg)
   if (session->require_icy)
     --streaming_icy_clients;
 
+  /* Possible libevent bug; ownership of evhttp_request with libevent
+   * Workaround to force mem cleanup, prefered over evhttp_request_free()
+   */
+  evhttp_send_reply_end(session->req);
   free(session);
 
   if (!streaming_sessions)


### PR DESCRIPTION
close callback, `streaming_close_cb()`, cleans up the session but not the `evhhttp_request` object alloc'd from `httpd()-> event_base_dispatch() -> ... -> event_base_loop() -> ... -> evhttp_request_new()`

This leak can be observed by:
* starting the server
* connect a streaming client to the server (`ffmpeg -i http://forked-daapd.local:3689/stream.mp3`)
* kill/disconnect the streaming client
* stop the server

```
==13137== 1,658 (216 direct, 1,442 indirect) bytes in 1 blocks are definitely lost in loss record 369 of 380
==13137==    at 0x4C3114A: calloc (vg_replace_malloc.c:762)
==13137==    by 0x8A433EC: evhttp_request_new (in /usr/lib64/libevent-2.1.so.6.0.2)
==13137==    by 0x8A4352B: ??? (in /usr/lib64/libevent-2.1.so.6.0.2)
==13137==    by 0x8A43740: ??? (in /usr/lib64/libevent-2.1.so.6.0.2)
==13137==    by 0x8A2FC10: ??? (in /usr/lib64/libevent-2.1.so.6.0.2)
==13137==    by 0x8A275B0: ??? (in /usr/lib64/libevent-2.1.so.6.0.2)
==13137==    by 0x8A27D46: event_base_loop (in /usr/lib64/libevent-2.1.so.6.0.2)
==13137==    by 0x425B28: httpd (httpd.c:767)
==13137==    by 0x9EFD593: start_thread (in /usr/lib64/libpthread-2.27.so)
==13137==    by 0xA416E6E: clone (in /usr/lib64/libc-2.27.so)
```

If the server is stopped with active clients the server cleans this up in `session_end()` via `evhttp_send_reply_end(session->req)`