### PR TITLE
Support RSS podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,15 +467,15 @@ forked-daapd can support RSS podcasts via [libmrss](https://github.com/bakulf/li
 and its sister dependancy [libnxml](https://github.com/bakulf/libnxml). When enabled, RSS feed podcasts will be automatically 
 refreshed periodically.
 
-To add a RSS feed to the library we have to create either a `.rss` (containing 
-feed XML) or a `.rss_url` file that contains a single line with the RSS feed URL.
-The initial addition to the library will cause the RSS feed podcast episodes to 
-be added to the library as if it were an album.
+To add a RSS feed to the library we have to create a `.rss` file that contains a
+single line with the RSS feed URL (direct link to rss or an Apple podcast link).
+The initial addition to the library will cause the RSS feed podcast episodes to
+be added to the library.
 
 The server will periodically refresh - the period can be changed via the config
 file.  Alternatively, a user can _force_ a refresh by initiating a library `scan`
 but this is not deseriabale as it will scan all items in library or a user can
-_touch_ the underlying `.rss` or `.rss_url` file.
+_touch_ the underlying `.rss` file.
 
 ## Spotify
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ forked-daapd is a Linux/FreeBSD DAAP (iTunes), MPD (Music Player Daemon) and
 RSP (Roku) media server.
 
 It supports AirPlay devices/speakers, Apple Remote (and compatibles),
-MPD clients, Chromecast, network streaming, internet radio, Spotify and LastFM.
+MPD clients, Chromecast, network streaming, internet radio, RSS podcasts, 
+Spotify and LastFM.
 
 It does not support streaming video by AirPlay nor Chromecast.
 
@@ -50,6 +51,7 @@ please see the
 - [Artwork](#artwork)
 - [Library](#library)
 - [Command line](#command-line)
+- [RSS podcasts](#rss)
 - [Spotify](#spotify)
 - [LastFM](#lastfm)
 - [MPD clients](#mpd-clients)
@@ -459,6 +461,21 @@ curl "http://localhost:3689/ctrl-int/1/playspec?database-spec='dmap.persistentid
 curl "http://localhost:3689/logout?session-id=50"
 ```
 
+
+## RSS podcasts
+forked-daapd can support RSS podcasts via [libmrss](https://github.com/bakulf/libmrss)
+and its sister dependancy [libnxml](https://github.com/bakulf/libnxml). When enabled, RSS feed podcasts will be automatically 
+refreshed periodically.
+
+To add a RSS feed to the library we have to create either a `.rss` (containing 
+feed XML) or a `.rss_url` file that contains a single line with the RSS feed URL.
+The initial addition to the library will cause the RSS feed podcast episodes to 
+be added to the library as if it were an album.
+
+The server will periodically refresh - the period can be changed via the config
+file.  Alternatively, a user can _force_ a refresh by initiating a library `scan`
+but this is not deseriabale as it will scan all items in library or a user can
+_touch_ the underlying `.rss` or `.rss_url` file.
 
 ## Spotify
 

--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,11 @@ AS_IF([[test "x$with_avahi" = "xno"]],
 		[AC_MSG_ERROR([[Avahi client or Bonjour DNS_SD required, please install one.]])])])
 AM_CONDITIONAL([COND_AVAHI], [[test "x$with_avahi" = "xyes"]])
 
+dnl Build with libmrss
+FORK_ARG_WITH_CHECK([FORKED_OPTS], [libmrss support], [mrss], [LIBMRSS],
+	[mrss], [], [mrss.h])
+AM_CONDITIONAL([COND_MRSS], [[test "x$with_mrss" = "xyes"]])
+
 dnl Spotify with dynamic linking to libspotify
 FORK_ARG_ENABLE([Spotify support], [spotify], [SPOTIFY],
 	[AS_IF([[test "x$with_libcurl" = "xno"]],
@@ -302,6 +307,13 @@ FORK_ARG_ENABLE([LastFM support], [lastfm], [LASTFM],
 		[AC_MSG_ERROR([[LastFM support requires libcurl]])])
 	])
 AM_CONDITIONAL([COND_LASTFM], [[test "x$enable_lastfm" = "xyes"]])
+
+dnl RSS support with libmrss
+FORK_ARG_ENABLE([MRSS support], [mrss], [MRSS],
+	[AS_IF([[test "x$with_libmrss" = "xno"]],
+		[AC_MSG_ERROR([[RSS support requires libmrss]])])
+	])
+AM_CONDITIONAL([COND_MRSS], [[test "x$enable_mrss" = "xyes"]])
 
 dnl ChromeCast support with libprotobuf-c
 FORK_ARG_ENABLE([Chromecast support], [chromecast], [CHROMECAST],

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -399,3 +399,10 @@ streaming {
 	# Set the MP3 streaming bit rate (in kbps), valid options: 64 / 96 / 128 / 192 / 320
 #	bit_rate = 192
 }
+
+
+# RSS settings
+rss {
+	# Period, in seconds, to sync RSS feeds
+#	sync_period = 3600
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@ MPD_SRC=mpd.c mpd.h
 endif
 
 if COND_MRSS
-MRSS_SRC=library/filescanner_rss.c
+MRSS_SRC=library/filescanner_rss.c rss.c
 endif
 
 if COND_RAOP_VERIFICATION

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,10 @@ if COND_MPD
 MPD_SRC=mpd.c mpd.h
 endif
 
+if COND_MRSS
+MRSS_SRC=library/filescanner_rss.c
+endif
+
 if COND_RAOP_VERIFICATION
 RAOP_VERIFICATION_SRC=outputs/raop_verification.c outputs/raop_verification.h
 endif
@@ -143,6 +147,7 @@ forked_daapd_SOURCES = main.c \
 	commands.c commands.h \
 	mxml-compat.h \
 	$(LIBWEBSOCKETS_SRC) \
+	$(MRSS_SRC) \
 	$(GPERF_SRC) \
 	$(ANTLR_SRC) 
 

--- a/src/SMARTPL.g
+++ b/src/SMARTPL.g
@@ -101,6 +101,7 @@ DATETAG		:	'time_added'
 			|	'time_modified'
 			|	'time_played'
 			|	'time_skipped'
+			|	'date_released'
 			;
 
 ENUMTAG		:	'data_kind'

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -174,6 +174,13 @@ static cfg_opt_t sec_spotify[] =
     CFG_END()
   };
 
+/* RSS section structure */
+static cfg_opt_t sec_rss[] =
+  {
+    CFG_INT("sync_period", 3600, CFGF_NONE),
+    CFG_END()
+  };
+
 /* SQLite section structure */
 static cfg_opt_t sec_sqlite[] =
   {
@@ -221,6 +228,7 @@ static cfg_opt_t toplvl_cfg[] =
     CFG_SEC("sqlite", sec_sqlite, CFGF_NONE),
     CFG_SEC("mpd", sec_mpd, CFGF_NONE),
     CFG_SEC("streaming", sec_streaming, CFGF_NONE),
+    CFG_SEC("rss", sec_rss, CFGF_NONE),
     CFG_END()
   };
 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -92,7 +92,7 @@ static cfg_opt_t sec_library[] =
     CFG_STR("name_radio", "Radio", CFGF_NONE),
     CFG_STR_LIST("artwork_basenames", "{artwork,cover,Folder}", CFGF_NONE),
     CFG_BOOL("artwork_individual", cfg_false, CFGF_NONE),
-    CFG_STR_LIST("filetypes_ignore", "{.db,.ini,.db-journal,.pdf,.metadata}", CFGF_NONE),
+    CFG_STR_LIST("filetypes_ignore", "{.db,.ini,.db-journal,.pdf,.metadata,.png,.jpg}", CFGF_NONE),
     CFG_STR_LIST("filepath_ignore", NULL, CFGF_NONE),
     CFG_BOOL("filescan_disable", cfg_false, CFGF_NONE),
     CFG_BOOL("m3u_overrides", cfg_false, CFGF_NONE),

--- a/src/db.c
+++ b/src/db.c
@@ -627,6 +627,7 @@ free_mfi(struct media_file_info *mfi, int content_only)
   free(mfi->orchestra);
   free(mfi->conductor);
   free(mfi->grouping);
+  free(mfi->url);
   free(mfi->description);
   free(mfi->codectype);
   free(mfi->album_artist);

--- a/src/db.c
+++ b/src/db.c
@@ -426,6 +426,7 @@ static const char *sort_clause[] =
     "f.virtual_path COLLATE NOCASE",
     "pos",
     "shuffle_pos",
+    "f.date_released DESC",
   };
 
 /* Browse clauses, used for SELECT, WHERE, GROUP BY and for default ORDER BY

--- a/src/db.c
+++ b/src/db.c
@@ -1856,6 +1856,7 @@ db_build_query_plitems(struct query_params *qp, struct query_clause *qc)
 	query = db_build_query_plitems_smart(qp, pli);
 	break;
 
+      case PL_RSS:
       case PL_PLAIN:
       case PL_FOLDER:
 	query = db_build_query_plitems_plain(qp, qc);

--- a/src/db.h
+++ b/src/db.h
@@ -232,6 +232,7 @@ enum pl_type {
   PL_FOLDER = 1,
   PL_SMART = 2,
   PL_PLAIN = 3,
+  PL_RSS  = 4,
   PL_MAX,
 };
 

--- a/src/db.h
+++ b/src/db.h
@@ -30,6 +30,7 @@ enum sort_type {
   S_VPATH,
   S_POS,
   S_SHUFFLE_POS,
+  S_RELEASEDATE,
 };
 
 #define Q_F_BROWSE (1 << 15)

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -368,6 +368,9 @@ static const struct db_init_query db_init_table_queries[] =
 #define I_QUEUE_SHUFFLEPOS				\
   "CREATE INDEX IF NOT EXISTS idx_queue_shufflepos ON queue(shuffle_pos);"
 
+#define I_FILE_DATE_RELEASED                    \
+  "CREATE INDEX IF NOT EXISTS idx_file_datereleased ON files(date_released);"
+
 static const struct db_init_query db_init_index_queries[] =
   {
     { I_RESCAN,    "create rescan index" },
@@ -401,6 +404,8 @@ static const struct db_init_query db_init_index_queries[] =
 
     { I_QUEUE_POS,  "create queue pos index" },
     { I_QUEUE_SHUFFLEPOS,  "create queue shuffle pos index" },
+
+    { I_FILE_DATE_RELEASED, "create file date_released index" },
   };
 
 

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -573,7 +573,7 @@ query_params_set(struct query_params *qp, int *sort_headers, struct httpd_reques
       else if (strcmp(param, "artist") == 0 && (type != Q_BROWSE_ARTISTS)) // Only set if non-default sort requested
 	qp->sort = S_ARTIST;
       else if (strcmp(param, "releasedate") == 0)
-	qp->sort = S_NAME;
+	qp->sort = S_RELEASEDATE;
       else
 	DPRINTF(E_DBG, L_DAAP, "Unknown sort param: %s\n", param);
 

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -481,7 +481,7 @@ user_agent_filter(struct query_params *qp, struct httpd_request *hreq)
       // contained extended_media_kind:1, which characterise the queries we want
       // to filter. TODO: Not a really nice way of doing this, but best I could
       // think of.
-      if (!qp->filter || !strstr(qp->filter, "f.media_kind"))
+      if (!qp->filter || !strstr(qp->filter, "f.media_kind") || (qp->filter && strstr(qp->filter, "f.media_kind = 4")))
 	return;
 
       filter = safe_asprintf("%s AND (f.data_kind <> %d)", qp->filter, DATA_KIND_HTTP);

--- a/src/library.h
+++ b/src/library.h
@@ -124,10 +124,13 @@ bool
 library_is_scanning();
 
 /*
- * @param is_scanning true if scan is running, otherwise false
+ * Put library in locked/unlocked state for scanner
  */
 void
-library_set_scanning(bool is_scanning);
+library_scanning_start(int domain, const char *msg);
+
+void
+library_scanning_end(int domain, const char *msg);
 
 /*
  * @return true if a running scan should be aborted due to imminent shutdown, otherwise false

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -1692,9 +1692,9 @@ filescanner_initscan()
     }
 
   if (cfg_getbool(cfg_getsec(cfg, "library"), "filescan_disable"))
-    bulk_scan(F_SCAN_BULK | F_SCAN_FAST);
+    bulk_scan(F_SCAN_BULK | F_SCAN_FAST | F_SCAN_RSS);
   else
-    bulk_scan(F_SCAN_BULK);
+    bulk_scan(F_SCAN_BULK | F_SCAN_RSS);
 
   if (!library_is_exiting())
     {
@@ -1747,7 +1747,7 @@ filescanner_fullrescan()
 
   inofd_event_unset(); // Clears all inotify watches
   inofd_event_set();
-  bulk_scan(F_SCAN_BULK);
+  bulk_scan(F_SCAN_BULK | F_SCAN_RSS);
 
   if (!library_is_exiting())
     {

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -433,7 +433,7 @@ parent_dir(const char **current, const char *path)
 }
 
 int
-playlist_fill(struct playlist_info *pli, const char *path)
+playlist_fill_type(struct playlist_info *pli, const char *path, enum pl_type type)
 {
   const char *filename;
   char virtual_path[PATH_MAX];
@@ -447,7 +447,7 @@ playlist_fill(struct playlist_info *pli, const char *path)
 
   memset(pli, 0, sizeof(struct playlist_info));
 
-  pli->type  = PL_PLAIN;
+  pli->type  = type;
   pli->path  = strdup(path);
   pli->title = strip_extension(filename); // Will alloc
   pli->virtual_path = strip_extension(virtual_path); // Will alloc
@@ -458,12 +458,18 @@ playlist_fill(struct playlist_info *pli, const char *path)
 }
 
 int
-playlist_add(const char *path)
+playlist_fill(struct playlist_info *pli, const char *path)
+{
+  return playlist_fill_type(pli, path, PL_PLAIN);
+}
+
+int
+playlist_add_type(const char *path, enum pl_type type)
 {
   struct playlist_info pli;
   int ret;
 
-  ret = playlist_fill(&pli, path);
+  ret = playlist_fill_type(&pli, path, type);
   if (ret < 0)
     return -1;
 
@@ -477,6 +483,12 @@ playlist_add(const char *path)
   free_pli(&pli, 1);
 
   return ret;
+}
+
+int
+playlist_add(const char *path)
+{
+  return playlist_add_type(path, PL_PLAIN);
 }
 
 

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -92,6 +92,7 @@ enum file_type {
   FILE_SMARTPL,
   FILE_ITUNES,
   FILE_ARTWORK,
+  FILE_RSS,
   FILE_CTRL_REMOTE,
   FILE_CTRL_RAOP_VERIFICATION,
   FILE_CTRL_LASTFM,
@@ -328,6 +329,9 @@ file_type_get(const char *path) {
 
   if ((strcasecmp(ext, ".m3u") == 0) || (strcasecmp(ext, ".pls") == 0))
     return FILE_PLAYLIST;
+
+  if (strcasecmp(ext, ".rss_url") == 0 || strcasecmp(ext, ".rss") == 0)
+    return FILE_RSS;
 
   if (strcasecmp(ext, ".smartpl") == 0)
     return FILE_SMARTPL;
@@ -664,6 +668,14 @@ process_file(char *file, struct stat *sb, int type, int flags, int dir_id)
 	  defer_playlist(file, sb->st_mtime, dir_id);
 	else
 	  process_playlist(file, sb->st_mtime, dir_id);
+	break;
+
+      case FILE_RSS:
+#ifdef MRSS
+	scan_rss(file, sb->st_mtime, dir_id);
+#else
+	DPRINTF(E_LOG, L_SCAN, "Found '%s', but this version was built without RSS support\n", file);
+#endif
 	break;
 
       case FILE_SMARTPL:

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -1707,12 +1707,12 @@ filescanner_initscan()
 static int
 filescanner_rescan()
 {
-  DPRINTF(E_LOG, L_SCAN, "Startup rescan triggered\n");
+  DPRINTF(E_LOG, L_SCAN, "rescan triggered\n");
 
   inofd_event_unset(); // Clears all inotify watches
   db_watch_clear();
   inofd_event_set();
-  bulk_scan(F_SCAN_BULK | F_SCAN_RESCAN);
+  bulk_scan(F_SCAN_BULK | F_SCAN_RESCAN | F_SCAN_RSS);
 
   if (!library_is_exiting())
     {

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -77,6 +77,7 @@
 #define F_SCAN_FAST    (1 << 2)
 #define F_SCAN_MOVED   (1 << 3)
 #define F_SCAN_METARESCAN  (1 << 4)
+#define F_SCAN_RSS     (1 << 5)
 
 #define F_SCAN_TYPE_FILE         (1 << 0)
 #define F_SCAN_TYPE_PODCAST      (1 << 1)
@@ -684,7 +685,7 @@ process_file(char *file, struct stat *sb, int type, int flags, int dir_id)
 
       case FILE_RSS:
 #ifdef MRSS
-	scan_rss(file, sb->st_mtime, dir_id);
+	scan_rss(file, sb->st_mtime, flags & F_SCAN_RSS);
 #else
 	DPRINTF(E_LOG, L_SCAN, "Found '%s', but this version was built without RSS support\n", file);
 #endif

--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -331,7 +331,7 @@ file_type_get(const char *path) {
   if ((strcasecmp(ext, ".m3u") == 0) || (strcasecmp(ext, ".pls") == 0))
     return FILE_PLAYLIST;
 
-  if (strcasecmp(ext, ".rss_url") == 0 || strcasecmp(ext, ".rss") == 0)
+  if (strcasecmp(ext, ".rss") == 0)
     return FILE_RSS;
 
   if (strcasecmp(ext, ".smartpl") == 0)

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -16,6 +16,11 @@ scan_metadata_stream(struct media_file_info *mfi, const char *path);
 void
 scan_playlist(const char *file, time_t mtime, int dir_id);
 
+#ifdef MRSS
+void
+scan_rss(const char *file, time_t mtime, int dir_id);
+#endif
+
 void
 scan_smartpl(const char *file, time_t mtime, int dir_id);
 

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -75,6 +75,8 @@ parent_dir(const char **current, const char *path);
  */
 int
 playlist_fill(struct playlist_info *pli, const char *path);
+int
+playlist_fill_type(struct playlist_info *pli, const char *path, enum pl_type type);
 
 /* Adds a playlist to the database with the fields set by playlist_fill()
  *
@@ -83,5 +85,7 @@ playlist_fill(struct playlist_info *pli, const char *path);
  */
 int
 playlist_add(const char *path);
+int
+playlist_add_type(const char *path, enum pl_type type);
 
 #endif /* !__FILESCANNER_H__ */

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -18,7 +18,7 @@ scan_playlist(const char *file, time_t mtime, int dir_id);
 
 #ifdef MRSS
 void
-scan_rss(const char *file, time_t mtime, int dir_id);
+scan_rss(const char *file, time_t mtime, bool force_rescan);
 #endif
 
 void

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -353,7 +353,7 @@ process_regular_file(int pl_id, char *path)
 }
 
 int
-playlist_prepare(const char *path, time_t mtime)
+playlist_prepare(const char *path, time_t mtime, enum pl_type type)
 {
   struct playlist_info *pli;
   int pl_id;
@@ -363,7 +363,7 @@ playlist_prepare(const char *path, time_t mtime)
     {
       DPRINTF(E_LOG, L_SCAN, "New playlist found, processing '%s'\n", path);
 
-      pl_id = playlist_add(path);
+      pl_id = playlist_add_type(path, type);
       if (pl_id < 0)
 	{
 	  DPRINTF(E_LOG, L_SCAN, "Error adding playlist '%s'\n", path);
@@ -421,7 +421,7 @@ scan_playlist(const char *file, time_t mtime, int dir_id)
     return;
 
   // Will create or update the playlist entry in the database
-  pl_id = playlist_prepare(file, mtime);
+  pl_id = playlist_prepare(file, mtime, PL_PLAIN);
   if (pl_id < 0)
     return; // Not necessarily an error, could also be that the playlist hasn't changed
 

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -44,7 +44,7 @@ enum playlist_type
 {
   PLAYLIST_UNKNOWN = 0,
   PLAYLIST_PLS,
-  PLAYLIST_M3U,
+  PLAYLIST_M3U
 };
 
 static enum playlist_type
@@ -352,7 +352,7 @@ process_regular_file(int pl_id, char *path)
   return 0;
 }
 
-static int
+int
 playlist_prepare(const char *path, time_t mtime)
 {
   struct playlist_info *pli;

--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -352,8 +352,8 @@ process_regular_file(int pl_id, char *path)
   return 0;
 }
 
-int
-playlist_prepare(const char *path, time_t mtime, enum pl_type type)
+static int
+playlist_prepare(const char *path, time_t mtime)
 {
   struct playlist_info *pli;
   int pl_id;
@@ -363,7 +363,7 @@ playlist_prepare(const char *path, time_t mtime, enum pl_type type)
     {
       DPRINTF(E_LOG, L_SCAN, "New playlist found, processing '%s'\n", path);
 
-      pl_id = playlist_add_type(path, type);
+      pl_id = playlist_add_type(path, PL_PLAIN);
       if (pl_id < 0)
 	{
 	  DPRINTF(E_LOG, L_SCAN, "Error adding playlist '%s'\n", path);
@@ -421,7 +421,7 @@ scan_playlist(const char *file, time_t mtime, int dir_id)
     return;
 
   // Will create or update the playlist entry in the database
-  pl_id = playlist_prepare(file, mtime, PL_PLAIN);
+  pl_id = playlist_prepare(file, mtime);
   if (pl_id < 0)
     return; // Not necessarily an error, could also be that the playlist hasn't changed
 

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -43,7 +43,7 @@
 #include "library.h"
 
 // from filescanner_playlist.c
-extern int playlist_prepare(const char *path, time_t mtime);
+extern int playlist_prepare(const char *path, time_t mtime, enum pl_type type);
 
 // RSS spec: https://validator.w3.org/feed/docs/rss2.html
 

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -510,6 +510,9 @@ scan_rss(const char *file, time_t mtime, int dir_id)
           free(mfi.url);    mfi.url    = safe_strdup(item->link);
           free(mfi.comment); mfi.comment = NULL;
 
+	  if (mfi.genre)
+	    mfi.genre = strdup("Podcast");
+
           rss_date(&tm, item->pubDate);
           mfi.date_released = mktime(&tm);
           mfi.year = 1900 + tm.tm_year;

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2020 whatdoineed2d/Ray
+ * based heavily on filescanner_playlist.c
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE
+#endif
+#include <time.h>
+
+#include <mrss.h>
+
+#include "logger.h"
+#include "db.h"
+#include "library/filescanner.h"
+#include "misc.h"
+#include "library.h"
+
+// from filescanner_playlist.c
+extern int playlist_prepare(const char *path, time_t mtime);
+
+// RSS spec: https://validator.w3.org/feed/docs/rss2.html
+
+enum rss_type {
+  RSS_UNKNOWN = 0,
+  RSS_FILE,
+  RSS_HTTP
+};
+
+static enum rss_type
+rss_type(const char *path)
+{
+  char *ptr;
+
+  ptr = strrchr(path, '.');
+  if (!ptr)
+    return RSS_UNKNOWN;
+
+  if (strcasecmp(ptr, ".rss") == 0)
+    return RSS_FILE;
+  else if (strcasecmp(ptr, ".rss_url") == 0)
+    return RSS_HTTP;
+  else
+    return RSS_UNKNOWN;
+}
+
+
+static bool
+rss_date(struct tm *tm, const char *date)
+{
+  // RFC822 https://tools.ietf.org/html/rfc822#section-5
+  // ie Fri, 07 Feb 2020 18:58:00 +0000
+  //    ^^^^                      ^^^^^
+  //    optional                  ^^^^^
+  //                              could also be GMT/UT/EST/A..I/M..Z
+
+  char *ptr;
+  time_t t;
+
+  memset(tm, 0, sizeof(struct tm));
+  ptr = strptime(date, "%a,%n", tm);
+  ptr = strptime(ptr ? ptr : date, "%d%n%b%n%Y%n%H:%M:%S%n", tm);
+  if (!ptr)
+    {
+      // date is junk, using current time
+      time(&t);
+      gmtime_r(&t, tm);
+      return false;
+    }
+
+  // TODO - adjust the TZ?
+  return true;
+}
+
+void
+scan_rss(const char *file, time_t mtime, int dir_id)
+{
+  FILE *fp;
+  struct media_file_info mfi;
+  struct stat sb;
+  char buf[PATH_MAX];
+  enum rss_type rss_format;
+  int pl_id;
+  int nadded;
+  struct tm tm;
+
+  mrss_t *data = NULL;
+  mrss_error_t ret;
+  mrss_item_t *item = NULL;
+  CURLcode code;
+
+  rss_format = rss_type(file);
+  if (rss_format == RSS_UNKNOWN)
+    return;
+
+  ret = stat(file, &sb);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_SCAN, "Could not stat() '%s': %s\n", file, strerror(errno));
+      return;
+    }
+  if (sb.st_size == 0)
+    {
+      DPRINTF(E_LOG, L_SCAN, "Ingoring empty RSS file '%s'\n", file);
+      return;
+    }
+
+  fp = fopen(file, "r");
+  if (!fp)
+    {
+      DPRINTF(E_LOG, L_SCAN, "Could not open RSS '%s': %s\n", file, strerror(errno));
+      return;
+    }
+
+  // Will create or update the playlist entry in the database
+  pl_id = playlist_prepare(file, mtime, PL_RSS);
+  if (pl_id < 0)
+    return; // Not necessarily an error, could also be that the playlist hasn't changed
+
+  memset(&mfi, 0, sizeof(struct media_file_info));
+  nadded = 0;
+
+  switch (rss_format)
+    {
+      case RSS_HTTP:
+        {
+          if (fgets(buf, sizeof(buf), fp) == NULL)
+            {
+              DPRINTF(E_LOG, L_SCAN, "Could not read RSS url from '%s': %s\n", file, strerror(errno));
+              goto cleanup;
+            }
+
+          if (strncmp (buf, "http://", 7) != 0 && strncmp(buf, "https://", 8) != 0)
+            {
+              DPRINTF(E_LOG, L_SCAN, "Could not read valid RSS url from '%s'\n", file);
+              goto cleanup;
+            }
+
+          trim(buf);
+          ret = mrss_parse_url_with_options_and_error(buf, &data, NULL, &code);
+          if (ret)
+            {
+              DPRINTF(E_LOG, L_SCAN, "Could not parse RSS from '%s': %s\n", buf, ret==MRSS_ERR_DOWNLOAD ? mrss_curl_strerror(code) : mrss_strerror(ret));
+              goto cleanup;
+            }
+        } break;
+
+      case RSS_FILE:
+        {
+          ret = mrss_parse_file((char*)file, &data);
+          if (ret)
+            {
+              DPRINTF(E_LOG, L_SCAN, "Could not parse RSS from '%s': %s\n", file, mrss_strerror(ret));
+              goto cleanup;
+            }
+        } break;
+
+      default:
+        DPRINTF(E_LOG, L_SCAN, "BUG: unhandled RSS type %d for file '%s'\n", rss_format, file);
+        goto cleanup;
+    }
+
+  /* Expect: 'Channel' (used as 'album name') followed by sequence of 'Items' (used as 'tracks' with artist,title,enclosure_url)
+   * Look at pubDate in items to determine if it's new
+   *
+        Channel:
+                title: CGP Grey
+                description: CGP Grey explains videos.
+                link: http://www.cgpgrey.com
+                language: en
+                rating: (null)
+                copyright: 2011-2015
+                pubDate: Sun, 26 Jan 2020 15:43:07 +0000
+                lastBuildDate: Sun, 09 Feb 2020 15:48:27 +0000
+                docs: http://www.cgpgrey.com
+                managingeditor: (null)
+                webMaster: (null)
+                generator: Libsyn WebEngine 2.0
+                ttl: 0
+
+
+        Items:
+                title: Your Theme
+                link: http://cgpgrey.libsyn.com/your-theme
+                description:
+                author: (null)
+                comments: (null)
+                pubDate: Sun, 26 Jan 2020 15:43:07 +0000
+                guid: 8d394457-02b5-4bc8-bce8-619aa87d395c
+                guid_isPermaLink: 0
+                source: (null)
+                source_url: (null)
+                enclosure: (null)
+                enclosure_url: http://traffic.libsyn.com/cgpgrey/Your_New_Years_Resolution_Has_Already_Failed.mp4?dest-id=256939
+                enclosure_length: 25467531
+                enclosure_type: video/mp4
+   */
+
+  db_transaction_begin();
+
+  item = data->item;
+  while (item)
+    {
+      DPRINTF(E_SPAM, L_SCAN, "Channel '%s' item={ PubDate '%s' Author '%s' Title '%s' Src '%s' Type '%s'\n", data->title, item->pubDate, item->author, item->title, item->enclosure_url, item->enclosure_type);
+
+      scan_metadata_stream(&mfi, item->enclosure_url);
+
+      // always take the main info from the RSS and not the stream
+      free(mfi.artist); mfi.artist = safe_strdup(item->author);
+      free(mfi.title);  mfi.title  = safe_strdup(item->title);
+      free(mfi.album);  mfi.album  = safe_strdup(data->title);
+      free(mfi.url);    mfi.url    = safe_strdup(item->link);
+      free(mfi.comment); mfi.comment = NULL;
+
+      rss_date(&tm, item->pubDate);
+      mfi.date_released = mktime(&tm);
+      mfi.year = 1900 + tm.tm_year;
+
+      mfi.id = db_file_id_bypath(item->enclosure_url);
+
+      ret = library_media_save(&mfi);
+      db_pl_add_item_bypath(pl_id, item->enclosure_url);
+
+      if (++nadded%50 == 0)
+        {
+	    DPRINTF(E_LOG, L_SCAN, "RSS added %d entries...\n", nadded);
+	    db_transaction_end();
+	    db_transaction_begin();
+        }
+
+      item = item->next;
+    }
+
+  db_transaction_end();
+
+cleanup:
+  free_mfi(&mfi, 1);
+  mrss_free(data);
+
+  DPRINTF(E_LOG, L_SCAN, "Done processing RSS, added/modified %d items\n", nadded);
+
+  fclose(fp);
+}

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -459,7 +459,6 @@ scan_rss(const char *file, time_t mtime, bool force_rescan)
    */
 
 
-  db_transaction_begin();
   time(&now);
 
   item = data->item;
@@ -533,8 +532,6 @@ scan_rss(const char *file, time_t mtime, bool force_rescan)
       free_mfi(&mfi, 1);
       item = item->next;
     }
-
-  db_transaction_end();
 
 cleanup:
   mrss_free(data);

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -327,11 +327,10 @@ rss_playlist_items(int plid)
 
 
 void
-scan_rss(const char *file, time_t mtime, int dir_id)
+scan_rss(const char *file, time_t mtime, bool force_rescan)
 {
   FILE *fp;
   struct media_file_info mfi;
-  struct stat sb;
   char buf[2048];
   enum rss_type rss_format;
   int pl_id;
@@ -354,18 +353,6 @@ scan_rss(const char *file, time_t mtime, int dir_id)
   if (rss_format == RSS_UNKNOWN)
     return;
 
-  ret = stat(file, &sb);
-  if (ret < 0)
-    {
-      DPRINTF(E_LOG, L_SCAN, "Could not stat() '%s': %s\n", file, strerror(errno));
-      return;
-    }
-  if (sb.st_size == 0)
-    {
-      DPRINTF(E_LOG, L_SCAN, "Ingoring empty RSS file '%s'\n", file);
-      return;
-    }
-
   fp = fopen(file, "r");
   if (!fp)
     {
@@ -374,7 +361,7 @@ scan_rss(const char *file, time_t mtime, int dir_id)
     }
 
   // Will create or update the playlist entry in the database
-  pl_id = rss_playlist_prepare(file, mtime);
+  pl_id = rss_playlist_prepare(file, force_rescan ? 0 : mtime);
   if (pl_id < 0)
     return;
 

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -466,10 +466,12 @@ scan_rss(const char *file, time_t mtime, bool force_rescan)
           // (apple) can use mp4 streams which tend not to have decent tags so 
           // in those cases take info from the RSS and not the stream
           if (!mfi.artist) mfi.artist = safe_strdup(item->author ? item->author : category_author);
-          if (!mfi.title)  mfi.title  = safe_strdup(item->title);
           if (!mfi.album)  mfi.album  = safe_strdup(data->title);
           if (!mfi.url)    mfi.url    = safe_strdup(item->link);
           if (!mfi.genre)  mfi.genre  = strdup("Podcast");
+
+          // Title not valid on mp4 (it becomes the url obj) so take from RSS feed
+          free(mfi.title); mfi.title  = safe_strdup(item->title);
 
           // Ignore this - some can be very verbose - we don't show use these
           // on the podcast

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -190,7 +190,7 @@ process_apple_rss(char* buf, unsigned bufsz, const char *file)
   ctx.input_body = evbuf;
 
   ret = http_client_request(&ctx);
-  if (ret < 0 || ret && ctx.response_code != HTTP_OK)
+  if (ret < 0 || (ret && ctx.response_code != HTTP_OK))
     {
       evbuffer_free(evbuf);
       return NULL;
@@ -281,7 +281,7 @@ process_image_url(const char *image_url, const char *file)
   ctx.input_body = evbuf;
 
   ret = http_client_request(&ctx);
-  if (ret < 0 || ret && ctx.response_code != HTTP_OK)
+  if (ret < 0 || (ret && ctx.response_code != HTTP_OK))
     {
       DPRINTF(E_INFO, L_SCAN, "Could not retreive RSS image\n");
     }
@@ -297,6 +297,7 @@ process_image_url(const char *image_url, const char *file)
 }
 
 
+#ifdef RSS_DEBUG
 static void
 rss_playlist_items(int plid)
 {
@@ -324,7 +325,7 @@ rss_playlist_items(int plid)
 
   return;
 }
-
+#endif
 
 void
 scan_rss(const char *file, time_t mtime, bool force_rescan)
@@ -350,6 +351,7 @@ scan_rss(const char *file, time_t mtime, bool force_rescan)
   CURLcode code;
 
   rss_format = rss_type(file);
+  DPRINTF(E_DBG, L_SCAN, "RSS working on: '%s' type: %d\n", file, rss_format);
   if (rss_format == RSS_UNKNOWN)
     return;
 
@@ -479,7 +481,7 @@ scan_rss(const char *file, time_t mtime, bool force_rescan)
 	  sprintf(vpath, "/%s", item->enclosure_url);
 
 	  // check if this item is already in the db - if so, we can stop since the RSS is given to us as LIFO stream
-	  if (feed_file_id = db_file_id_by_virtualpath_match(vpath))
+	  if ((feed_file_id = db_file_id_by_virtualpath_match(vpath)) > 0)
 	    {
 	      DPRINTF(E_DBG, L_SCAN, "Item %d already in DB, finished with RSS feed: plid %d Channel '%s' item={ PubDate '%s' url '%s' }\n", feed_file_id, pl_id, data->title, item->pubDate, item->enclosure_url);
 	      break;

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -143,7 +143,7 @@ process_apple_rss(char* buf, unsigned bufsz, const char *file)
   ctx.input_body = evbuf;
 
   ret = http_client_request(&ctx);
-  if (ret < 0)
+  if (ret < 0 || ret && ctx.response_code != HTTP_OK)
     {
       evbuffer_free(evbuf);
       return NULL;

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -75,6 +75,8 @@ rss_playlist_prepare(const char *path, time_t mtime)
     }
 
   db_pl_ping(pli->id);
+  db_pl_ping_items_bymatch("http://", pli->id);
+  db_pl_ping_items_bymatch("https://", pli->id);
 
   // mtime == db_timestamp is also treated as a modification because some editors do
   // stuff like 1) close the file with no changes (leading us to update db_timestamp),
@@ -82,8 +84,6 @@ rss_playlist_prepare(const char *path, time_t mtime)
   // is equal to the newly updated db_timestamp)
   if (mtime && (pli->db_timestamp > mtime))
     {
-      db_pl_ping_items_bymatch("http://", pli->id);
-      db_pl_ping_items_bymatch("https://", pli->id);
       free_pli(pli, 0);
       return -1;
     }

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -343,6 +343,7 @@ scan_rss(const char *file, time_t mtime, int dir_id)
   unsigned vpathlen = 0;
   unsigned len = 0;
   bool has_artwork = false;
+  time_t now;
 
   mrss_t *data = NULL;
   mrss_error_t ret;
@@ -470,6 +471,7 @@ scan_rss(const char *file, time_t mtime, int dir_id)
 
 
   db_transaction_begin();
+  time(&now);
 
   item = data->item;
   while (item)
@@ -516,8 +518,14 @@ scan_rss(const char *file, time_t mtime, int dir_id)
           rss_date(&tm, item->pubDate);
           mfi.date_released = mktime(&tm);
           mfi.year = 1900 + tm.tm_year;
-          mfi.track = nadded +1;
           mfi.media_kind = MEDIA_KIND_PODCAST;
+
+	  // fake the time - useful when we are adding a new stream - since the
+	  // newest podcasts are added first (the stream is most recent first) 
+	  // having time_added date which is older on the most recent episodes 
+	  // makes no sense so make all the dates the same for a singleu update
+	  mfi.time_added = now;
+
           if (has_artwork)
             mfi.artwork = ARTWORK_DIR;
 

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -107,7 +107,7 @@ scan_rss(const char *file, time_t mtime, int dir_id)
   char buf[PATH_MAX];
   enum rss_type rss_format;
   int pl_id;
-  int nadded;
+  unsigned nadded;
   struct tm tm;
 
   mrss_t *data = NULL;
@@ -241,6 +241,8 @@ scan_rss(const char *file, time_t mtime, int dir_id)
       rss_date(&tm, item->pubDate);
       mfi.date_released = mktime(&tm);
       mfi.year = 1900 + tm.tm_year;
+      mfi.track = nadded +1;
+      mfi.media_kind = MEDIA_KIND_PODCAST;
 
       mfi.id = db_file_id_bypath(item->enclosure_url);
 
@@ -263,7 +265,7 @@ cleanup:
   free_mfi(&mfi, 1);
   mrss_free(data);
 
-  DPRINTF(E_LOG, L_SCAN, "Done processing RSS, added/modified %d items\n", nadded);
+  DPRINTF(E_LOG, L_SCAN, "Done processing RSS, added/modified %u items\n", nadded);
 
   fclose(fp);
 }

--- a/src/library/filescanner_rss.c
+++ b/src/library/filescanner_rss.c
@@ -498,9 +498,7 @@ scan_rss(const char *file, time_t mtime, bool force_rescan)
 
           if (++nadded%50 == 0)
             {
-                DPRINTF(E_LOG, L_SCAN, "RSS added %d entries...\n", nadded);
-                db_transaction_end();
-                db_transaction_begin();
+              DPRINTF(E_LOG, L_SCAN, "RSS added %d entries...\n", nadded);
             }
         }
       free_mfi(&mfi, 1);

--- a/src/logger.c
+++ b/src/logger.c
@@ -57,7 +57,7 @@ static uint32_t logger_repeat_counter;
 static uint32_t logger_last_hash;
 static char *logfilename;
 static FILE *logfile;
-static char *labels[] = { "config", "daap", "db", "httpd", "http", "main", "mdns", "misc", "rsp", "scan", "xcode", "event", "remote", "dacp", "ffmpeg", "artwork", "player", "raop", "laudio", "dmap", "dbperf", "spotify", "lastfm", "cache", "mpd", "stream", "cast", "fifo", "lib", "web" };
+static char *labels[] = { "config", "daap", "db", "httpd", "http", "main", "mdns", "misc", "rsp", "scan", "xcode", "event", "remote", "dacp", "ffmpeg", "artwork", "player", "raop", "laudio", "dmap", "dbperf", "spotify", "lastfm", "cache", "mpd", "stream", "cast", "fifo", "lib", "web", "rss" };
 static char *severities[] = { "FATAL", "LOG", "WARN", "INFO", "DEBUG", "SPAM" };
 
 

--- a/src/logger.h
+++ b/src/logger.h
@@ -36,8 +36,9 @@
 #define L_FIFO        27
 #define L_LIB         28
 #define L_WEB         29
+#define L_RSS         30
 
-#define N_LOGDOMAINS  30
+#define N_LOGDOMAINS  31
 
 /* Severities */
 #define E_FATAL   0

--- a/src/main.c
+++ b/src/main.c
@@ -74,6 +74,10 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 #ifdef LASTFM
 # include "lastfm.h"
 #endif
+#ifdef MRSS
+# include "rss.h"
+#endif
+
 
 #ifdef HAVE_LIBCURL
 # include <curl/curl.h>
@@ -843,6 +847,17 @@ main(int argc, char **argv)
   lastfm_init();
 #endif
 
+#ifdef MRSS
+  ret = rss_init();
+  if (ret != 0)
+    {
+      DPRINTF(E_FATAL, L_MAIN, "RSS thread failed to start\n");
+
+      ret = EXIT_FAILURE;
+      goto rss_fail;
+    }
+#endif
+
   /* Start Remote pairing service */
   ret = remote_pairing_init();
   if (ret != 0)
@@ -935,6 +950,13 @@ main(int argc, char **argv)
   remote_pairing_deinit();
 
  remote_fail:
+#ifdef MRSS
+  DPRINTF(E_LOG, L_MAIN, "RSS deinit\n");
+  rss_deinit();
+
+  rss_fail:
+#endif
+
 #ifdef MPD
   DPRINTF(E_LOG, L_MAIN, "MPD deinit\n");
   mpd_deinit();

--- a/src/rss.c
+++ b/src/rss.c
@@ -49,6 +49,10 @@ static struct event *rss_syncev = NULL;
 static pthread_t  rss_tid = -1;
 const char *pl_dir = NULL;
 
+static bool lib_updating = false;
+static pthread_mutex_t lib_upd_mtx;
+static pthread_cond_t lib_upd_cond;
+
 
 // relevant fields from playlist tbl
 struct rss_file_item {
@@ -95,6 +99,15 @@ rfi_add(struct rss_file_item* head)
   return curr->next;
 }
 
+static void
+rss_listener_cb(short events)
+{
+  pthread_mutex_lock(&lib_upd_mtx);
+  lib_updating = !lib_updating;
+DPRINTF(E_INFO, L_RSS, "*** library update change: %s ***\n", lib_updating ? "start" : "done");
+  pthread_cond_broadcast(&lib_upd_cond);
+  pthread_mutex_unlock(&lib_upd_mtx);
+}
 
 /* Thread: rss */
 static void
@@ -102,26 +115,45 @@ rss_sync(int *retval)
 {
   struct query_params query_params;
   struct db_playlist_info dbpli;
-  struct rss_file_item*  rfi = NULL;
-  struct rss_file_item*  head = NULL;
+  struct rss_file_item *rfi = NULL;
+  struct rss_file_item *head = NULL;
+  struct timespec ts;
+  struct timeval tvnow;
   time_t  now;
   int ret = 0;
 
   *retval = 0;
 
-  DPRINTF(E_INFO, L_RSS, "refreshing RSS feeds\n");
   memset(&query_params, 0, sizeof(struct query_params));
+
+  pthread_mutex_lock(&lib_upd_mtx);
+  while (library_is_scanning())
+    {
+      DPRINTF(E_INFO, L_RSS, "DB scan in progress, delaying RSS feed update\n");
+      do
+        {
+          gettimeofday(&tvnow, NULL);
+          ts.tv_sec  = tvnow.tv_sec + 5;
+          ts.tv_nsec = tvnow.tv_usec;
+
+          pthread_cond_timedwait(&lib_upd_cond, &lib_upd_mtx, &ts);
+          if (library_is_exiting())
+            {
+              pthread_mutex_unlock(&lib_upd_mtx);
+              goto cleanup;
+            }
+        }
+      while (lib_updating);
+      DPRINTF(E_INFO, L_RSS, "Resuming RSS feed update\n");
+    }
+  // lock library
+  library_set_scanning(true);
+  pthread_mutex_unlock(&lib_upd_mtx);
+  DPRINTF(E_INFO, L_RSS, "Refreshing RSS feeds\n");
 
   query_params.type = Q_PL;
   query_params.sort = S_PLAYLIST;
   query_params.filter = db_mprintf("(f.type = %d)", PL_RSS);
-
-  // TODO - how to do this in FD framework???
-  while (library_is_scanning())
-  {
-    DPRINTF(E_LOG, L_RSS, "DB scan in progress, waiting\n");
-    sleep(10);
-  }
 
   ret = db_query_start(&query_params);
   if (ret < 0)
@@ -148,7 +180,6 @@ rss_sync(int *retval)
   db_query_end(&query_params);
   time(&now);
 
-  library_set_scanning(true);
   rfi = head;
   while (rfi)
   {
@@ -171,6 +202,7 @@ rss_sync(int *retval)
   free(query_params.filter);
   free_rfi(head);
 
+ cleanup:
   evtimer_add(rss_syncev, &rss_sync_interval);
 }
 
@@ -211,6 +243,9 @@ rss_init()
 {
   int ret;
 
+  pthread_mutex_init(&lib_upd_mtx, NULL);
+  pthread_cond_init(&lib_upd_cond, NULL);
+
   rss_sync_interval.tv_sec = cfg_getint(cfg_getsec(cfg, "rss"), "sync_period");
   if (rss_sync_interval.tv_sec < 60) 
     {
@@ -223,6 +258,13 @@ rss_init()
     {
       DPRINTF(E_LOG, L_RSS, "Config playlist dir is not writable, will disable saving of new RSS feeds\n");
       pl_dir = NULL;
+    }
+
+  ret = listener_add(rss_listener_cb, LISTENER_UPDATE);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_RSS, "Could not create an DB watcher\n");
+      goto listener_fail;
     }
 
   evbase_rss = event_base_new();
@@ -266,6 +308,8 @@ rss_init()
   evbase_rss = NULL;
 
  evbase_fail:
+  listener_remove(rss_listener_cb);
+ listener_fail:
   return -1;
 }
 
@@ -283,6 +327,10 @@ rss_deinit()
     }
   event_free(rss_syncev);
   event_base_free(evbase_rss);
+
+  listener_remove(rss_listener_cb);
+  pthread_mutex_destroy(&lib_upd_mtx);
+  pthread_cond_destroy(&lib_upd_cond);
 }
 
 int

--- a/src/rss.c
+++ b/src/rss.c
@@ -299,7 +299,7 @@ rss_feed_create(const char *name, const char* url)
   if (strncmp(url, "http://", 7) != 0 && strncmp(url, "https://", 8) != 0)
     return -1;
 
-  ret = snprintf(path, sizeof(path), "%s/%s.rss_url", pl_dir, name);
+  ret = snprintf(path, sizeof(path), "%s/%s.rss", pl_dir, name);
   if (ret < 0 || ret > sizeof(path))
     {
       DPRINTF(E_LOG, L_RSS, "Unable to create file path RSS feed: '%s' under '%s'\n", name, pl_dir);

--- a/src/rss.c
+++ b/src/rss.c
@@ -36,8 +36,7 @@
 #include "library.h"
 #include "listener.h"
 #include "logger.h"
-
-extern void scan_rss(const char *file, time_t mtime, int removeme);
+#include "library/filescanner.h"
 
 
 static struct event_base *evbase_rss = NULL;
@@ -158,7 +157,7 @@ rss_sync(int *retval)
     else
       {
 	DPRINTF(E_LOG, L_RSS, "Sync'ing %s  last update: %s", rfi->title, ctime(&(rfi->lastupd)));
-	scan_rss(rfi->file, time(&now), -1);
+	scan_rss(rfi->file, time(&now), false);
       }
     rfi = rfi->next;
   }

--- a/src/rss.c
+++ b/src/rss.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2020 whatdoineed2do/Ray <whatdoineed2do @ gmail com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <event2/event.h>
+#include <stddef.h>
+#include <string.h>
+#include <time.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <pthread.h>
+#ifdef HAVE_PTHREAD_NP_H
+# include <pthread_np.h>
+#endif
+
+#include "rss.h"
+#include "conffile.h"
+#include "db.h"
+#include "library.h"
+#include "listener.h"
+#include "logger.h"
+
+extern void scan_rss(const char *file, time_t mtime, int removeme);
+
+
+static struct event_base *evbase_rss = NULL;
+static struct commands_base *cmdbase = NULL;
+static struct timeval rss_sync_interval = { 60, 0 };
+static struct event *rss_syncev = NULL;
+
+
+static pthread_t  rss_tid = -1;
+static bool  first = true;
+
+
+// relevant fields from playlist tbl
+struct rss_file_item {
+  char *title;
+  char *file;
+  time_t lastupd;
+  struct rss_file_item *next;
+};
+
+static void
+free_rfi(struct rss_file_item* rfi)
+{
+  if (!rfi) return;
+
+  struct rss_file_item *tmp;
+  while (rfi)
+  {
+    tmp = rfi->next;
+    free(rfi->file);
+    free(rfi->title);
+    free(rfi);
+    rfi = tmp;
+  }
+}
+
+// should only be called by rfi_add() and if you are getting a new list
+static struct rss_file_item*
+rfi_alloc()
+{
+  struct rss_file_item *obj = malloc(sizeof(struct rss_file_item));
+  memset(obj, 0, sizeof(struct rss_file_item));
+  return obj;
+}
+
+// returns the newly alloc'd / added item at end of list
+static struct rss_file_item*
+rfi_add(struct rss_file_item* head)
+{
+  struct rss_file_item *curr = head;
+  while (curr->next)
+    curr = curr->next;
+
+  curr->next = rfi_alloc();
+  return curr->next;
+}
+
+
+/* Thread: rss */
+static void
+rss_sync(int *retval)
+{
+  struct query_params query_params;
+  struct db_playlist_info dbpli;
+  struct rss_file_item*  rfi = NULL;
+  struct rss_file_item*  head = NULL;
+  time_t  now;
+  int ret = 0;
+
+  *retval = 0;
+
+  memset(&query_params, 0, sizeof(struct query_params));
+
+  query_params.type = Q_PL;
+  query_params.sort = S_PLAYLIST;
+  query_params.filter = db_mprintf("(f.type = %d)", PL_RSS);
+
+  // TODO - how to do this in FD framework???
+  while (library_is_scanning())
+  {
+    DPRINTF(E_LOG, L_RSS, "DB scan in progress, waiting\n");
+    sleep(30);
+  }
+
+  ret = db_query_start(&query_params);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_RSS, "Failed to find current RSS feeds from db\n");
+      *retval = ret;
+      goto error;
+    }
+
+  while (((ret = db_query_fetch_pl(&query_params, &dbpli)) == 0) && (dbpli.id))
+    {
+      if (!rfi) 
+      {
+	rfi = rfi_alloc();
+	head = rfi;
+      }
+      else
+	rfi = rfi_add(rfi);
+
+      rfi->title = strdup(dbpli.title);
+      rfi->file  = strdup(dbpli.path);
+      rfi->lastupd = atol(dbpli.db_timestamp);
+    }
+  db_query_end(&query_params);
+  time(&now);
+
+  library_set_scanning(true);
+  rfi = head;
+  while (rfi)
+  {
+    if (!first && now < rfi->lastupd + rss_sync_interval.tv_sec)
+      {
+	DPRINTF(E_DBG, L_RSS, "Skipping %s  last update: %s", rfi->title, ctime(&(rfi->lastupd)));
+      }
+    else
+      {
+	DPRINTF(E_LOG, L_RSS, "Sync'ing %s  last update: %s", rfi->title, ctime(&(rfi->lastupd)));
+	scan_rss(rfi->file, time(&now), -1);
+      }
+    rfi = rfi->next;
+  }
+  library_set_scanning(false);
+
+ error:
+  free(query_params.filter);
+  free_rfi(head);
+
+  evtimer_add(rss_syncev, &rss_sync_interval);
+  first = false;
+}
+
+static enum command_state
+rss_sync_cmd(void *arg, int *retval)
+{
+  rss_sync(retval);
+  return COMMAND_END;
+}
+
+static void
+rss_sync_cb(int fd, short what, void *arg)
+{
+  commands_exec_async(cmdbase, rss_sync_cmd, NULL);
+}
+
+static void *
+rss(void *arg)
+{
+  int ret;
+
+  ret = db_perthread_init();
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_RSS, "Error: DB init failed\n");
+
+      pthread_exit(NULL);
+    }
+  rss_sync(&ret);
+  event_base_dispatch(evbase_rss);
+
+  db_perthread_deinit();
+
+  pthread_exit(NULL);
+}
+
+int
+rss_init()
+{
+  int ret;
+
+  rss_sync_interval.tv_sec = cfg_getint(cfg_getsec(cfg, "rss"), "sync_period");
+  if (rss_sync_interval.tv_sec < 60) 
+    {
+      DPRINTF(E_LOG, L_RSS, "RSS 'sync_period' too low, defaulting to 60seconds\n");
+      rss_sync_interval.tv_sec = 60;
+    }
+
+  evbase_rss = event_base_new();
+  if (!evbase_rss)
+    {
+      DPRINTF(E_LOG, L_RSS, "Could not create an event base\n");
+      goto evbase_fail;
+    }
+  rss_syncev= evtimer_new(evbase_rss, rss_sync_cb, NULL);
+  if (!rss_syncev)
+    {
+      DPRINTF(E_LOG, L_RSS, "Could not create an event timer\n");
+      goto evnew_fail;
+    }
+
+  cmdbase = commands_base_new(evbase_rss, NULL);
+
+  DPRINTF(E_INFO, L_RSS, "RSS thread init\n");
+
+  ret = pthread_create(&rss_tid, NULL, rss, NULL);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_RSS, "Could not spawn RSS thread: %s\n", strerror(errno));
+      goto thread_fail;
+    }
+
+#if defined(HAVE_PTHREAD_SETNAME_NP)
+  pthread_setname_np(rss_tid, "rss");
+#elif defined(HAVE_PTHREAD_SET_NAME_NP)
+  pthread_set_name_np(rss_tid, "rss");
+#endif
+  
+  return 0;
+
+ thread_fail:
+ evnew_fail:
+  event_free(rss_syncev);
+  event_base_free(evbase_rss);
+  evbase_rss = NULL;
+
+ evbase_fail:
+  return -1;
+}
+
+void
+rss_deinit()
+{
+  int ret;
+
+  commands_base_destroy(cmdbase);
+  ret = pthread_join(rss_tid, NULL);
+  if (ret != 0)
+    {
+      DPRINTF(E_FATAL, L_RSS, "Could not join RSS thread: %s\n", strerror(errno));
+      return;
+    }
+  event_free(rss_syncev);
+  event_base_free(evbase_rss);
+}

--- a/src/rss.c
+++ b/src/rss.c
@@ -157,7 +157,9 @@ rss_sync(int *retval)
     else
       {
 	DPRINTF(E_DBG, L_RSS, "Sync'ing %s  last update: %s", rfi->title, ctime(&(rfi->lastupd)));
+        db_transaction_begin();
 	scan_rss(rfi->file, time(&now), false);
+        db_transaction_end();
       }
     rfi = rfi->next;
   }

--- a/src/rss.h
+++ b/src/rss.h
@@ -1,0 +1,13 @@
+#ifndef FD_RSS_H
+#define FD_RSS_H
+
+/* Start RSS scanning thread
+ * @return       0 on success, -1 on error
+ */
+int
+rss_init(void);
+
+void
+rss_deinit(void);
+
+#endif

--- a/src/rss.h
+++ b/src/rss.h
@@ -10,4 +10,10 @@ rss_init(void);
 void
 rss_deinit(void);
 
+int
+rss_feed_create(const char *name, const char* url);
+
+int
+rss_feed_delete(const char *name, const char* url);
+
 #endif


### PR DESCRIPTION
Implements https://github.com/ejurgensen/forked-daapd/issues/880

**WIP** - I'd like to get some feedback on this PR that would allow RSS podcasts to be stored and automatically retreived by the server - its a WIP but works well enough to add podcasts to the library and update them correctly.

Of note:
* RSS feeds are treated as `playlists` on the filesystem.
As such, we provide the RSS feeds to the library in files.  These files can a local file (`.rss`) containing the feed's XML or much preferably a local file (`.rss_url`) that contains the web address for RSS feed ( such as `https://podcasts.files.bbci.co.uk/p004t1hd.rss`).  The retreival of RSS feed is a filescanner
The actual audio streams are not downloaded but simply referenced to the remote `http` streams in the `files` tbl with `media_kind = 4/podcast`

* playlist table
Added a `PL_RSS` type so we can identify RSS in the db tbl and exposed some methods from `filescanner_playlist.c`

* no other tbl used (at the moment)
This means that we always inspect the file on the filesystem representing rss feed to obtain the feed url.  We could add this to the db as part of `playlist` tbl.  The name file on disk  is represnted in the `playlist ` tbl but not show in the web interface or the IOS remote appl. 

* The RSS are treated as albums and each RSS podcast a track; most of the info is taken from the RSS channel and RSS item even if some remote mp3 streams have embedded meta (like genre but also title etc).  Given RSS aggregators use whats published on the rss stream, we'll do the same

* periodic refresh
This has a thread that uses an `evtimer` to kick off the periodic feed scans based on config value;  it creates a simple query for playlists that has `type = PL_RSS`.  On the returned RSS results it will determine if it needs to refresh based on timestramp in db.
~**TODO: needs some guidance to figure out how not busy wait if a db scan is in flight** -- using `listener UPDATE` and tracking changes to know when library is 'free' and then lock library to perform periodic RSS scan and update~There is a consideration to avoid mutiple scans/updates to db at the same time - the `library`'s `*scan` functions call a start/end method to lock to library for their updates.  The refresh thread asks the library to lock library before performing the scan.
Only new items not in the DB will be added - as the rss feed should give most recent first, it'll stop adding new tracks to db when it finds a stream in the feed that it's seen before

* uses [libmrss](http://github.com/bakulf/libmrss) for RSS retrieval and parsing
Not in fedora ~or~ but in debian repos as `libmrss0-dev`

* IOS remote - showing in `podcast` section
There is this code in `httpd_daap.c` that skips the lookup on internet streams.  However blocks the db from finding the rss streams which are obviously http types.  What would be the most sensible way to get around this?  Dropping this (as PoC) does in fact present the rss podcasts on the IOS remote appl's podcast section.
Using additional check on filter when the client is asking for `media_kind = 4` (podcast)
```
 user_agent_filter(struct query_params *qp, struct daap_request *dreq)
 {
   char *filter;

   if (s->is_remote)
    {
      // This makes sure 1) the SELECT is from files, 2) that the Remote query
      // contained extended_media_kind:1, which characterise the queries we want
      // to filter. TODO: Not a really nice way of doing this, but best I could
      // think of.
      if (!qp->filter || !strstr(qp->filter, "f.media_kind"))
        return;

      filter = safe_asprintf("%s AND (f.data_kind <> %d)", qp->filter, DATA_KIND_HTTP);
```
The DAAP request when IOS remote podcast is being populated:
```
[DEBUG]     daap: DAAP request: '/databases/1/groups?meta=dmap.itemname,dmap.itemid,dmap.persistentid,daap.songartist,daap.songyear,daap.songtracknumber,daap.songtime,daap.songcategory,daap.songgenre,daap.songhasbeenplayed,daap.songuserplaycount,daap.songdatereleased,daap.songdatepurchased,daap.songdateadded,daap.sortartist,daap.songcontentdescription,daap.songlongcontentdescription,com.apple.itunes.is-hd-video,com.apple.itunes.has-chapter-data,dmap.itemcount,com.apple.itunes.extended-media-kind&type=music&group-type=albums&sort=album&include-sort-headers=0&query=('daap.songalbum!:'+('com.apple.itunes.extended-media-kind:4','com.apple.itunes.extended-media-kind:36','com.apple.itunes.extended-media-kind:6','com.apple.itunes.extended-media-kind:7'))&session-id=596195498'
[DEBUG]     daap: Sorting songlist by album
[DEBUG]     daap: DAAP browse query filter: ('daap.songalbum!:' ('com.apple.itunes.extended-media-kind:4','com.apple.itunes.extended-media-kind:36','com.apple.itunes.extended-media-kind:6','com.apple.itunes.extended-media-kind:7'))
[DEBUG]     daap: Trying DAAP query -('daap.songalbum!:' ('com.apple.itunes.extended-media-kind:4','com.apple.itunes.extended-media-kind:36','com.apple.itunes.extended-media-kind:6','com.apple.itunes.extended-media-kind:7'))-
[DEBUG]     daap: Ignoring clause 'daap.songalbum!:'
[DEBUG]     daap: DAAP SQL query: -((((f.media_kind = 4 OR f.media_kind = 36) OR f.media_kind = 6) OR f.media_kind = 7))-
[DEBUG]     daap: SQL filter w/client mod: ((((f.media_kind = 4 OR f.media_kind = 36) OR f.media_kind = 6) OR f.media_kind = 7)) AND (f.data_kind <> 1)
[DEBUG]     daap: Asking for 21 meta tags
[ WARN]     daap: Could not find requested meta field 'daap.songdatepurchased'
[ WARN]     daap: Could not find requested meta field 'com.apple.itunes.is-hd-video'
[ WARN]     daap: Could not find requested meta field 'com.apple.itunes.has-chapter-data'
[DEBUG]     daap: Found 18 meta tags
[DEBUG]       db: Running query 'SELECT COUNT(DISTINCT f.songalbumid) FROM files f WHERE f.disabled = 0 AND ((((f.media_kind = 4 OR f.media_kind = 36) OR f.media_kind = 6) OR f.media_kind = 7)) AND (f.data_kind <> 1);'
[DEBUG]       db: Starting query 'SELECT g.id, g.persistentid, f.album, f.album_sort, COUNT(f.id) as track_count, COUNT(DISTINCT f.songartistid) as artist_count, COUNT(DISTINCT f.songalbumid) as album_count, CASE WHEN COUNT(DISTINCT f.songartistid) > 1 THEN 'Various Artists' ELSE f.album_artist END as album_artist, GROUP_CONCAT(DISTINCT f.songartistid) as songartistid, SUM(f.song_length) FROM files f JOIN groups g ON f.songalbumid = g.persistentid WHERE f.disabled = 0 AND ((((f.media_kind = 4 OR f.media_kind = 36) OR f.media_kind = 6) OR f.media_kind = 7)) AND (f.data_kind <> 1) GROUP BY f.songalbumid  ORDER BY f.album_sort, f.disc, f.track, f.title_sort, f.album_artist_sort ;'
[DEBUG]       db: End of query results
[DEBUG]     daap: Done with group list, 0 groups
```
Thanks