### PR TITLE
[http] leak fix for curl_slist_append() 

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -370,9 +370,9 @@ https_client_request_impl(struct http_client_ctx *ctx)
   curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent);
   curl_easy_setopt(curl, CURLOPT_URL, ctx->url);
 
+  headers = NULL;
   if (ctx->output_headers)
     {
-      headers = NULL;
       for (okv = ctx->output_headers->head; okv; okv = okv->next)
 	{
 	  snprintf(header, sizeof(header), "%s: %s", okv->name, okv->value);
@@ -400,6 +400,7 @@ https_client_request_impl(struct http_client_ctx *ctx)
   if (res != CURLE_OK)
     {
       DPRINTF(E_LOG, L_HTTP, "Request to %s failed: %s\n", ctx->url, curl_easy_strerror(res));
+      curl_slist_free_all(headers);
       curl_easy_cleanup(curl);
       return -1;
     }
@@ -408,6 +409,7 @@ https_client_request_impl(struct http_client_ctx *ctx)
   ctx->response_code = (int) response_code;
   curl_headers_save(ctx->input_headers, curl);
 
+  curl_slist_free_all(headers);
   curl_easy_cleanup(curl);
 
   return 0;


### PR DESCRIPTION
list is not freed when headers are requested:
```
==17141==    at 0x4C2EE3B: malloc (vg_replace_malloc.c:309)
==17141==    by 0x911DDFE: curl_slist_append (in /usr/lib64/libcurl.so.4.5.0)
==17141==    by 0x44AF19: https_client_request_impl (http.c:379)
==17141==    by 0x470528: request_endpoint (spotify_webapi.c:293)
==17141==    by 0x470648: request_user_info (spotify_webapi.c:339)
==17141==    by 0x470B04: token_refresh (spotify_webapi.c:444)
==17141==    by 0x472E0D: spotifywebapi_access_token_get (spotify_webapi.c:1969)
```

Observed with having spotify enabled at runtime connecting to web i/f.
```
[  LOG]      lib: Library init scan completed in 18 sec (0 changes)
[ INFO]     http: Making request for https://accounts.spotify.com/api/token
[ INFO]     http: Making request for https://api.spotify.com/v1/me
^C[  LOG]     main: Got SIGTERM or SIGINT
```