### PR TITLE
[input] Add handler for StreamUrl tag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ nobase_dist_doc_DATA = \
 	README_ALSA.md \
 	README_SMARTPL.md \
 	README_PLAYER_WEBINTERFACE.md \
+	README_RADIO_STREAMS.md \
 	scripts/pairinghelper.sh
 
 EXTRA_DIST = \

--- a/README.md
+++ b/README.md
@@ -323,6 +323,10 @@ forked-daapd has support for smart playlists. How to create a smart playlist is
 documented in
 [README_SMARTPL.md](https://github.com/ejurgensen/forked-daapd/blob/master/README_SMARTPL.md).
 
+If you're not satisfied with internet radio metadata that forked-daapd shows,
+then you can read about tweaking it in
+[README_RADIO_STREAMS.md](https://github.com/ejurgensen/forked-daapd/blob/master/README_RADIO_STREAMS.md).
+
 
 ## Artwork
 

--- a/README_RADIO_STREAMS.md
+++ b/README_RADIO_STREAMS.md
@@ -1,0 +1,97 @@
+# forked-daapd and Radio Stream tweaking
+
+Radio streams have many different ways in how metadata is sent.  Many should
+just work as expected, but a few may require some tweaking. If you are not
+seeing expected title, track, artist, artwork in forked-daapd clients or web UI,
+the following may help.
+
+First, understand what and how the particular stream is sending information.
+ffprobe is a command that can be used to interegrate most of the stream
+information. `ffprobe <http://stream.url>` should give you some useful output,
+look at the Metadata section, below is an example.
+
+```
+ Metadata:
+    icy-br          : 320
+    icy-description : DJ-mixed blend of modern and classic rock, electronica, world music, and more. Always 100% commercial-free
+    icy-genre       : Eclectic
+    icy-name        : Radio Paradise (320k aac)
+    icy-pub         : 1
+    icy-url         : https://radioparadise.com
+    StreamTitle     : Depeche Mode - Strangelove
+    StreamUrl       : http://img.radioparadise.com/covers/l/B000002LCI.jpg
+```
+
+In the example above, all tags are populated with correct information, no
+modifications to forked-daapd configuration should be needed. Note that
+StreamUrl points to the artwork image file.
+
+
+Below is another example that will require some tweaks to forked-daapd, Notice
+`icy-name` is blank and `StreamUrl` doesn't point to an image.
+
+```
+Metadata:
+    icy-br          : 127
+    icy-pub         : 0
+    icy-description : Unspecified description
+    icy-url         : 
+    icy-genre       : various
+    icy-name        : 
+    StreamTitle     : Pour Some Sugar On Me - Def Leppard
+    StreamUrl       : https://radio.stream.domain/api9/eventdata/49790578
+```
+
+In the above, first fix is the blank name, second is the image artwork.
+### 1) Stream Name/Title
+Set the name with an EXTINF tag in the m3u playlist file:
+
+```
+#EXTM3U
+#EXTINF:-1, - My Radio Stream Name
+http://radio.stream.domain/stream.url
+```
+
+The format is basically `#EXTINF:<length>, <Artist Name> - <Artist Title>`.
+Length is -1 since it's a stream, `<Artist Name>` was left blank since
+`StreamTitle` is accurate in the Metadata but `<Artist Title>` was set to
+`My Radio Stream Name` since `icy-name` was blank.
+
+### 2) Artwork (and track duration)
+If `StreamUrl` does not point directly to an artwork file then the link may be
+to a json file that contains an artwork link. If so, you can make forked-daapd
+download the file automatically and search for an artwork link, and also track
+duration.
+
+Try to download the file, e.g. with `curl "https://radio.stream.domain/api9/eventdata/49790578"`.
+Let's assume you get something like this:
+
+```
+{
+    "eventId": 49793707,
+    "eventStart": "2020-05-08 16:23:03",
+    "eventFinish": "2020-05-08 16:27:21",
+    "eventDuration": 254,
+    "eventType": "Song",
+    "eventSongTitle": "Pour Some Sugar On Me",
+    "eventSongArtist": "Def Leppard",
+    "eventImageUrl": "https://radio.stream.domain/artist/1-1/320x320/562.jpg?ver=1465083491",
+    "eventImageUrlSmall": "https://radio.stream.domain/artist/1-1/160x160/562.jpg?ver=1465083491",
+    "eventAppleMusicUrl": "https://geo.itunes.apple.com/dk/album/530707298?i=530707313"
+}
+```
+
+In this case, you would need to tell forked-daapd to look for "eventDuration"
+and "eventImageUrl" (or just "duration" and "url"). You can do that like this:
+
+```
+curl -X PUT "http://localhost:3689/api/settings/misc/streamurl_keywords_length" --data "{\"name\":\"streamurl_keywords_length\",\"value\":\"duration\"}"
+curl -X PUT "http://localhost:3689/api/settings/misc/streamurl_keywords_artwork_url" --data "{\"name\":\"streamurl_keywords_artwork_url\",\"value\":\"url\"}
+```
+
+If you want multiple search phrases then comma separate, e.g. "duration,length".
+
+
+If your radio station is not returning any artwork links, you can also just make
+a static artwork by placing a png/jpg in the same directory as the m3u, and with
+the same name, e.g. `My Radio Stream.jpg` for `My Radio Stream.m3u`.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,7 +130,7 @@ forked_daapd_SOURCES = main.c \
 	worker.c worker.h \
 	settings.c settings.h \
 	input.h input.c \
-	inputs/file_http.c inputs/pipe.c inputs/timer.c \
+	inputs/file.c inputs/http.c inputs/pipe.c inputs/timer.c \
 	outputs.h outputs.c \
 	outputs/rtp_common.h outputs/rtp_common.c \
 	outputs/raop.c $(RAOP_VERIFICATION_SRC) \

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -275,11 +275,14 @@ static struct artwork_source artwork_item_source[] =
       .cache = ON_SUCCESS | ON_FAILURE,
     },
     {
+      // Here we must use STASH because this handler must always just be a
+      // backup when artwork_url_get fails. If we used ON_SUCCESS this image
+      // would go in permanent cache, and artwork_url_get not get called again.
       .name = "playlist own",
       .handler = source_item_ownpl_get,
       .data_kinds = (1 << DATA_KIND_HTTP),
       .media_kinds = MEDIA_KIND_ALL,
-      .cache = ON_SUCCESS | ON_FAILURE,
+      .cache = STASH,
     },
     {
       .name = "Spotify search web api (files)",

--- a/src/artwork.c
+++ b/src/artwork.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -193,7 +194,7 @@ static int source_group_dir_get(struct artwork_ctx *ctx);
 static int source_item_cache_get(struct artwork_ctx *ctx);
 static int source_item_embedded_get(struct artwork_ctx *ctx);
 static int source_item_own_get(struct artwork_ctx *ctx);
-static int source_item_stream_get(struct artwork_ctx *ctx);
+static int source_item_artwork_url_get(struct artwork_ctx *ctx);
 static int source_item_pipe_get(struct artwork_ctx *ctx);
 static int source_item_spotifywebapi_track_get(struct artwork_ctx *ctx);
 static int source_item_ownpl_get(struct artwork_ctx *ctx);
@@ -254,7 +255,7 @@ static struct artwork_source artwork_item_source[] =
     },
     {
       .name = "stream",
-      .handler = source_item_stream_get,
+      .handler = source_item_artwork_url_get,
       .data_kinds = (1 << DATA_KIND_HTTP),
       .media_kinds = MEDIA_KIND_MUSIC,
       .cache = STASH,
@@ -1503,25 +1504,15 @@ source_item_own_get(struct artwork_ctx *ctx)
 }
 
 /*
- * Downloads the artwork pointed to by the ICY metadata tag in an internet radio
- * stream (the StreamUrl tag). The path will be converted back to the id, which
- * is given to the player. If the id is currently being played, and there is a
- * valid ICY metadata artwork URL available, it will be returned to this
- * function, which will then use the http client to get the artwork.
+ * Downloads the artwork from the location pointed to by queue_item->artwork_url
  */
 static int
-source_item_stream_get(struct artwork_ctx *ctx)
+source_item_artwork_url_get(struct artwork_ctx *ctx)
 {
   struct db_queue_item *queue_item;
-  char *url;
-  char *ext;
-  int len;
   int ret;
 
-
-  DPRINTF(E_SPAM, L_ART, "Trying internet stream artwork in %s\n", ctx->dbmfi->path);
-
-  ret = ART_E_NONE;
+  DPRINTF(E_SPAM, L_ART, "Trying artwork url for %s\n", ctx->dbmfi->path);
 
   queue_item = db_queue_fetch_byfileid(ctx->id);
   if (!queue_item || !queue_item->artwork_url)
@@ -1530,23 +1521,11 @@ source_item_stream_get(struct artwork_ctx *ctx)
       return ART_E_NONE;
     }
 
-  url = strdup(queue_item->artwork_url);
+  ret = artwork_get_byurl(ctx->evbuf, queue_item->artwork_url, ctx->max_w, ctx->max_h);
+
+  snprintf(ctx->path, sizeof(ctx->path), "%s", queue_item->artwork_url);
+
   free_queue_item(queue_item, 0);
-
-  len = strlen(url);
-  if ((len < 14) || (len > PATH_MAX)) // Can't be shorter than http://a/1.jpg
-    goto out_url;
-
-  ext = strrchr(url, '.');
-  if (!ext)
-    goto out_url;
-  if ((strcmp(ext, ".jpg") != 0) && (strcmp(ext, ".png") != 0))
-    goto out_url;
-
-  ret = artwork_get_byurl(ctx->evbuf, url, ctx->max_w, ctx->max_h);
-
- out_url:
-  free(url);
 
   return ret;
 }
