### PR TITLE
Json spotify token leak

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -1110,7 +1110,7 @@ jsonapi_reply_spotify(struct httpd_request *hreq)
   spotifywebapi_access_token_get(&webapi_token);
   safe_json_add_string(jreply, "webapi_token", webapi_token.token);
   json_object_object_add(jreply, "webapi_token_expires_in", json_object_new_int(webapi_token.expires_in));
-
+  free(webapi_token.token);
 #else
   json_object_object_add(jreply, "enabled", json_object_new_boolean(false));
 #endif


### PR DESCRIPTION
```
==28284== 394 bytes in 2 blocks are definitely lost in loss record 311 of 341
==28284==    at 0x4C2EE3B: malloc (vg_replace_malloc.c:309)
==28284==    by 0xA7B3C89: strdup (in /usr/lib64/libc-2.27.so)
==28284==    by 0x477580: spotifywebapi_access_token_get (spotify_webapi.c:1980)
==28284==    by 0x4494C8: jsonapi_reply_spotify (httpd_jsonapi.c:1110)
```
strdup is never free