### PR TITLE
[SMARTPL] add 'random' in 'order by' clause

### DIFF
--- a/src/SMARTPL.g
+++ b/src/SMARTPL.g
@@ -37,6 +37,7 @@ ordertag	:	STRTAG
 			|	INTTAG
 			|	DATETAG
 			|	ENUMTAG
+			|	RANDOMTAG
 			|	(XXX)? NeverUsedRule
 			;
 
@@ -115,6 +116,9 @@ ENUMTAG		:	'data_kind'
 
 GROUPTAG	:	'track_count'
 			|	'album_count'
+			;
+
+RANDOMTAG	:	'random'
 			;
 
 INCLUDES	:	'includes'

--- a/src/SMARTPL2SQL.g
+++ b/src/SMARTPL2SQL.g
@@ -345,6 +345,11 @@ ordertag	returns [ pANTLR3_STRING result ]
 			$result->append8($result, "f.");
 			$result->appendS($result, $ENUMTAG.text->toUTF8($ENUMTAG.text));
 		}
+	|	RANDOMTAG
+		{
+			$result = $RANDOMTAG.text->factory->newRaw($RANDOMTAG.text->factory);
+			$result->append8($result, "random()");
+		}
 	;
 
 dateval		returns [ pANTLR3_STRING result ]


### PR DESCRIPTION
Closes #992 

'random' tag in 'order by' clause to request SQLite to random select data rows from result set
```
    "random 3 pop" {
      genre is "Pop" and
      media_kind is music
      order by random desc
      limit 3
    }
```