### PR TITLE
[web-src] RSS feed maintainence: add / remove RSS

### DIFF
--- a/web-src/src/components/ModalDialogAddRss.vue
+++ b/web-src/src/components/ModalDialogAddRss.vue
@@ -1,0 +1,85 @@
+<template>
+  <div>
+    <transition name="fade">
+      <div class="modal is-active" v-if="show">
+        <div class="modal-background" @click="$emit('close')"></div>
+        <div class="modal-content fd-modal-card">
+          <div class="card">
+            <div class="card-content">
+              <p class="title is-4">RSS feed</p>
+              <form class="fd-has-margin-bottom">
+                <div class="field">
+                  <p class="control is-expanded has-icons-left">
+                    <input class="input is-shadowless" type="text" placeholder="http://url-to-rss" v-model="url" :disabled="loading" ref="url_field">
+                    <span class="icon is-left">
+                      <i class="mdi mdi-rss-box"></i>
+                    </span>
+                  </p>
+                </div>
+              </form>
+            </div>
+            <footer class="card-footer" v-if="loading">
+              <a class="card-footer-item has-text-dark">
+                <span class="icon"><i class="mdi mdi-web"></i></span> <span class="is-size-7">Processing ...</span>
+              </a>
+            </footer>
+            <footer class="card-footer" v-else>
+              <a class="card-footer-item has-text-danger" @click="$emit('close')">
+                <span class="icon"><i class="mdi mdi-cancel"></i></span> <span class="is-size-7">Cancel</span>
+              </a>
+              <a class="card-footer-item has-text-dark" @click="add_stream">
+                <span class="icon"><i class="mdi mdi-playlist-plus"></i></span> <span class="is-size-7">Add</span>
+              </a>
+            </footer>
+          </div>
+        </div>
+        <button class="modal-close is-large" aria-label="close" @click="$emit('close')"></button>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+import webapi from '@/webapi'
+
+export default {
+  name: 'ModalDialogAddRss',
+  props: [ 'show' ],
+
+  data () {
+    return {
+      url: '',
+      loading: false
+    }
+  },
+
+  methods: {
+    add_stream: function () {
+      this.loading = true
+      webapi.library_add(this.url).then(() => {
+        this.$emit('close')
+        this.$emit('rss_change')
+        this.url = ''
+      }).catch(() => {
+        this.loading = false
+      })
+    }
+  },
+
+  watch: {
+    'show' () {
+      if (this.show) {
+        this.loading = false
+
+        // We need to delay setting the focus to the input field until the field is part of the dom and visible
+        setTimeout(() => {
+          this.$refs.url_field.focus()
+        }, 10)
+      }
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/web-src/src/components/NavbarTop.vue
+++ b/web-src/src/components/NavbarTop.vue
@@ -7,7 +7,7 @@
       <navbar-item-link to="/music">
         <span class="icon"><i class="mdi mdi-music"></i></span>
       </navbar-item-link>
-      <navbar-item-link to="/podcasts" v-if="podcasts.tracks > 0">
+      <navbar-item-link to="/podcasts">
         <span class="icon"><i class="mdi mdi-microphone"></i></span>
       </navbar-item-link>
       <navbar-item-link to="/audiobooks" v-if="audiobooks.tracks > 0">

--- a/web-src/src/pages/PagePlaylists.vue
+++ b/web-src/src/pages/PagePlaylists.vue
@@ -8,7 +8,7 @@
       <list-item-playlist v-for="playlist in playlists.items" :key="playlist.id" :playlist="playlist" @click="open_playlist(playlist)">
         <template slot="icon">
           <span class="icon">
-            <i class="mdi" :class="{ 'mdi-library-music': playlist.type !== 'folder', 'mdi-folder': playlist.type === 'folder' }"></i>
+            <i class="mdi" :class="{ 'mdi-library-music': playlist.type !== 'folder', 'mdi-rss': playlist.type === 'rss', 'mdi-folder': playlist.type === 'folder' }"></i>
           </span>
         </template>
         <template slot="actions">

--- a/web-src/src/webapi/index.js
+++ b/web-src/src/webapi/index.js
@@ -217,6 +217,10 @@ export default {
     return axios.get('/api/library/albums/' + albumId + '/tracks')
   },
 
+  library_album_track_update (albumId, attributes) {
+    return axios.put('/api/library/albums/' + albumId + '/tracks', undefined, { params: attributes })
+  },
+
   library_genres () {
     return axios.get('/api/library/genres')
   },
@@ -277,6 +281,14 @@ export default {
     return axios.get('/api/search', {
       params: episodesParams
     })
+  },
+
+  library_add (url) {
+    return axios.post('/api/library/add', undefined, { params: { 'url': url } })
+  },
+
+  library_playlist_delete (playlistId) {
+    return axios.delete('/api/library/playlists/' + playlistId, undefined)
   },
 
   library_audiobooks () {


### PR DESCRIPTION
https://github.com/ejurgensen/forked-daapd/issues/880

Provides:
* new modal to `add rss` on podcasts page
* `mark all played` on main podcasts page - for new episodes only, only if unplayed exits
* `mark all played` on individual podcast page - only if unplayed exits
* `unsubscribe` on individual podcast page

![rss](https://user-images.githubusercontent.com/18466811/78472138-77c7b880-772e-11ea-8d31-6a8df947ceea.png)