@@ -2024,7 +2003,7 @@ artwork_get_group(struct evbuffer *evbuf, int id, int max_w, int max_h)
 }
 
 /* Checks if the file is an artwork file */
-int
+bool
 artwork_file_is_artwork(const char *filename)
 {
   cfg_t *lib;
@@ -2039,7 +2018,7 @@ artwork_file_is_artwork(const char *filename)
 
   for (i = 0; i < n; i++)
     {
-      for (j = 0; j < (sizeof(cover_extension) / sizeof(cover_extension[0])); j++)
+      for (j = 0; j < ARRAY_SIZE(cover_extension); j++)
 	{
 	  ret = snprintf(artwork, sizeof(artwork), "%s.%s", cfg_getnstr(lib, "artwork_basenames", i), cover_extension[j]);
 	  if ((ret < 0) || (ret >= sizeof(artwork)))
@@ -2049,12 +2028,42 @@ artwork_file_is_artwork(const char *filename)
 	    }
 
 	  if (strcmp(artwork, filename) == 0)
-	    return 1;
+	    return true;
 	}
 
-      if (j < (sizeof(cover_extension) / sizeof(cover_extension[0])))
+      if (j < ARRAY_SIZE(cover_extension))
 	break;
     }
 
-  return 0;
+  return false;
+}
+
+bool
+artwork_extension_is_artwork(const char *path)
+{
+  char *ext;
+  int len;
+  int i;
+
+  ext = strrchr(path, '.');
+  if (!ext)
+    return false;
+
+  ext++;
+
+  for (i = 0; i < ARRAY_SIZE(cover_extension); i++)
+    {
+      len = strlen(cover_extension[i]);
+
+      if (strncasecmp(cover_extension[i], ext, len) != 0)
+        continue;
+
+      // Check that after the extension we either have the end or "?"
+      if (ext[len] != '\0' && ext[len] != '?')
+        continue;
+
+      return true;
+    }
+
+  return false;
 }

