### PR TITLE
[scan] support EXTGENRE in m3u playlist

### DIFF
--- a/src/library/filescanner_playlist.c
+++ b/src/library/filescanner_playlist.c
@@ -131,6 +131,12 @@ exttag_read(struct media_file_info *mfi, const char *tag)
       mfi->album_artist = val;
       return 0;
     }
+  if (strncmp(tag, "#EXTGENRE:", strlen("#EXTGENRE:")) == 0 && extval_read(&val, tag) == 0)
+    {
+      free(mfi->genre);
+      mfi->genre = val;
+      return 0;
+    }
 
   return -1;
 }


### PR DESCRIPTION
Support `genre` name via m3u `EXTGENRE` [tag](https://en.wikipedia.org/wiki/M3U)

If we have a playlist of internet radio streams, some radio streams show up as `unknown genre` even though they provide some other tags.
```
#EXTGENRE:Internet Radio
http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio4extra_mf_p

#EXTINF:-1,RTHK - RTHK Radio 2
#EXTGENRE:Internet Radio
#EXTALB:RTHK Radio Stream
http://stm.rthk.hk/radio2
```