### PR TITLE
Update metadata progress another way

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -77,6 +77,7 @@ struct input_metadata
   // Input can override the default player progress by setting this
   // FIXME only implemented for Airplay speakers currently
   uint32_t pos_ms;
+  bool progress_updated;
 
   // Sets new song length (input will also update queue_item)
   uint32_t len_ms;

--- a/src/input.h
+++ b/src/input.h
@@ -77,7 +77,6 @@ struct input_metadata
   // Input can override the default player progress by setting this
   // FIXME only implemented for Airplay speakers currently
   uint32_t pos_ms;
-  bool progress_updated;
 
   // Sets new song length (input will also update queue_item)
   uint32_t len_ms;

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -363,6 +363,7 @@ handle_progress(struct input_metadata *m, char *progress)
     m->pos_ms = (pos - start) * 1000 / pipe_sample_rate;
   if (end > start)
     m->len_ms = (end - start) * 1000 / pipe_sample_rate;
+  m->progress_updated=true;
 }
 
 static void

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -363,7 +363,6 @@ handle_progress(struct input_metadata *m, char *progress)
     m->pos_ms = (pos - start) * 1000 / pipe_sample_rate;
   if (end > start)
     m->len_ms = (end - start) * 1000 / pipe_sample_rate;
-  m->progress_updated = true;
 }
 
 static void

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -765,9 +765,7 @@ pipe_metadata_read_cb(evutil_socket_t fd, short event, void *arg)
     {
       // Reset the pipe
       ret = watch_reset(pipe_metadata.pipe);
-      if (ret < 0)
-	return;
-      goto readd;
+      return;
     }
 
   len = evbuffer_get_length(pipe_metadata.evbuf);

--- a/src/inputs/pipe.c
+++ b/src/inputs/pipe.c
@@ -363,7 +363,7 @@ handle_progress(struct input_metadata *m, char *progress)
     m->pos_ms = (pos - start) * 1000 / pipe_sample_rate;
   if (end > start)
     m->len_ms = (end - start) * 1000 / pipe_sample_rate;
-  m->progress_updated=true;
+  m->progress_updated = true;
 }
 
 static void

--- a/src/player.c
+++ b/src/player.c
@@ -956,7 +956,7 @@ event_read_metadata(struct input_metadata *metadata)
   // don't always show correct progress for http streams, pipes and files with
   // chapters.
   if (metadata->progress_updated){
-    pb_session.playing_now->last_pos_ms = pb_session.playing_now->pos_ms;
+    pb_session.playing_now->last_pos_ms = pb_session.playing_now->seek_ms + 1000UL * (pb_session.pos - pb_session.playing_now->play_start) / pb_session.playing_now->quality.sample_rate;
     pb_session.playing_now->metadata_pos_ms = metadata->pos_ms - 1000UL * OUTPUTS_BUFFER_DURATION;
     pb_session.playing_now->metadata_len_ms = metadata->len_ms;
     pb_session.playing_now->use_metadata_progress = true;


### PR DESCRIPTION
This uses new fields in struct player_source and only modifies the status update in get_status, so it is less of a hack and shouldn't break anything.
Since the incoming metadata is assumed to be at read time while pos_ms is at speaker time, the incoming metadata is offset by the buffer time. Note that pos_ms is not always at speaker time (it is held at 0 until playing starts), but this isn't a big problem as it only happens at the start of the session. A bigger problem is that metadata comes in at read time but the actual playing item doesn't change, so the progress transitions might come slightly before the playback transitions. This seems hard to easily work around. 