### PR TITLE
Update metadata progress, mk4

### DIFF
--- a/src/httpd_dacp.c
+++ b/src/httpd_dacp.c
@@ -174,7 +174,13 @@ dacp_nowplaying(struct evbuffer *evbuf, struct player_status *status, struct db_
    */
   if (queue_item->data_kind == DATA_KIND_HTTP || queue_item->data_kind == DATA_KIND_PIPE)
     {
-      id = djb_hash(queue_item->album, strlen(queue_item->album));
+      // Could also use queue_item->queue_version, but it changes a bit too much
+      // leading to Remote reloading too much
+      if (queue_item->artwork_url)
+	id = djb_hash(queue_item->artwork_url, strlen(queue_item->artwork_url));
+      else
+	id = djb_hash(queue_item->title, strlen(queue_item->title));
+
       songalbumid = (int64_t)id;
     }
   else

--- a/src/input.c
+++ b/src/input.c
@@ -177,6 +177,9 @@ map_data_kind(int data_kind)
 static void
 metadata_free(struct input_metadata *metadata, int content_only)
 {
+  if (!metadata)
+    return;
+
   free(metadata->artist);
   free(metadata->title);
   free(metadata->album);
@@ -193,7 +196,6 @@ static struct input_metadata *
 metadata_get(struct input_source *source)
 {
   struct input_metadata *metadata;
-  struct db_queue_item *queue_item;
   int ret;
 
   if (!inputs[source->type]->metadata_get)
@@ -205,37 +207,7 @@ metadata_get(struct input_source *source)
   if (ret < 0)
     goto out_free_metadata;
 
-  queue_item = db_queue_fetch_byitemid(source->item_id);
-  if (!queue_item)
-    {
-      DPRINTF(E_LOG, L_PLAYER, "Bug! Input source item_id does not match anything in queue\n");
-      goto out_free_metadata;
-    }
-
-  // Update queue item if metadata changed
-  if (metadata->artist || metadata->title || metadata->album || metadata->genre || metadata->artwork_url || metadata->len_ms)
-    {
-      // Since we won't be using the metadata struct values for anything else
-      // than this we just swap pointers
-      if (metadata->artist)
-	swap_pointers(&queue_item->artist, &metadata->artist);
-      if (metadata->title)
-	swap_pointers(&queue_item->title, &metadata->title);
-      if (metadata->album)
-	swap_pointers(&queue_item->album, &metadata->album);
-      if (metadata->genre)
-	swap_pointers(&queue_item->genre, &metadata->genre);
-      if (metadata->artwork_url)
-	swap_pointers(&queue_item->artwork_url, &metadata->artwork_url);
-      if (metadata->len_ms)
-	queue_item->song_length = metadata->len_ms;
-
-      ret = db_queue_update_item(queue_item);
-      if (ret < 0)
-	DPRINTF(E_LOG, L_PLAYER, "Database error while updating queue with new metadata\n");
-    }
-
-  free_queue_item(queue_item, 0);
+  metadata->item_id = source->item_id;
 
   return metadata;
 
@@ -867,7 +839,6 @@ input_flush(short *flags)
   flush(flags);
 }
 
-// Not currently used, perhaps remove?
 void
 input_metadata_free(struct input_metadata *metadata, int content_only)
 {

--- a/src/input.h
+++ b/src/input.h
@@ -74,9 +74,12 @@ struct input_metadata
   // queue_item id
   uint32_t item_id;
 
-  // Input can override the default player progress by setting this
-  // FIXME only implemented for Airplay speakers currently
-  uint32_t pos_ms;
+  // Input can override the default player progress by setting this. For the
+  // other fields the receiver can check whether an update happened by checking
+  // if it is non-zero/null, but not for pos_ms since 0 and even negative values
+  // are valid.
+  bool pos_is_updated;
+  int32_t pos_ms;
 
   // Sets new song length (input will also update queue_item)
   uint32_t len_ms;
@@ -87,9 +90,6 @@ struct input_metadata
   char *album;
   char *genre;
   char *artwork_url;
-
-  // Indicates whether we are starting playback. Just passed on to output.
-  int startup;
 };
 
 struct input_definition
@@ -219,7 +219,7 @@ void
 input_flush(short *flags);
 
 /*
- * Free the entire struct
+ * Free input_metadata
  */
 void
 input_metadata_free(struct input_metadata *metadata, int content_only);


### PR DESCRIPTION
Supersedes PR #996 

@uvjustin I am ditching my previous attempt at this, here is another go at it. I wasn't satisfied with Remote and the web not being updated in the same way, so this change has the delayed, async update of db, speakers and clients.

You will see that progress metadata sometimes is slightly delayed compared to the rest. This is because Shairport gives negative playback positions, which forked-daapd interprets as "wait before updating the progress" - and I think that is correct to make the progress match what is actually being played.