### PR TITLE
[rss] support playlist wide artwork

### DIFF
--- a/src/artwork.c
+++ b/src/artwork.c
@@ -1743,8 +1743,19 @@ source_item_ownpl_get(struct artwork_ctx *ctx)
       if (!dbpli.path)
 	continue;
 
-      ctx->dbmfi->path = dbpli.path;
-      format = source_item_own_get(ctx);
+      if (dbpli.artwork_url)
+	{
+	  format = artwork_get_byurl(ctx->evbuf, dbpli.artwork_url, ctx->max_w, ctx->max_h);
+	  if (format > 0)
+	    break;
+	}
+
+      // Only handle non-remote paths with source_item_own_get()
+      if (dbpli.path && dbpli.path[0] == '/')
+	{
+	  ctx->dbmfi->path = dbpli.path;
+	  format = source_item_own_get(ctx);
+	}
     }
 
   ctx->dbmfi->path = mfi_path;

--- a/src/db.c
+++ b/src/db.c
@@ -240,6 +240,7 @@ static const struct col_type_map pli_cols_map[] =
     { "query_order",        pli_offsetof(query_order),        DB_TYPE_STRING, DB_FIXUP_NO_SANITIZE },
     { "query_limit",        pli_offsetof(query_limit),        DB_TYPE_INT },
     { "media_kind",         pli_offsetof(media_kind),         DB_TYPE_INT,    DB_FIXUP_MEDIA_KIND },
+    { "artwork_url",        pli_offsetof(artwork_url),        DB_TYPE_STRING, DB_FIXUP_NO_SANITIZE },
 
     // Not in the database, but returned via the query's COUNT()/SUM()
     { "items",              pli_offsetof(items),              DB_TYPE_INT,    DB_FIXUP_STANDARD, DB_FLAG_NO_BIND },
@@ -376,6 +377,7 @@ static const ssize_t dbpli_cols_map[] =
     dbpli_offsetof(query_order),
     dbpli_offsetof(query_limit),
     dbpli_offsetof(media_kind),
+    dbpli_offsetof(artwork_url),
 
     dbpli_offsetof(items),
     dbpli_offsetof(streams),
@@ -673,6 +675,7 @@ free_pli(struct playlist_info *pli, int content_only)
   free(pli->path);
   free(pli->virtual_path);
   free(pli->query_order);
+  free(pli->artwork_url);
 
   if (!content_only)
     free(pli);

--- a/src/db.h
+++ b/src/db.h
@@ -254,6 +254,7 @@ struct playlist_info {
   char *query_order;     /* order by clause, used by e.g. a smart playlists */
   int32_t query_limit;   /* limit, used by e.g. smart playlists */
   uint32_t media_kind;
+  char *artwork_url;     /* optional artwork */
   uint32_t items;        /* number of items (mimc) */
   uint32_t streams;      /* number of internet streams */
 };
@@ -276,6 +277,7 @@ struct db_playlist_info {
   char *query_order;
   char *query_limit;
   char *media_kind;
+  char *artwork_url;
   char *items;
   char *streams;
 };

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -115,7 +115,8 @@
   "   directory_id   INTEGER DEFAULT 0,"		\
   "   query_order    VARCHAR(1024),"			\
   "   query_limit    INTEGER DEFAULT -1,"		\
-  "   media_kind     INTEGER DEFAULT 1"			\
+  "   media_kind     INTEGER DEFAULT 1,"		\
+  "   artwork_url    VARCHAR(4096) DEFAULT NULL"	\
   ");"
 
 #define T_PLITEMS				\

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * forked-daapd after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 21
-#define SCHEMA_VERSION_MINOR 03
+#define SCHEMA_VERSION_MINOR 04
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1048,6 +1048,17 @@ static const struct db_upgrade_query db_upgrade_v2103_queries[] =
     { U_V2103_SCVER_MINOR,    "set schema_version_minor to 03" },
   };
 
+#define U_v2104_ALTER_PLAYLISTS_ADD_ARTWORK_URL \
+  "ALTER TABLE playlists ADD COLUMN artwork_url VARCHAR(4096) DEFAULT NULL;"
+#define U_v2104_SCVER_MINOR                    \
+  "UPDATE admin SET value = '04' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v2104_queries[] =
+  {
+    { U_v2104_ALTER_PLAYLISTS_ADD_ARTWORK_URL, "alter table playlists add column artwork_url" },
+
+    { U_v2104_SCVER_MINOR,    "set schema_version_minor to 04" },
+  };
 
 
 int
@@ -1215,6 +1226,13 @@ db_upgrade(sqlite3 *hdl, int db_ver)
 
     case 2102:
       ret = db_generic_upgrade(hdl, db_upgrade_v2103_queries, ARRAY_SIZE(db_upgrade_v2103_queries));
+      if (ret < 0)
+	return -1;
+
+      /* FALLTHROUGH */
+
+    case 2103:
+      ret = db_generic_upgrade(hdl, db_upgrade_v2104_queries, ARRAY_SIZE(db_upgrade_v2104_queries));
       if (ret < 0)
 	return -1;
       break;


### PR DESCRIPTION
close #964 

Support RSS podcasts that provide artwork at the feed level rather than embedded in each audio stream.  Solves issue with 0.7 web interface that unconditionally displasy artwork for `now playing` and `album` modals - for RSS streams that provide artwork at feed level, this was a generated image.

* new `artwork_url` column to `playlists` to support _playlist_ wide artwork
* RSS scanner updated to add artwork url from `channel->image->url` if available to `playlist` db entry
* update `artwork` module to consider `artwork_url` if available for `playlitsts`

This PR also deals with the issue observed by @chme in https://github.com/ejurgensen/forked-daapd/pull/953#issuecomment-616042071 where RSS streams have no embedded art in any streams which causes all streams in podcast episodes to be probed.  With this PR, the artwork is:
* probed `embedded` for one episode, finds nothing
* probed `stream`, finds nothing
* probed `playlist own` and returns artwork if definied by RSS channel/feed

It may even be worth adjusting `rssscanner` to point to a local default coverart image (as part of `htdocs`) if the RSS feed does not provide a _channel image_ to address the performance hit.