--- a/src/artwork.h
+++ b/src/artwork.h
@@ -9,6 +9,7 @@
 #define ART_DEFAULT_WIDTH  600
 
 #include <event2/buffer.h>
+#include <stdbool.h>
 
 /*
  * Get the artwork image for an individual item (track)
@@ -38,9 +39,20 @@ artwork_get_group(struct evbuffer *evbuf, int id, int max_w, int max_h);
  * Checks if the file is an artwork file (based on user config)
  *
  * @in  filename Name of the file
- * @return       1 if true, 0 if false
+ * @return       true/false
  */
-int
+bool
 artwork_file_is_artwork(const char *filename);
+
+/*
+ * Checks if the path (or URL) has file extension that is recognized as a
+ * supported file type (e.g. ".jpg"). Also supports URL-encoded paths, e.g.
+ * http://foo.com/bar.jpg?something
+ *
+ * @in  path     Path to the file (can also be a URL)
+ * @return       true/false
+ */
+bool
+artwork_extension_is_artwork(const char *path);
 
 #endif /* !__ARTWORK_H__ */

--- a/src/http.c
+++ b/src/http.c
@@ -720,11 +720,11 @@ metadata_header_get(struct http_icy_metadata *metadata, AVFormatContext *fmtctx)
       if (ptr[0] == ' ')
 	ptr++;
 
