### PR TITLE
[pairing] Refactor remote_pairing to use cmdbase

### DIFF
--- a/src/remote_pairing.h
+++ b/src/remote_pairing.h
@@ -2,8 +2,14 @@
 #ifndef __REMOTE_PAIRING_H__
 #define __REMOTE_PAIRING_H__
 
+#define REMOTE_ERROR -1
+#define REMOTE_INVALID_PIN -2
+
 void
 remote_pairing_kickoff(char **arglist);
+
+int
+remote_pairing_pair(const char *pin);
 
 char *
 remote_pairing_get_name(void);


### PR DESCRIPTION
@ejurgensen This requires a bit more work, but a short test was successful. I am opening the PR early to get feedback, if this change is acceptable. The goal is to be able to call the pairing request with a synchronous command from the JSON API and return a meaningful response (success or failure) to e. g. the web interface.