### PR TITLE
[library] RSS bug fix - meta rescan resets "play count" and other fields

### DIFF
--- a/src/library/rssscanner.c
+++ b/src/library/rssscanner.c
@@ -453,6 +453,13 @@ rss_save(struct playlist_info *pli, int *count, enum rss_scan_type scan_type)
 	  if (ret > 0)
 	    continue;
 	}
+      else if (scan_type == RSS_SCAN_META)
+	{
+	  // Using existing file id if already in library, resulting in update but preserving play_count etc
+	  mfi.id = db_file_id_bypath(ri.url);
+	  if (mfi.id > 0)
+	    time_added = 0;
+	}
 
       scan_metadata_stream(&mfi, ri.url);
 


### PR DESCRIPTION
Prevents a meta refresh (aka web `library rescan`) from resetting `play counts` of RSS podcasts.

Fixes issue when performing an REST `api/rescan` (results in `RSS_SCAN_META` scan type in this module) that would result in a `library_media_save()` -> `db_file_add()` even for entries that already exist in db.  

This would result in dropping db record, incl `play_count` etc instead of an `db_file_update()`.