### PR TITLE
JSON API - Support for Playlist Folders

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -747,6 +747,7 @@ curl -X PUT "http://localhost:3689/api/queue/items/2"
 | GET       | [/api/library/playlists](#list-playlists)                   | Get a list of playlists              |
 | GET       | [/api/library/playlists/{id}](#get-a-playlist)              | Get a playlist                       |
 | GET       | [/api/library/playlists/{id}/tracks](#list-playlist-tracks) | Get list of tracks for a playlist    |
+| GET       | [/api/library/playlists/{id}/playlists](#list-playlists-in-a-playlist-folder) | Get list of playlists for a playlist folder   |
 | GET       | [/api/library/artists](#list-artists)                       | Get a list of artists                |
 | GET       | [/api/library/artists/{id}](#get-an-artist)                 | Get an artist                        |
 | GET       | [/api/library/artists/{id}/albums](#list-artist-albums)     | Get list of albums for an artist     |
@@ -807,7 +808,7 @@ curl -X GET "http://localhost:3689/api/library"
 
 ### List playlists
 
-Lists the playlists in your library
+Lists all playlists in your library (does not return playlist folders)
 
 **Endpoint**
 
@@ -962,6 +963,76 @@ curl -X GET "http://localhost:3689/api/library/playlists/1/tracks"
     ...
   ],
   "total": 20,
+  "offset": 0,
+  "limit": -1
+}
+```
+
+
+### List playlists in a playlist folder
+
+Lists the playlists in a playlist folder
+
+**Note**: The root playlist folder has `id` 0.
+
+**Endpoint**
+
+```http
+GET /api/library/playlists/{id}/playlists
+```
+
+**Path parameters**
+
+| Parameter       | Value                |
+| --------------- | -------------------- |
+| id              | Playlist id          |
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| offset          | *(Optional)* Offset of the first playlist to return         |
+| limit           | *(Optional)* Maximum number of playlist to return           |
+
+**Response**
+
+| Key             | Type     | Value                                            |
+| --------------- | -------- | ------------------------------------------------ |
+| items           | array    | Array of [`playlist`](#playlist-object) objects  |
+| total           | integer  | Total number of playlists in the playlist folder |
+| offset          | integer  | Requested offset of the first playlist           |
+| limit           | integer  | Requested maximum number of playlist             |
+
+
+**Example**
+
+```shell
+curl -X GET "http://localhost:3689/api/library/playlists/0/tracks"
+```
+
+```json
+{
+  "items": [
+    {
+      "id": 11,
+      "name": "Spotify",
+      "path": "spotify:playlistfolder",
+      "parent_id": "0",
+      "smart_playlist": false,
+      "folder": true,
+      "uri": "library:playlist:11"
+    },
+    {
+      "id": 8,
+      "name": "bytefm",
+      "path": "/srv/music/Playlists/bytefm.m3u",
+      "parent_id": "0",
+      "smart_playlist": false,
+      "folder": false,
+      "uri": "library:playlist:8"
+    }
+  ],
+  "total": 2,
   "offset": 0,
   "limit": -1
 }
@@ -2203,7 +2274,10 @@ curl --include \
 | id              | string   | Playlist id                               |
 | name            | string   | Playlist name                             |
 | path            | string   | Path                                      |
-| smart_playlist  | boolean  | `true` if playlist is a smart playlist   |
+| parent_id       | integer  | Playlist id of the parent (folder) playlist |
+| type            | string   | Type of this playlist: `special`, `folder`, `smart`, `plain` |
+| smart_playlist  | boolean  | `true` if playlist is a smart playlist    |
+| folder          | boolean  | `true` if it is a playlist folder         |
 | uri             | string   | Resource identifier                       |
 
 

--- a/src/db.c
+++ b/src/db.c
@@ -510,6 +510,20 @@ db_data_kind_label(enum data_kind data_kind)
   return NULL;
 }
 
+/* Keep in sync with enum pl_type */
+static char *pl_type_label[] = { "special", "folder", "smart", "plain" };
+
+const char *
+db_pl_type_label(enum pl_type pl_type)
+{
+  if (pl_type < ARRAY_SIZE(pl_type_label))
+    {
+      return pl_type_label[pl_type];
+    }
+
+  return NULL;
+}
+
 /* Shuffle RNG state */
 struct rng_ctx shuffle_rng;
 

--- a/src/db.h
+++ b/src/db.h
@@ -227,6 +227,7 @@ struct media_file_info {
 
 #define mfi_offsetof(field) offsetof(struct media_file_info, field)
 
+/* Keep in sync with pl_type_label[] */
 /* PL_SPECIAL value must be in sync with type value in Q_PL* in db_init.c */
 enum pl_type {
   PL_SPECIAL = 0,
@@ -235,6 +236,9 @@ enum pl_type {
   PL_PLAIN = 3,
   PL_MAX,
 };
+
+const char *
+db_pl_type_label(enum pl_type pl_type);
 
 struct playlist_info {
   uint32_t id;           /* integer id (miid) */


### PR DESCRIPTION
First part to tackle #897, web interface changes will be done in a separate PR.

The changes to the API are backwards compatible, i. e. the `/api/library/playlists` endpoint still lists all playlists (excluding special playlists and folders).

The playlist folder hierarchy can be fetched with the new `/api/library/playlists/{id}/playlists` endpoint.