### PR TITLE
Add Eclipse CDT specific files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ debian/
 /.settings
 /.cproject
 /.project
+/.autotools


### PR DESCRIPTION
Add Eclipse CDT specific files to gitignore
(a new .autotools file was generated by the new Eclipse CDT version)