### PR TITLE
[rss] Always use RSS feed title and author for album and artist

### DIFF
--- a/src/library/rssscanner.c
+++ b/src/library/rssscanner.c
@@ -353,13 +353,14 @@ mfi_metadata_fixup(struct media_file_info *mfi, struct rss_item_info *ri, const 
 {
   struct tm tm;
 
-  // Always take the meta from media file if possible; some podcasts (Apple) can
-  // use mp4 streams which tend not to have decent tags so in those cases take
-  // info from the RSS and not the stream
-  if (!mfi->artist)
-    mfi->artist = safe_strdup(feed_author);
-  if (!mfi->album)
-    mfi->album  = safe_strdup(feed_title);
+  // Always take the artist and album from the RSS feed and not the stream
+  free(mfi->artist);
+  mfi->artist = safe_strdup(feed_author);
+  free(mfi->album);
+  mfi->album  = safe_strdup(feed_title);
+
+  // Some podcasts (Apple) can use mp4 streams which tend not to have decent tags so
+  // in those cases take info from the RSS and not the stream
   if (!mfi->url)
     mfi->url    = safe_strdup(ri->link);
   if (!mfi->genre || strcmp("(186)Podcast", mfi->genre) == 0)


### PR DESCRIPTION
I am testing the new RSS feed feature a bit and found this issue with the podcasts i tested with. The metadata tags from the episode streams do contain the podcast author and the podcast title.

The feeds information for title and author are the values shown in other podcast players and they should always hold the correct information. I did not follow the discussion around the PR for the podcast feature, so appologies if this has been discussed already ... (i still think, it is wrong to rely on the episodes stream information ;-)

Podcasts that have this issue are for example:
- https://feeds.lagedernation.org/feeds/ldn-mp3.xml
- https://ubuntupodcast.org/feed/podcast/

(a side effect of this problem is, that the playlist name is not identical to the album name, which makes it sometimes hard to identify the matching counterpart)