### PR TITLE
[artwork] Ignore streams with media kind != music in artwork sources

### DIFF
--- a/src/artwork.c
+++ b/src/artwork.c
@@ -1496,7 +1496,15 @@ source_item_stream_get(struct artwork_ctx *ctx)
   char *url;
   char *ext;
   int len;
+  int media_kind;
   int ret;
+
+  ret = safe_atoi32(ctx->dbmfi->media_kind, &media_kind);
+  if (ret != 0 || media_kind != MEDIA_KIND_MUSIC)
+    {
+      DPRINTF(E_SPAM, L_ART, "Ignoring internet stream artwork request for media_kind != music: %s\n", ctx->dbmfi->path);
+      return ART_E_NONE;
+    }
 
   DPRINTF(E_SPAM, L_ART, "Trying internet stream artwork in %s\n", ctx->dbmfi->path);
 
@@ -1562,10 +1570,18 @@ static int
 source_item_discogs_get(struct artwork_ctx *ctx)
 {
   char *url;
+  int media_kind;
   int ret;
 
   if (!online_source_is_enabled(&discogs_source))
     return ART_E_NONE;
+
+  ret = safe_atoi32(ctx->dbmfi->media_kind, &media_kind);
+  if (ret != 0 || media_kind != MEDIA_KIND_MUSIC)
+    {
+      DPRINTF(E_SPAM, L_ART, "Ignoring internet stream artwork request for media_kind != music: %s\n", ctx->dbmfi->path);
+      return ART_E_NONE;
+    }
 
   url = online_source_search(&discogs_source, ctx);
   if (!url)
@@ -1583,10 +1599,18 @@ static int
 source_item_coverartarchive_get(struct artwork_ctx *ctx)
 {
   char *url;
+  int media_kind;
   int ret;
 
   if (!online_source_is_enabled(&musicbrainz_source))
     return ART_E_NONE;
+
+  ret = safe_atoi32(ctx->dbmfi->media_kind, &media_kind);
+  if (ret != 0 || media_kind != MEDIA_KIND_MUSIC)
+    {
+      DPRINTF(E_SPAM, L_ART, "Ignoring internet stream artwork request for media_kind != music: %s\n", ctx->dbmfi->path);
+      return ART_E_NONE;
+    }
 
   // We search Musicbrainz to get the Musicbrainz ID, which we need to get the
   // artwork from the Cover Art Archive
@@ -1627,10 +1651,18 @@ source_item_spotifywebapi_search_get(struct artwork_ctx *ctx)
 {
   struct spotifywebapi_access_token info;
   char *url;
+  int media_kind;
   int ret;
 
   if (!online_source_is_enabled(&spotify_source))
     return ART_E_NONE;
+
+  ret = safe_atoi32(ctx->dbmfi->media_kind, &media_kind);
+  if (ret != 0 || media_kind != MEDIA_KIND_MUSIC)
+    {
+      DPRINTF(E_SPAM, L_ART, "Ignoring internet stream artwork request for media_kind != music: %s\n", ctx->dbmfi->path);
+      return ART_E_NONE;
+    }
 
   spotifywebapi_access_token_get(&info);
   if (!info.token)


### PR DESCRIPTION
This is a quick, ugly and only partial fix for a problem i am running into.

I have added a podcast stream (https://linuxlads.com/feed_mp3.rss), that does not provide any artwork (at least not at the places forked-daapd currently searches for it). It scans correctly and is shown in the web interface under the podcasts as expected. 

Opening the details dialog for this podcast (podcast album details) now tries to fetch the cover artwork for this podcast. This takes quite a while because it tries to fetch artwork for every podcast episode: 

1. source_item_stream_get
2. source_item_ownpl_get
3. source_item_spotifywebapi_search_get
4. source_item_discogs_get
5. source_item_embedded_get
6. source_item_coverartarchive_get

The resulting "no artwork found" is not cached, i think `source_item_stream_get` tells us not to cache artwork for streams. So every time i open the dialog the artwork search starts from the beginning.

The changes in this pr, will check if `media_kind` is not music and return early in the `source_item_*` handlers where i thought it does not make sense to search for non-music artwork. 
@ejurgensen There are for sure better solutions and i hope you can guide me towards them. Ideally artwork for podcasts added as RSS feed playlists should be cached forever, like it would be for locally stored podcasts.