### PR TITLE
Update player with progress metadata

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -77,6 +77,7 @@ struct input_metadata
   // Input can override the default player progress by setting this
   // FIXME only implemented for Airplay speakers currently
   uint32_t pos_ms;
+  bool progress_updated;
 
   // Sets new song length (input will also update queue_item)
   uint32_t len_ms;

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -363,6 +363,7 @@ handle_progress(struct input_metadata *m, char *progress)
     m->pos_ms = (pos - start) * 1000 / pipe_sample_rate;
   if (end > start)
     m->len_ms = (end - start) * 1000 / pipe_sample_rate;
+  m->progress_updated=true;
 }
 
 static void

--- a/src/player.c
+++ b/src/player.c
@@ -942,7 +942,13 @@ event_read_metadata(struct input_metadata *metadata)
   // to the outputs, but the player's pos_ms is not adjusted. That means we
   // don't always show correct progress for http streams, pipes and files with
   // chapters.
-
+  if (metadata->progress_updated){
+    //since pos_ms is continually updated, reverse out the proper seek_ms and update that instead
+    if (pb_session.playing_now->quality.sample_rate && pb_session.pos >= pb_session.playing_now->play_start)
+      pb_session.playing_now->seek_ms = metadata->pos_ms - 1000UL * (pb_session.pos - pb_session.playing_now->play_start) / pb_session.playing_now->quality.sample_rate;
+    pb_session.playing_now->len_ms = metadata->len_ms;
+    metadata->progress_updated = false;
+  }
   outputs_metadata_send(pb_session.playing_now->item_id, false, metadata_finalize_cb);
 
   status_update(player_state);

--- a/src/player.c
+++ b/src/player.c
@@ -944,7 +944,7 @@ event_read_metadata(struct input_metadata *metadata)
   // chapters.
   if (metadata->progress_updated){
     //since pos_ms is continually updated, reverse out the proper seek_ms and update that instead
-    if (pb_session.playing_now->quality.sample_rate && pb_session.pos >= pb_session.playing_now->play_start)
+    if (pb_session.playing_now->quality.sample_rate)
       pb_session.playing_now->seek_ms = metadata->pos_ms - 1000UL * (pb_session.pos - pb_session.playing_now->play_start) / pb_session.playing_now->quality.sample_rate;
     pb_session.playing_now->len_ms = metadata->len_ms;
     metadata->progress_updated = false;


### PR DESCRIPTION
This PR propagates the progress metadata from an incoming pipe to the player. Works for my use case but not sure if it takes care of all the cases that the FIXME notes refer to.