### PR TITLE
[web] IOS `now playing` artwork rendering and skip foward/back fix

### DIFF
--- a/web-src/src/components/PlayerButtonSeekBack.vue
+++ b/web-src/src/components/PlayerButtonSeekBack.vue
@@ -23,7 +23,7 @@ export default {
           this.now_playing.data_kind === 'pipe'
     },
     visible () {
-      return ['podcast', 'audiobook'].includes(this.now_playing.media_kind)
+      return ['podcast', 'music', 'audiobook'].includes(this.now_playing.media_kind) && this.$store.state.player.item_length_ms > 0
     }
   },
 

--- a/web-src/src/components/PlayerButtonSeekForward.vue
+++ b/web-src/src/components/PlayerButtonSeekForward.vue
@@ -23,7 +23,7 @@ export default {
           this.now_playing.data_kind === 'pipe'
     },
     visible () {
-      return ['podcast', 'audiobook'].includes(this.now_playing.media_kind)
+      return ['podcast', 'music', 'audiobook'].includes(this.now_playing.media_kind) && this.$store.state.player.item_length_ms > 0
     }
   },
 

--- a/web-src/src/mystyles.css
+++ b/web-src/src/mystyles.css
@@ -131,6 +131,7 @@ section.fd-tabs-section + section.fd-content {
 .fd-cover-image img {
   width: 100%;
   height: 100%;
+  max-height: calc(100vh - 28rem);
   object-fit: contain;
   object-position: bottom;
   filter: drop-shadow(0px 0px 1px rgba(0,0,0,.3)) drop-shadow(0px 0px 10px rgba(0,0,0,.3));


### PR DESCRIPTION
closes #974 - skip buttons visible for music but not live http streams (length == 0)
closes #967 - IOS `now playing` page artwork rendering fix (credit @cdlenfert)

PR does NOT include the `htdocs` rebuild as per previous web PRs - generated/attached here for reference:
[fd-htdocs-0.7fix.tar.gz](https://github.com/ejurgensen/forked-daapd/files/4559690/fd-htdocs-0.7fix.tar.gz)
