### PR TITLE
[alsa] multi alsa cfg section SEGV with no nickname

### DIFF
--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -1188,13 +1188,13 @@ alsa_device_add(cfg_t* cfg_audio, int id)
 {
   struct output_device *device;
   struct alsa_extra *ae;
+  const char *nickname;
   int ret;
 
   CHECK_NULL(L_LAUDIO, device = calloc(1, sizeof(struct output_device)));
   CHECK_NULL(L_LAUDIO, ae = calloc(1, sizeof(struct alsa_extra)));
 
   device->id = id;
-  device->name = strdup(cfg_getstr(cfg_audio, "nickname"));
   device->type = OUTPUT_TYPE_ALSA;
   device->type_name = outputs_name(device->type);
   device->extra_device_info = ae;
@@ -1204,6 +1204,9 @@ alsa_device_add(cfg_t* cfg_audio, int id)
   ae->card_name = cfg_title(cfg_audio);
   if (!ae->card_name)
     ae->card_name = cfg_getstr(cfg_audio, "card");
+
+  nickname = cfg_getstr(cfg_audio, "nickname");
+  device->name = strdup(nickname ? nickname : ae->card_name);
 
   ae->mixer_name = cfg_getstr(cfg_audio, "mixer");
   ae->mixer_device_name = cfg_getstr(cfg_audio, "mixer_device");


### PR DESCRIPTION
multi alsa cfg section with no `nickname` will SEGV.  Fix to use name of 'card' when `nickname` not specified.

If we have:
```
alsa "default" {
}
```
This will SEGV at https://github.com/ejurgensen/forked-daapd/blob/cc78926721e991298087a680718e6b5ae1829f27/src/outputs/alsa.c#L1197 because of the definition https://github.com/ejurgensen/forked-daapd/blob/cc78926721e991298087a680718e6b5ae1829f27/src/conffile.c#L128-135  explicitly has
https://github.com/ejurgensen/forked-daapd/blob/cc78926721e991298087a680718e6b5ae1829f27/src/conffile.c#L131 defaulting to `NULL`.

This simple fix forces the `nickname` of the ALSA device to be the same as the `card` name rather than taking a default value which will be confusing if there are multiple `alsa` sections that do not specify a `nickname` - ideally these nicknames are enforced as unique as are the devices these sections refer