### PR TITLE
[web-src] use browser locale for 'time' filter for display

### DIFF
--- a/web-src/src/App.vue
+++ b/web-src/src/App.vue
@@ -23,6 +23,7 @@ import ModalDialogRemotePairing from '@/components/ModalDialogRemotePairing'
 import webapi from '@/webapi'
 import * as types from '@/store/mutation_types'
 import ReconnectingWebSocket from 'reconnectingwebsocket'
+import moment from 'moment'
 
 export default {
   name: 'App',
@@ -57,6 +58,7 @@ export default {
   },
 
   created: function () {
+    moment.locale(navigator.language)
     this.connect()
 
     //  Start the progress bar on app start

--- a/web-src/src/pages/PageAbout.vue
+++ b/web-src/src/pages/PageAbout.vue
@@ -76,11 +76,11 @@
                   </tr>
                   <tr>
                     <th>Library updated</th>
-                    <td class="has-text-right">{{ library.updated_at | timeFromNow }} <span class="has-text-grey">({{ library.updated_at | time('MMM Do, h:mm') }})</span></td>
+                    <td class="has-text-right">{{ library.updated_at | timeFromNow }} <span class="has-text-grey">({{ library.updated_at | time('lll') }})</span></td>
                   </tr>
                   <tr>
                     <th>Uptime</th>
-                    <td class="has-text-right">{{ library.started_at | timeFromNow(true) }} <span class="has-text-grey">({{ library.started_at | time('MMM Do, h:mm') }})</span></td>
+                    <td class="has-text-right">{{ library.started_at | timeFromNow(true) }} <span class="has-text-grey">({{ library.started_at | time('ll') }})</span></td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
Closes #981 

Uses browser's `navigator.language` string to set locale - `moment` will default to `en-US` (current settings used) is string is not valid/available.

Tested on chrome, firefox on linux and IOS13

---
the `release date` (dd/mm/yyyy) and `added at` (dd month yyyy 24h:mm) are in `en-GB` format rather than default `en-US` format
![locale-date](https://user-images.githubusercontent.com/18466811/81589248-2d7eca80-93b1-11ea-8181-f1b9c0dfb33f.png)