### PR TITLE
[player] not error when: a) play on empty Q b) pause when not playing

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -2042,6 +2042,7 @@ playback_start(void *arg, int *retval)
 {
   struct db_queue_item *queue_item = NULL;
   enum command_state cmd_state;
+  uint32_t count;
 
   *retval = -1;
 
@@ -2050,7 +2051,13 @@ playback_start(void *arg, int *retval)
       // Start playback of first item in queue
       queue_item = db_queue_fetch_bypos(0, shuffle);
       if (!queue_item)
-	return COMMAND_END;
+      {
+	count = 0;
+	db_queue_get_count(&count);
+	if (count == 0)
+	  *retval = 1;
+        return COMMAND_END;
+      }
     }
 
   cmd_state = playback_start_item(queue_item, retval);
@@ -2249,7 +2256,8 @@ playback_pause(void *arg, int *retval)
 {
   if (player_state == PLAY_STOPPED)
     {
-      *retval = -1;
+      // No execution of _bh but caller gets 'success' return
+      *retval = 1;
       return COMMAND_END;
     }
 


### PR DESCRIPTION
Closes https://github.com/ejurgensen/forked-daapd/issues/805

This PR solves 2 issues in the player were a user's actions leads to `internal error` response from JSON api that is confusing.  This behavior does not fit in with what a real CD player (and hence most users expectations).

|Action|Current Repsonse from JSON/web ui|CD player/Expected Response|
|-|-|-|
|play when queue is empty|`internal error`|no action/no error - as if CD player has no disc|
|pause when not playing|`internal error`|no action/no error - as if CD player not playing|

Conversely, when a `stop` is requested when the player is not playing this behaves as you'd expect with no action and NO error.  This PR would bring the the play/pause actions inline with stop and user expectations