### PR TITLE
Library metarescan fix

### DIFF
--- a/src/library.c
+++ b/src/library.c
@@ -747,7 +747,16 @@ library_init(void)
   for (i = 0; sources[i]; i++)
     {
       if (!sources[i]->init)
-	continue;
+        {
+          DPRINTF(E_LOG, L_LIB, "BUG: library source '%s' has no init()\n", sources[i]->name);
+          return -1;
+        }
+
+      if (!sources[i]->metarescan)
+        {
+          DPRINTF(E_LOG, L_LIB, "BUG: library source '%s' has no metarescan()\n", sources[i]->name);
+          return -1;
+        }
 
       ret = sources[i]->init();
       if (ret < 0)

--- a/src/spotify_webapi.c
+++ b/src/spotify_webapi.c
@@ -1965,6 +1965,7 @@ struct library_source spotifyscanner =
   .init = spotifywebapi_init,
   .deinit = spotifywebapi_deinit,
   .rescan = rescan,
+  .metarescan = rescan,
   .initscan = initscan,
   .fullrescan = fullrescan,
   .queue_add = queue_add,


### PR DESCRIPTION
Fix for this bug https://github.com/ejurgensen/forked-daapd/pull/755#issuecomment-582649979

* spotify `rmetarescan` performs normal `rescan`
* `library` kicks out if mandatory `init` and `metarescan` methods not implemented in `library_source`