### PR TITLE
[json] enable playlist play_count

### DIFF
--- a/README_JSON_API.md
+++ b/README_JSON_API.md
@@ -747,6 +747,7 @@ curl -X PUT "http://localhost:3689/api/queue/items/2"
 | GET       | [/api/library/playlists](#list-playlists)                   | Get a list of playlists              |
 | GET       | [/api/library/playlists/{id}](#get-a-playlist)              | Get a playlist                       |
 | GET       | [/api/library/playlists/{id}/tracks](#list-playlist-tracks) | Get list of tracks for a playlist    |
+| PUT       | [/api/library/playlists/{id}/tracks](#update-playlist-tracks) | Update play count of tracks for a playlist    |
 | GET       | [/api/library/playlists/{id}/playlists](#list-playlists-in-a-playlist-folder) | Get list of playlists for a playlist folder   |
 | GET       | [/api/library/artists](#list-artists)                       | Get a list of artists                |
 | GET       | [/api/library/artists/{id}](#get-an-artist)                 | Get an artist                        |
@@ -968,6 +969,34 @@ curl -X GET "http://localhost:3689/api/library/playlists/1/tracks"
 }
 ```
 
+### Update playlist tracks
+
+Updates the play count for tracks in a playlists
+
+**Endpoint**
+
+```http
+PUT /api/library/playlists/{id}/tracks
+```
+
+**Path parameters**
+
+| Parameter       | Value                |
+| --------------- | -------------------- |
+| id              | Playlist id          |
+
+**Query parameters**
+
+| Parameter       | Value                                                       |
+| --------------- | ----------------------------------------------------------- |
+| play_count      | Either `increment`, `played` or `reset`. `increment` will increment `play_count` and update `time_played`, `played` will be like `increment` but only where `play_count` is 0, `reset` will set `play_count` and `skip_count` to zero and delete `time_played` and `time_skipped` |
+
+
+**Example**
+
+```shell
+curl -X PUT "http://localhost:3689/api/library/playlists/1/tracks?play_count=played"
+```
 
 ### List playlists in a playlist folder
 

--- a/src/db.h
+++ b/src/db.h
@@ -581,6 +581,12 @@ void
 db_file_inc_playcount(int id);
 
 void
+db_file_inc_playcount_byplid(int id, bool only_unplayed);
+
+void
+db_file_inc_playcount_bysongalbumid(int64_t id, bool only_unplayed);
+
+void
 db_file_inc_skipcount(int id);
 
 void

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3115,6 +3115,25 @@ jsonapi_reply_library_album_tracks(struct httpd_request *hreq)
 }
 
 static int
+jsonapi_reply_library_album_tracks_put_byid(struct httpd_request *hreq)
+{
+  const char *album_id;;
+  struct query_params qp;
+  int ret;
+
+  album_id = hreq->uri_parsed->path_parts[3];
+
+  memset(&qp, 0, sizeof(struct query_params));
+  qp.type = Q_ITEMS;
+  qp.filter = db_mprintf("(f.songalbumid = %q)", album_id);
+
+  ret = play_count_update(hreq, &qp);
+  free(qp.filter);
+
+  return ret < 0 ? HTTP_INTERNAL : ret == 0 ? HTTP_OK : ret;
+}
+
+static int
 jsonapi_reply_library_tracks_get_byid(struct httpd_request *hreq)
 {
   struct query_params query_params;
@@ -4081,6 +4100,7 @@ static struct httpd_uri_map adm_handlers[] =
     { EVHTTP_REQ_GET,    "^/api/library/albums$",                        jsonapi_reply_library_albums },
     { EVHTTP_REQ_GET,    "^/api/library/albums/[[:digit:]]+$",           jsonapi_reply_library_album },
     { EVHTTP_REQ_GET,    "^/api/library/albums/[[:digit:]]+/tracks$",    jsonapi_reply_library_album_tracks },
+    { EVHTTP_REQ_PUT,    "^/api/library/albums/[[:digit:]]+/tracks$",    jsonapi_reply_library_album_tracks_put_byid },
     { EVHTTP_REQ_GET,    "^/api/library/tracks/[[:digit:]]+$",           jsonapi_reply_library_tracks_get_byid },
     { EVHTTP_REQ_PUT,    "^/api/library/tracks/[[:digit:]]+$",           jsonapi_reply_library_tracks_put_byid },
     { EVHTTP_REQ_GET,    "^/api/library/genres$",                        jsonapi_reply_library_genres},


### PR DESCRIPTION
Implementing #911 

* New put endpoint `/api/library/playlists/[[:digit:]]+/tracks` to enable `play_count` increment,reset,played.
* re-factored existing `play_count` handling to use one common update function - for future update as per @chme for album updates
