### PR TITLE
Daap support date released

### DIFF
--- a/src/SMARTPL.g
+++ b/src/SMARTPL.g
@@ -101,6 +101,7 @@ DATETAG		:	'time_added'
 			|	'time_modified'
 			|	'time_played'
 			|	'time_skipped'
+			|	'date_released'
 			;
 
 ENUMTAG		:	'data_kind'

--- a/src/db.c
+++ b/src/db.c
@@ -426,6 +426,7 @@ static const char *sort_clause[] =
     "f.virtual_path COLLATE NOCASE",
     "pos",
     "shuffle_pos",
+    "f.date_released DESC",
   };
 
 /* Browse clauses, used for SELECT, WHERE, GROUP BY and for default ORDER BY

--- a/src/db.h
+++ b/src/db.h
@@ -30,6 +30,7 @@ enum sort_type {
   S_VPATH,
   S_POS,
   S_SHUFFLE_POS,
+  S_RELEASEDATE,
 };
 
 #define Q_F_BROWSE (1 << 15)

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -368,6 +368,9 @@ static const struct db_init_query db_init_table_queries[] =
 #define I_QUEUE_SHUFFLEPOS				\
   "CREATE INDEX IF NOT EXISTS idx_queue_shufflepos ON queue(shuffle_pos);"
 
+#define I_FILE_DATE_RELEASED                    \
+  "CREATE INDEX IF NOT EXISTS idx_file_datereleased ON files(date_released);"
+
 static const struct db_init_query db_init_index_queries[] =
   {
     { I_RESCAN,    "create rescan index" },
@@ -401,6 +404,8 @@ static const struct db_init_query db_init_index_queries[] =
 
     { I_QUEUE_POS,  "create queue pos index" },
     { I_QUEUE_SHUFFLEPOS,  "create queue shuffle pos index" },
+
+    { I_FILE_DATE_RELEASED, "create file date_released index" },
   };
 
 

--- a/src/httpd_daap.c
+++ b/src/httpd_daap.c
@@ -573,7 +573,7 @@ query_params_set(struct query_params *qp, int *sort_headers, struct httpd_reques
       else if (strcmp(param, "artist") == 0 && (type != Q_BROWSE_ARTISTS)) // Only set if non-default sort requested
 	qp->sort = S_ARTIST;
       else if (strcmp(param, "releasedate") == 0)
-	qp->sort = S_NAME;
+	qp->sort = S_RELEASEDATE;
       else
 	DPRINTF(E_DBG, L_DAAP, "Unknown sort param: %s\n", param);
 


### PR DESCRIPTION
`daap` can ask for sorting via `releasedate` - this currently returns items sorted by name (`S_NAME`).

Add new index for `date_released`, sorting criteria, and expose `date_released` on SMARTPL