### PR TITLE
[alsa] Prevent (user error cfg) multiple devices with same name

### DIFF
--- a/src/outputs.c
+++ b/src/outputs.c
@@ -623,6 +623,14 @@ outputs_device_add(struct output_device *add, bool new_deselect, int default_vol
     {
       if (device->id == add->id)
 	break;
+
+      // name clash, different id for this type (can be user error in cfg)
+      if (device->type == add->type && strcmp(device->name, add->name) == 0)
+        {
+          DPRINTF(E_WARN, L_PLAYER, "Ignoring duplicate %s device with name/id '%s'/%" PRIu64 "\n", add->type_name, add->name, add->id);
+          outputs_device_free(add);
+          return NULL;
+        }
     }
 
   // New device


### PR DESCRIPTION
Outputs may be misconfigured to have the same name (via `nickname`) particularly for ALSA devices - this means whilst the server will identify these as unique (the `id` for ALSA is unique) the end user will find it very difficult to distinguish between these devices without looking in the db or at the cfg file

The web interface will show speakers with the same name and the json api shows this:
```
{
  "outputs": [
    {
      "id": "1",
      "name": "dupname",
      "type": "ALSA",
      "selected": false,
      "has_password": false,
      "requires_auth": false,
      "needs_auth_key": false,
      "volume": 50
    },
    {
      "id": "0",
      "name": "dupname",
      "type": "ALSA",
      "selected": false,
      "has_password": false,
      "requires_auth": false,
      "needs_auth_key": false,
      "volume": 50
    }
  ]
}
```
We don't perform the duplicate validation in the `outputs/*.c` backends as the `player_device_add()` performs the add asynchronously (makes looking at `output_device_list` a race condition) and it makes sense to validate for all.

Currently this checks name uniqueness for the same type although it may be adventagous to enforce uniquness across all speakers