### PR TITLE
[streaming] bug fix - drop client connections if libav has not mp3 encode 

### DIFF
--- a/src/httpd_streaming.c
+++ b/src/httpd_streaming.c
@@ -222,6 +222,7 @@ streaming_meta_cb(evutil_socket_t fd, short event, void *arg)
     {
       DPRINTF(E_LOG, L_STREAMING, "Will not be able to stream MP3, libav does not support MP3 encoding: %d/%d/%d @ %d\n", streaming_quality_out.sample_rate, streaming_quality_out.bits_per_sample, streaming_quality_out.channels, streaming_quality_out.bit_rate);
       streaming_not_supported = 1;
+      streaming_end();
       return;
     }
 


### PR DESCRIPTION
If `libav` has no mp3 encode the server does not attempt to send data, but it does not drop the client's connection in `streaming_meta_cb()`

This results in audio packets coming but never sent because of the connected client - we see this in the log:
```
[  LOG]   stream: Will not be able to stream MP3, libav does not support MP3 encoding: 44100/16/2 @ 192000
[  LOG]   stream: Streaming unsupported
[  LOG]   stream: Streaming unsupported
[  LOG]   stream: Streaming unsupported
[  LOG]   stream: Streaming unsupported
[  LOG]   stream: Streaming unsupported
[  LOG]   stream: Streaming unsupported
[  LOG]   stream: Streaming unsupported
[  LOG]   stream: Streaming unsupported
[  LOG]   stream: Streaming unsupported
[  LOG]   stream: Streaming unsupported
```

Simple one line fix to drop client when no encoding support - this is what also (currently) happens when an error is detected in the same function.