-      if ((strncmp(icy_token, "icy-name", strlen("icy-name")) == 0) && !metadata->name)
+      if ((strncmp(icy_token, "icy-name", strlen("icy-name")) == 0) && ptr[0] != '\0' && !metadata->name)
 	metadata->name = strdup(ptr);
-      else if ((strncmp(icy_token, "icy-description", strlen("icy-description")) == 0) && !metadata->description)
+      else if ((strncmp(icy_token, "icy-description", strlen("icy-description")) == 0) && ptr[0] != '\0' && !metadata->description)
 	metadata->description = strdup(ptr);
-      else if ((strncmp(icy_token, "icy-genre", strlen("icy-genre")) == 0) && !metadata->genre)
+      else if ((strncmp(icy_token, "icy-genre", strlen("icy-genre")) == 0) && ptr[0] != '\0' && !metadata->genre)
 	metadata->genre = strdup(ptr);
 
       icy_token = strtok_r(NULL, "\r\n", &save_pr);
@@ -816,17 +816,17 @@ http_icy_metadata_get(AVFormatContext *fmtctx, int packet_only)
   CHECK_NULL(L_HTTP, metadata = calloc(1, sizeof(struct http_icy_metadata)));
 
   got_header = 0;
-  if ( (value = keyval_get(ctx.input_headers, "icy-name")) )
+  if ( (value = keyval_get(ctx.input_headers, "icy-name")) && value[0] != '\0' )
     {
       metadata->name = strdup(value);
       got_header = 1;
     }
-  if ( (value = keyval_get(ctx.input_headers, "icy-description")) )
+  if ( (value = keyval_get(ctx.input_headers, "icy-description")) && value[0] != '\0' )
     {
       metadata->description = strdup(value);
       got_header = 1;
     }
-  if ( (value = keyval_get(ctx.input_headers, "icy-genre")) )
+  if ( (value = keyval_get(ctx.input_headers, "icy-genre")) && value[0] != '\0' )
     {
       metadata->genre = strdup(value);
       got_header = 1;

--- a/src/http.c
+++ b/src/http.c
@@ -667,9 +667,9 @@ metadata_packet_get(struct http_icy_metadata *metadata, AVFormatContext *fmtctx)
 	  else
 	    metadata->title = strdup(metadata->title);
 	}
-      else if ((strncmp(icy_token, "StreamUrl", strlen("StreamUrl")) == 0) && !metadata->artwork_url && strlen(ptr) > 0)
+      else if ((strncmp(icy_token, "StreamUrl", strlen("StreamUrl")) == 0) && !metadata->url && strlen(ptr) > 0)
 	{
-	  metadata->artwork_url = strdup(ptr);
+	  metadata->url = strdup(ptr);
 	}
 
       if (end)
@@ -741,10 +741,7 @@ http_icy_metadata_get(AVFormatContext *fmtctx, int packet_only)
   int got_packet;
   int got_header;
 
-  metadata = malloc(sizeof(struct http_icy_metadata));
-  if (!metadata)
-    return NULL;
-  memset(metadata, 0, sizeof(struct http_icy_metadata));
+  CHECK_NULL(L_HTTP, metadata = calloc(1, sizeof(struct http_icy_metadata)));
 
   got_packet = (metadata_packet_get(metadata, fmtctx) == 0);
   got_header = (!packet_only) && (metadata_header_get(metadata, fmtctx) == 0);
