### PR TITLE
Make Apple Music on Catalina work

### DIFF
--- a/src/db_init.c
+++ b/src/db_init.c
@@ -114,7 +114,8 @@
   "   parent_id      INTEGER DEFAULT 0,"		\
   "   directory_id   INTEGER DEFAULT 0,"		\
   "   query_order    VARCHAR(1024),"			\
-  "   query_limit    INTEGER DEFAULT -1"		\
+  "   query_limit    INTEGER DEFAULT -1,"		\
+  "   media_kind     INTEGER DEFAULT 1"			\
   ");"
 
 #define T_PLITEMS				\

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * forked-daapd after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 21
-#define SCHEMA_VERSION_MINOR 01
+#define SCHEMA_VERSION_MINOR 02
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1020,6 +1020,22 @@ static const struct db_upgrade_query db_upgrade_v2101_queries[] =
     { U_v2101_SCVER_MINOR,    "set schema_version_minor to 01" },
   };
 
+// This column added because Apple Music makes a DAAP request for playlists
+// that has a query condition on extended-media-kind. We set the default value
+// to 1 to signify music.
+#define U_v2102_ALTER_PLAYLISTS_ADD_MEDIA_KIND \
+  "ALTER TABLE playlists ADD COLUMN media_kind INTEGER DEFAULT 1;"
+
+#define U_v2102_SCVER_MINOR                    \
+  "UPDATE admin SET value = '02' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v2102_queries[] =
+  {
+    { U_v2102_ALTER_PLAYLISTS_ADD_MEDIA_KIND, "alter table playlists add column media_kind" },
+
+    { U_v2102_SCVER_MINOR,    "set schema_version_minor to 02" },
+  };
+
 
 int
 db_upgrade(sqlite3 *hdl, int db_ver)
@@ -1175,6 +1191,12 @@ db_upgrade(sqlite3 *hdl, int db_ver)
       if (ret < 0)
 	return -1;
 
+      /* FALLTHROUGH */
+
+    case 2101:
+      ret = db_generic_upgrade(hdl, db_upgrade_v2102_queries, ARRAY_SIZE(db_upgrade_v2102_queries));
+      if (ret < 0)
+	return -1;
       break;
 
     default:

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -821,10 +821,11 @@ daap_reply_server_info(struct httpd_request *hreq)
 
   dmap_add_short(content, "ated", 7);        // daap.supportsextradata
 
-  /* Sub-optimal user-agent sniffing to solve the problem that iTunes 12.1
-   * does not work if we announce support for groups.
-   */ 
+  // Sub-optimal user-agent sniffing to solve the problem that iTunes 12.1 and
+  // Apple Music do not work if we announce support for groups
   if (hreq->user_agent && (strncmp(hreq->user_agent, "iTunes", strlen("iTunes")) == 0))
+    dmap_add_short(content, "asgr", 0);      // daap.supportsgroups (1=artists, 2=albums, 3=both)
+  else if (hreq->user_agent && (strncmp(hreq->user_agent, "Music", strlen("Music")) == 0))
     dmap_add_short(content, "asgr", 0);      // daap.supportsgroups (1=artists, 2=albums, 3=both)
   else
     dmap_add_short(content, "asgr", 3);      // daap.supportsgroups (1=artists, 2=albums, 3=both)


### PR DESCRIPTION
@chme hope to get your opinion on one of the issues with current Apple Music. Its request for playlists looks like this:

`/databases/71/containers?session-id=12345678&revision-number=4&delta=0&query=('dmap.itemname:Library%20name','com.apple.itunes.extended-media-kind:1','com.apple.itunes.extended-media-kind:32','com.apple.itunes.extended-media-kind:128','com.apple.itunes.extended-media-kind:65537')&meta=dmap.itemid,dmap.itemname,dmap.persistentid,dmap.parentcontainerid,com.apple.itunes.is-podcast-playlist,com.apple.itunes.special-playlist,com.apple.itunes.smart-playlist,dmap.haschildcontainers,com.apple.itunes.saved-genius,dmap.objectextradata`

forked-daapd parses that to a SQL query for the playlists table which has a WHERE that includes media_kind. That then fails because there is no such column in the playlists table.

So what would you say is the best way to handle this? I suppose the options are:
1. Add such a column? - but how should it be filled, and would it give any actual value? 
2. A hack to ignore the entire query part of all playlist requests? (current solution in this PR)
3. Something else?