### PR TITLE
Update volume on device reconnect

### DIFF
--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -1044,6 +1044,8 @@ alsa_device_start(struct output_device *device, int callback_id)
   if (!as)
     return -1;
 
+  volume_set(&as->mixer, device->volume);
+
   as->state = OUTPUT_STATE_CONNECTED;
   alsa_status(as);
 


### PR DESCRIPTION
Volume changes to the device don't propagate to the output if the output is idle and the session has closed. This results in the device volume not matching the output volume.