### PR TITLE
[smartpl] support birate,bits_per_sample,codectype

### DIFF
--- a/src/SMARTPL.g
+++ b/src/SMARTPL.g
@@ -86,6 +86,7 @@ STRTAG		:	'artist'
 			|	'album_id'
 			|	'songartistid'
 			|	'songalbumid'
+			|	'codectype'
 			;
 
 INTTAG		:	'play_count'
@@ -95,6 +96,8 @@ INTTAG		:	'play_count'
 			|	'compilation'
 			|	'track'
 			|	'disc'
+			|	'bitrate'
+			|	'bits_per_sample'
 			;
 
 DATETAG		:	'time_added'


### PR DESCRIPTION
Closes #928 