@@ -761,7 +758,7 @@ http_icy_metadata_get(AVFormatContext *fmtctx, int packet_only)
 	metadata->genre,
 	metadata->title,
 	metadata->artist,
-	metadata->artwork_url,
+	metadata->url,
 	metadata->hash
 	);
 */
@@ -816,10 +813,7 @@ http_icy_metadata_get(AVFormatContext *fmtctx, int packet_only)
       return NULL;
     }
 
-  metadata = malloc(sizeof(struct http_icy_metadata));
-  if (!metadata)
-    return NULL;
-  memset(metadata, 0, sizeof(struct http_icy_metadata));
+  CHECK_NULL(L_HTTP, metadata = calloc(1, sizeof(struct http_icy_metadata)));
 
   got_header = 0;
   if ( (value = keyval_get(ctx.input_headers, "icy-name")) )
@@ -853,7 +847,7 @@ http_icy_metadata_get(AVFormatContext *fmtctx, int packet_only)
 	metadata->genre,
 	metadata->title,
 	metadata->artist,
-	metadata->artwork_url,
+	metadata->url,
 	metadata->hash
 	);*/
 
@@ -864,24 +858,14 @@ http_icy_metadata_get(AVFormatContext *fmtctx, int packet_only)
 void
 http_icy_metadata_free(struct http_icy_metadata *metadata, int content_only)
 {
-  if (metadata->name)
-    free(metadata->name);
+  if (!metadata)
+    return;
 
-  if (metadata->description)
-    free(metadata->description);
-
-  if (metadata->genre)
-    free(metadata->genre);
-
-  if (metadata->title)
-    free(metadata->title);
-
-  if (metadata->artist)
-    free(metadata->artist);
-
-  if (metadata->artwork_url)
-    free(metadata->artwork_url);
-
-  if (!content_only)
-    free(metadata);
+  free(metadata->name);
+  free(metadata->description);
+  free(metadata->genre);
+  free(metadata->title);
+  free(metadata->artist);
+  free(metadata->url);
+  free(metadata);
 }

--- a/src/http.h
+++ b/src/http.h
@@ -49,7 +49,7 @@ struct http_icy_metadata
   /* Track specific, comes from icy_metadata_packet */
   char *title;
   char *artist;
-  char *artwork_url;
+  char *url;
 
   uint32_t hash;
 };

--- a/src/input.h
+++ b/src/input.h
@@ -133,7 +133,7 @@ struct input_definition
 /*
  * Transfer stream data to the player's input buffer. Data must be PCM-LE
  * samples. The input evbuf will be drained on succesful write. This is to avoid
- * copying memory.
+ * copying memory. Thread-safe.
  *
  * @in  evbuf    Raw PCM_LE audio data to write
  * @in  evbuf    Quality of the PCM (sample rate etc.)

--- a/src/inputs/file.c
+++ b/src/inputs/file.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2017-2020 Espen Jurgensen
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+
+#include <event2/buffer.h>
+
+#include "transcode.h"
+#include "misc.h"
+#include "logger.h"
+#include "input.h"
+
+/*---------------------------- Input implementation --------------------------*/
+
+// Important! If you change any of the below then consider if the change also
+// should be made in http.c
+
+static int
+setup(struct input_source *source)
+{
+  struct transcode_ctx *ctx;
+
+  ctx = transcode_setup(XCODE_PCM_NATIVE, NULL, source->data_kind, source->path, source->len_ms, NULL);
+  if (!ctx)
+    return -1;
+
+  CHECK_NULL(L_PLAYER, source->evbuf = evbuffer_new());
+
+  source->quality.sample_rate = transcode_encode_query(ctx->encode_ctx, "sample_rate");
+  source->quality.bits_per_sample = transcode_encode_query(ctx->encode_ctx, "bits_per_sample");
+  source->quality.channels = transcode_encode_query(ctx->encode_ctx, "channels");
+
+  source->input_ctx = ctx;
+
+  return 0;
+}
+
+static int
+stop(struct input_source *source)
+{
+  struct transcode_ctx *ctx = source->input_ctx;
+
+  transcode_cleanup(&ctx);
+
+  if (source->evbuf)
+    evbuffer_free(source->evbuf);
+
+  source->input_ctx = NULL;
+  source->evbuf = NULL;
+
+  return 0;
+}
+
+static int
+play(struct input_source *source)
+{
+  struct transcode_ctx *ctx = source->input_ctx;
+  int ret;
+
+  // We set "wanted" to 1 because the read size doesn't matter to us
+  // TODO optimize?
+  ret = transcode(source->evbuf, NULL, ctx, 1);
+  if (ret == 0)
+    {
+      input_write(source->evbuf, &source->quality, INPUT_FLAG_EOF);
+      stop(source);
+      return -1;
+    }
+  else if (ret < 0)
+    {
+      input_write(NULL, NULL, INPUT_FLAG_ERROR);
+      stop(source);
+      return -1;
+    }
+
+  input_write(source->evbuf, &source->quality, 0);
+
+  return 0;
+}
+
+static int
+seek(struct input_source *source, int seek_ms)
+{
+  return transcode_seek(source->input_ctx, seek_ms);
+}
+
+struct input_definition input_file =
+{
+  .name = "file",
+  .type = INPUT_TYPE_FILE,
+  .disabled = 0,
+  .setup = setup,
+  .play = play,
+  .stop = stop,
+  .seek = seek,
+};

