### PR TITLE
[outputs] support multi alsa devices/outputs

### DIFF
--- a/README_ALSA.md
+++ b/README_ALSA.md
@@ -274,3 +274,29 @@ audio {
     mixer_device="hw:1"
 }
 ```
+
+## Multiple devices
+
+If your machine has multiple physical devices like our Raspberry Pi example above (the DAC hat and the onboard headphone jack), we can make all these devices available to `forked-daapd` using seperate `alsa { .. }` sections.
+
+NB: When introducing `alsa { .. }` section(s) the ALSA specific configuration in the `audio { .. }` section will be ignored.
+
+For example:
+```
+audio {
+    type = "alsa"
+}
+
+alsa "dac" {
+    card="dac"
+    mixer="Analogue"
+    mixer_device="hw:1"
+}
+
+alsa "headphones" {
+    card = "hw:0,0"
+    mixer = "PCM"
+    mixer_device = "hw:0"
+}
+
+```

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -216,6 +216,8 @@ audio {
 	# socket.
 #	server = ""
 
+        # ALSA settings can be definied in their own 'alsa { }' sections for 
+        # multiple devices
 	# Audio PCM device name for local audio output - ALSA only
 #	card = "default"
 
@@ -245,6 +247,25 @@ audio {
 	# are required. This setting sets the length of that period in seconds.
 #	adjust_period_seconds = 100
 }
+
+# ALSA device settings
+# Multiple sections can be defined for multiple ALSA devices on a host (i.e. a
+# RPi with onboard headphones and DAC hat).  ALSA may see these devices as hw:0
+# and hw:1 via 'aplay -l' (see README_ALSA)
+#
+# Overrides ALSA settings in 'audio' section
+#alsa "alsa default" {
+	# Audio PCM device name for local audio output
+#	card = "default"
+
+	# Mixer channel to use for volume control
+	# If not set, PCM will be used if available, otherwise Master.
+#	mixer = ""
+
+	# Mixer device to use for volume control
+	# If not set, the value for "card" will be used.
+#	mixer_device = ""
+#}
 
 # Pipe output
 # Allows forked-daapd to output audio data to a named pipe

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -124,6 +124,17 @@ static cfg_opt_t sec_audio[] =
     CFG_END()
   };
 
+
+/* local ALSA audio section structure */
+static cfg_opt_t sec_alsa[] =
+  {
+    CFG_STR("card", "default", CFGF_NONE),
+    CFG_STR("mixer", NULL, CFGF_NONE),
+    CFG_STR("mixer_device", NULL, CFGF_NONE),
+    CFG_INT("offset_ms", 0, CFGF_NONE),
+    CFG_END()
+  };
+
 /* AirPlay/ApEx device section structure */
 static cfg_opt_t sec_airplay[] =
   {
@@ -201,6 +212,7 @@ static cfg_opt_t toplvl_cfg[] =
     CFG_SEC("general", sec_general, CFGF_NONE),
     CFG_SEC("library", sec_library, CFGF_NONE),
     CFG_SEC("audio", sec_audio, CFGF_NONE),
+    CFG_SEC("alsa", sec_alsa, CFGF_MULTI | CFGF_TITLE),
     CFG_SEC("airplay", sec_airplay, CFGF_MULTI | CFGF_TITLE),
     CFG_SEC("chromecast", sec_chromecast, CFGF_MULTI | CFGF_TITLE),
     CFG_SEC("fifo", sec_fifo, CFGF_NONE),


### PR DESCRIPTION
This simple PR adds support for multiple `ALSA` output devices - the functionality for other output types support multiple devices is available for other output types such as `cast` or `airplay` output devices.

This functionality supports a use case for me where a raspberry pi has an onboard headphone output and also an add-on DAC hat that feeds into my amp:  this means this device has multiple h/w output devices which can be selected by the server.

The config file is updated to allow multiple `alsa "..." { }` sections - if none are specified, the server looks in `audio { }` section as current to be less instrusive wtih existing configurations.
```
audio {
        # Name - used in the speaker list in Remote
        nickname = "Computer"
        
        # Type of the output (alsa, pulseaudio, dummy or disabled)
        type = "alsa"
}

alsa "dac" 
        card = "dac"
        mixer = "Analogue"
        mixer_device = "hw:1"
}

alsa "headphones" {
        # Audio PCM device name for local audio output - ALSA only
        #   $ aplay -l
        #   **** List of PLAYBACK Hardware Devices ****
        #   card 0: ALSA [bcm2835 ALSA], device 0: bcm2835 ALSA [bcm2835 ALSA]
        #   card 0: ALSA [bcm2835 ALSA], device 1: bcm2835 ALSA [bcm2835 IEC958/HDMI]
        #   card 1: IQaudIODAC [IQaudIODAC], device 0: IQaudIO DAC HiFi pcm512x-hifi-0 []
        #
        # headphones -> " aplay -Dhw:0,0 /tmp/foo.wav"
        card = "hw:0,0"
        mixer = "PCM"
        mixer_device = "hw:0"
}
```