### PR TITLE
[raop] Allow configuration of raop control and timing ports

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -29,6 +29,10 @@ general {
 	# Websocket port for the web interface.
 #	websocket_port = 3688
 
+        # Ports for airplay raop server
+#       raop_control_port = 0
+#       raop_timing_port = 0
+
 	# Sets who is allowed to connect without authorisation. This applies to
 	# client types like Remotes, DAAP clients (iTunes) and to the web
 	# interface. Options are "any", "localhost" or the prefix to one or

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -29,10 +29,6 @@ general {
 	# Websocket port for the web interface.
 #	websocket_port = 3688
 
-        # Ports for airplay raop server
-#       raop_control_port = 0
-#       raop_timing_port = 0
-
 	# Sets who is allowed to connect without authorisation. This applies to
 	# client types like Remotes, DAAP clients (iTunes) and to the web
 	# interface. Options are "any", "localhost" or the prefix to one or
@@ -278,6 +274,15 @@ audio {
 #fifo {
 #	nickname = "fifo"
 #	path = "/path/to/fifo"
+#}
+
+# AirPlay/Airport Express settings
+# common to all devices
+#airplay_shared {
+        # UDP ports used when ariplay devices make connections back to forked-daapd
+        # (choosing specific ports may be helpful when running forked-daapd behind a firewall)
+#       control_port = 0
+#       timing_port = 0
 #}
 
 # AirPlay/Airport Express device settings

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -279,7 +279,7 @@ audio {
 # AirPlay/Airport Express settings
 # common to all devices
 #airplay_shared {
-        # UDP ports used when ariplay devices make connections back to forked-daapd
+        # UDP ports used when airplay devices make connections back to forked-daapd
         # (choosing specific ports may be helpful when running forked-daapd behind a firewall)
 #       control_port = 0
 #       timing_port = 0

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -137,7 +137,7 @@ static cfg_opt_t sec_alsa[] =
     CFG_END()
   };
 
-/* AirPlay/ApEx share section structure */
+/* AirPlay/ApEx shared section structure */
 static cfg_opt_t sec_airplay_shared[] =
   {
     CFG_INT("control_port", 0, CFGF_NONE),

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -50,8 +50,6 @@ static cfg_opt_t sec_general[] =
     CFG_INT_CB("loglevel", E_LOG, CFGF_NONE, &cb_loglevel),
     CFG_STR("admin_password", NULL, CFGF_NONE),
     CFG_INT("websocket_port", 3688, CFGF_NONE),
-    CFG_INT("raop_control_port", 0, CFGF_NONE),
-    CFG_INT("raop_timing_port", 0, CFGF_NONE),
     CFG_STR_LIST("trusted_networks", "{localhost,192.168,fd}", CFGF_NONE),
     CFG_BOOL("ipv6", cfg_true, CFGF_NONE),
     CFG_STR("cache_path", STATEDIR "/cache/" PACKAGE "/cache.db", CFGF_NONE),
@@ -139,6 +137,14 @@ static cfg_opt_t sec_alsa[] =
     CFG_END()
   };
 
+/* AirPlay/ApEx share section structure */
+static cfg_opt_t sec_airplay_shared[] =
+  {
+    CFG_INT("control_port", 0, CFGF_NONE),
+    CFG_INT("timing_port", 0, CFGF_NONE),
+    CFG_END()
+  };
+
 /* AirPlay/ApEx device section structure */
 static cfg_opt_t sec_airplay[] =
   {
@@ -217,6 +223,7 @@ static cfg_opt_t toplvl_cfg[] =
     CFG_SEC("library", sec_library, CFGF_NONE),
     CFG_SEC("audio", sec_audio, CFGF_NONE),
     CFG_SEC("alsa", sec_alsa, CFGF_MULTI | CFGF_TITLE),
+    CFG_SEC("airplay_shared", sec_airplay_shared, CFGF_NONE),
     CFG_SEC("airplay", sec_airplay, CFGF_MULTI | CFGF_TITLE),
     CFG_SEC("chromecast", sec_chromecast, CFGF_MULTI | CFGF_TITLE),
     CFG_SEC("fifo", sec_fifo, CFGF_NONE),

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -50,6 +50,8 @@ static cfg_opt_t sec_general[] =
     CFG_INT_CB("loglevel", E_LOG, CFGF_NONE, &cb_loglevel),
     CFG_STR("admin_password", NULL, CFGF_NONE),
     CFG_INT("websocket_port", 3688, CFGF_NONE),
+    CFG_INT("raop_control_port", 0, CFGF_NONE),
+    CFG_INT("raop_timing_port", 0, CFGF_NONE),
     CFG_STR_LIST("trusted_networks", "{localhost,192.168,fd}", CFGF_NONE),
     CFG_BOOL("ipv6", cfg_true, CFGF_NONE),
     CFG_STR("cache_path", STATEDIR "/cache/" PACKAGE "/cache.db", CFGF_NONE),

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -3093,7 +3093,7 @@ raop_v2_timing_start_one(struct raop_service *svc, int family)
   memset(&sa, 0, sizeof(union sockaddr_all));
   sa.ss.ss_family = family;
 
-  timing_port = cfg_getint(cfg_getsec(cfg, "general"), "raop_timing_port");
+  timing_port = cfg_getint(cfg_getsec(cfg, "airplay_shared"), "timing_port");
   switch (family)
     {
       case AF_INET:
@@ -3347,7 +3347,7 @@ raop_v2_control_start_one(struct raop_service *svc, int family)
   memset(&sa, 0, sizeof(union sockaddr_all));
   sa.ss.ss_family = family;
 
-  control_port = cfg_getint(cfg_getsec(cfg, "general"), "raop_control_port");
+  control_port = cfg_getint(cfg_getsec(cfg, "airplay_shared"), "control_port");
   switch (family)
     {
       case AF_INET:

--- a/src/outputs/raop.c
+++ b/src/outputs/raop.c
@@ -3064,6 +3064,7 @@ raop_v2_timing_start_one(struct raop_service *svc, int family)
   int on;
   int len;
   int ret;
+  int timing_port;
 
 #ifdef SOCK_CLOEXEC
   svc->fd = socket(family, SOCK_DGRAM | SOCK_CLOEXEC, 0);
@@ -3092,17 +3093,18 @@ raop_v2_timing_start_one(struct raop_service *svc, int family)
   memset(&sa, 0, sizeof(union sockaddr_all));
   sa.ss.ss_family = family;
 
+  timing_port = cfg_getint(cfg_getsec(cfg, "general"), "raop_timing_port");
   switch (family)
     {
       case AF_INET:
 	sa.sin.sin_addr.s_addr = INADDR_ANY;
-	sa.sin.sin_port = 0;
+	sa.sin.sin_port = htons(timing_port);
 	len = sizeof(sa.sin);
 	break;
 
       case AF_INET6:
 	sa.sin6.sin6_addr = in6addr_any;
-	sa.sin6.sin6_port = 0;
+	sa.sin6.sin6_port = htons(timing_port);
 	len = sizeof(sa.sin6);
 	break;
     }
@@ -3316,6 +3318,7 @@ raop_v2_control_start_one(struct raop_service *svc, int family)
   int on;
   int len;
   int ret;
+  int control_port;
 
 #ifdef SOCK_CLOEXEC
   svc->fd = socket(family, SOCK_DGRAM | SOCK_CLOEXEC, 0);
@@ -3344,17 +3347,18 @@ raop_v2_control_start_one(struct raop_service *svc, int family)
   memset(&sa, 0, sizeof(union sockaddr_all));
   sa.ss.ss_family = family;
 
+  control_port = cfg_getint(cfg_getsec(cfg, "general"), "raop_control_port");
   switch (family)
     {
       case AF_INET:
 	sa.sin.sin_addr.s_addr = INADDR_ANY;
-	sa.sin.sin_port = 0;
+	sa.sin.sin_port = htons(control_port);
 	len = sizeof(sa.sin);
 	break;
 
       case AF_INET6:
 	sa.sin6.sin6_addr = in6addr_any;
-	sa.sin6.sin6_port = 0;
+	sa.sin6.sin6_port = htons(control_port);
 	len = sizeof(sa.sin6);
 	break;
     }


### PR DESCRIPTION
Allow raop control and timing ports to be configured to reduce the number of port needing opening when running behind a firewall and trying to output to airplay devices