--- a/src/inputs/file_http.c
+++ b/src/inputs/file_http.c
@@ -147,7 +147,7 @@ metadata_get_http(struct input_metadata *metadata, struct input_source *source)
   swap_pointers(&metadata->artist, &m->artist);
   // Note we map title to album, because clients should show stream name as titel
   swap_pointers(&metadata->album, &m->title);
-  swap_pointers(&metadata->artwork_url, &m->artwork_url);
+  swap_pointers(&metadata->artwork_url, &m->url);
 
   http_icy_metadata_free(m, 0);
   return 0;

--- a/src/settings.c
+++ b/src/settings.c
@@ -42,10 +42,17 @@ static struct settings_option artwork_options[] =
       { "use_artwork_source_coverartarchive", SETTINGS_TYPE_BOOL, NULL, artwork_coverartarchive_default_getbool, NULL },
   };
 
+static struct settings_option misc_options[] =
+  {
+      { "streamurl_keywords_artwork_url", SETTINGS_TYPE_STR },
+      { "streamurl_keywords_length", SETTINGS_TYPE_STR },
+  };
+
 static struct settings_category categories[] =
   {
       { "webinterface", webinterface_options, ARRAY_SIZE(webinterface_options) },
       { "artwork", artwork_options, ARRAY_SIZE(artwork_options) },
+      { "misc", misc_options, ARRAY_SIZE(misc_options) },
   };
 
 
@@ -93,7 +100,6 @@ artwork_coverartarchive_default_getbool(struct settings_option *option)
 {
   return artwork_default_getbool(false, "coverartarchive");
 }
-
 
 /* ------------------------------ IMPLEMENTATION -----------------------------*/
 


### PR DESCRIPTION
@sfeakes here is the change I am planning to better support the StreamUrl tag's, like you proposed. As you can see, in addition to artwork url's it also supports getting track length.

I'm a little unsure what the default behaviour should be. Right now it is to not download the link in the StreamUrl, unless the user has configured forked-daapd with strings to search for. So to use it you need to configure it with the words you want it to search for. This is done via the settings api, instead of config file, because that way it can be changed at runtime, and be made available as a setting via the web interface. Until then, you can do like this to configure it to look for e.g. "url" and "duration" (note that the words also match substrings, so ""duration" is enough to match "eventDuration"):
`curl -X PUT "http://localhost:3689/api/settings/misc/streamurl_keywords_artwork_url" --data "{\"name\":\"streamurl_keywords_artwork_url\",\"value\":\"url\"}"`
`curl -X PUT "http://localhost:3689/api/settings/misc/streamurl_keywords_length" --data "{\"name\":\"streamurl_keywords_length\",\"value\":\"duration\"}"`

The current implementation has the issue that it runs in the input thread. That can be an issue for playback if the server is slow to respond with the json, so I have to find a way to download async.