### PR TITLE
[httpd] Force browsers to always revalidate their cache

### DIFF
--- a/src/httpd.c
+++ b/src/httpd.c
@@ -301,7 +301,7 @@ httpd_request_etag_matches(struct evhttp_request *req, const char *etag)
 
   // Add cache headers to allow client side caching
   output_headers = evhttp_request_get_output_headers(req);
-  evhttp_add_header(output_headers, "Cache-Control", "private");
+  evhttp_add_header(output_headers, "Cache-Control", "private no-cache");
   evhttp_add_header(output_headers, "ETag", etag);
 
   return false;
@@ -337,7 +337,7 @@ httpd_request_not_modified_since(struct evhttp_request *req, const time_t *mtime
 
   // Add cache headers to allow client side caching
   output_headers = evhttp_request_get_output_headers(req);
-  evhttp_add_header(output_headers, "Cache-Control", "private");
+  evhttp_add_header(output_headers, "Cache-Control", "private no-cache");
   evhttp_add_header(output_headers, "Last-Modified", last_modified);
 
   return false;


### PR DESCRIPTION
Fix #814

The problem with the current version of forked-daapd is, that a browser is allowed to keep a cached version of the response for e. g. the `/api/library/playlists` request (`Cache-Control: private`). The browser can use this cached version without checking against the server (forked-daapd) if the cached version is still valid.

This pr solves it by telling the browser that it should always check, if the cached version is still valid. The browser therefor always requests the page from the server and only uses the cached version if the server returns a 403 "not modified" response code.
This obviously results in a lot more requests against forked-daapd while using the web interface. The majority of the requests should be fast, because forked-daapd returns early with a 403 response. But it will be noticeable, if the httpd thread is busy (e. g. if it is used for mp3 streaming).

This needs more testing, but i thought i open the pull request early, to get some feedback. 

(Helpful documentation for the Cache-Control attribute: https://csswizardry.com/2019/03/cache-control-for-civilians/)