### PR TITLE
Metadata for albums and artists

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -391,6 +391,9 @@ static const ssize_t dbgri_cols_map[] =
   {
     dbgri_offsetof(id),
     dbgri_offsetof(persistentid),
+    dbgri_offsetof(date_released),
+    dbgri_offsetof(data_kind),
+    dbgri_offsetof(media_kind),
     dbgri_offsetof(itemname),
     dbgri_offsetof(itemname_sort),
     dbgri_offsetof(itemcount),
@@ -883,12 +886,12 @@ fixup_defaults(char **tag, enum fixup_type fixup, struct fixup_ctx *ctx)
     {
       case DB_FIXUP_SONGARTISTID:
 	if (ctx->mfi && ctx->mfi->songartistid == 0)
-	  ctx->mfi->songartistid = two_str_hash(ctx->mfi->album_artist, NULL);
+	  ctx->mfi->songartistid = persistentid_hash(ctx->mfi->album_artist, NULL, -1, ctx->mfi->media_kind);
 	break;
 
       case DB_FIXUP_SONGALBUMID:
 	if (ctx->mfi && ctx->mfi->songalbumid == 0)
-	  ctx->mfi->songalbumid = two_str_hash(ctx->mfi->album_artist, ctx->mfi->album);
+	  ctx->mfi->songalbumid = persistentid_hash(ctx->mfi->album_artist, ctx->mfi->album, ctx->mfi->data_kind, ctx->mfi->media_kind);
 	break;
 
       case DB_FIXUP_TITLE:
@@ -1903,7 +1906,7 @@ db_build_query_group_albums(struct query_params *qp, struct query_clause *qc)
   char *query;
 
   count = sqlite3_mprintf("SELECT COUNT(DISTINCT f.songalbumid) FROM files f %s;", qc->where);
-  query = sqlite3_mprintf("SELECT g.id, g.persistentid, f.album, f.album_sort, COUNT(f.id) as track_count, 1 as album_count, f.album_artist, f.songartistid, SUM(f.song_length) FROM files f JOIN groups g ON f.songalbumid = g.persistentid %s GROUP BY f.songalbumid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
+  query = sqlite3_mprintf("SELECT g.id, g.persistentid, g.date_released, g.data_kind, g.media_kind, f.album, f.album_sort, COUNT(f.id) as track_count, 1 as album_count, f.album_artist, f.songartistid, SUM(f.song_length) FROM files f JOIN groups g ON f.songalbumid = g.persistentid %s GROUP BY f.songalbumid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
 
   return db_build_query_check(qp, count, query);
 }
@@ -1915,7 +1918,7 @@ db_build_query_group_artists(struct query_params *qp, struct query_clause *qc)
   char *query;
 
   count = sqlite3_mprintf("SELECT COUNT(DISTINCT f.songartistid) FROM files f %s;", qc->where);
-  query = sqlite3_mprintf("SELECT g.id, g.persistentid, f.album_artist, f.album_artist_sort, COUNT(f.id) as track_count, COUNT(DISTINCT f.songalbumid) as album_count, f.album_artist, f.songartistid, SUM(f.song_length) FROM files f JOIN groups g ON f.songartistid = g.persistentid %s GROUP BY f.songartistid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
+  query = sqlite3_mprintf("SELECT g.id, g.persistentid, g.date_released, g.data_kind, g.media_kind, f.album_artist, f.album_artist_sort, COUNT(f.id) as track_count, COUNT(DISTINCT f.songalbumid) as album_count, f.album_artist, f.songartistid, SUM(f.song_length) FROM files f JOIN groups g ON f.songartistid = g.persistentid %s GROUP BY f.songartistid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
 
   return db_build_query_check(qp, count, query);
 }

--- a/src/db.h
+++ b/src/db.h
@@ -290,6 +290,9 @@ struct db_playlist_info {
 struct group_info {
   uint32_t id;           /* integer id (miid) */
   uint64_t persistentid; /* ulonglong id (mper) */
+  uint32_t date_released;
+  uint32_t data_kind;
+  uint32_t media_kind;
   char *itemname;        /* album or album_artist (minm) */
   char *itemname_sort;   /* album_sort or album_artist_sort (~mshc) */
   uint32_t itemcount;    /* number of items (mimc) */
@@ -304,6 +307,9 @@ struct group_info {
 struct db_group_info {
   char *id;
   char *persistentid;
+  char *date_released;
+  char *data_kind;
+  char *media_kind;
   char *itemname;
   char *itemname_sort;
   char *itemcount;

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -132,6 +132,9 @@
   "   type           INTEGER NOT NULL,"					\
   "   name           VARCHAR(1024) NOT NULL COLLATE DAAP,"		\
   "   persistentid   INTEGER NOT NULL,"					\
+  "   date_released  INTEGER DEFAULT 0,"				\
+  "   data_kind      INTEGER DEFAULT NULL,"				\
+  "   media_kind     INTEGER DEFAULT NULL,"				\
   "CONSTRAINT groups_type_unique_persistentid UNIQUE (type, persistentid)" \
   ");"
 
@@ -414,15 +417,19 @@ static const struct db_init_query db_init_index_queries[] =
 #define TRG_GROUPS_INSERT										\
   "CREATE TRIGGER trg_groups_insert AFTER INSERT ON files FOR EACH ROW"					\
   " BEGIN"												\
-  "   INSERT OR IGNORE INTO groups (type, name, persistentid) VALUES (1, NEW.album, NEW.songalbumid);"	\
-  "   INSERT OR IGNORE INTO groups (type, name, persistentid) VALUES (2, NEW.album_artist, NEW.songartistid);"	\
+  "   INSERT OR IGNORE INTO groups (type, name, persistentid, date_released, data_kind, media_kind)"	\
+  "     VALUES (1, NEW.album, NEW.songalbumid, NEW.date_released, NEW.data_kind, NEW.media_kind);"	\
+  "   INSERT OR IGNORE INTO groups (type, name, persistentid, date_released, data_kind, media_kind)"	\
+  "     VALUES (2, NEW.album_artist, NEW.songartistid, NULL, NULL, NEW.media_kind);"			\
   " END;"
 
 #define TRG_GROUPS_UPDATE										\
   "CREATE TRIGGER trg_groups_update AFTER UPDATE OF songartistid, songalbumid ON files FOR EACH ROW"	\
   " BEGIN"												\
-  "   INSERT OR IGNORE INTO groups (type, name, persistentid) VALUES (1, NEW.album, NEW.songalbumid);"	\
-  "   INSERT OR IGNORE INTO groups (type, name, persistentid) VALUES (2, NEW.album_artist, NEW.songartistid);"	\
+  "   INSERT OR IGNORE INTO groups (type, name, persistentid, date_released, data_kind, media_kind)"	\
+  "     VALUES (1, NEW.album, NEW.songalbumid, NEW.date_released, NEW.data_kind, NEW.media_kind);"	\
+  "   INSERT OR IGNORE INTO groups (type, name, persistentid, date_released, data_kind, media_kind)"	\
+  "     VALUES (2, NEW.album_artist, NEW.songartistid, NULL, NULL, NEW.media_kind);"			\
   " END;"
 
 static const struct db_init_query db_init_trigger_queries[] =

--- a/src/db_init.h
+++ b/src/db_init.h
@@ -26,7 +26,7 @@
  * is a major upgrade. In other words minor version upgrades permit downgrading
  * forked-daapd after the database was upgraded. */
 #define SCHEMA_VERSION_MAJOR 21
-#define SCHEMA_VERSION_MINOR 04
+#define SCHEMA_VERSION_MINOR 05
 
 int
 db_init_indices(sqlite3 *hdl);

--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1060,6 +1060,24 @@ static const struct db_upgrade_query db_upgrade_v2104_queries[] =
     { U_v2104_SCVER_MINOR,    "set schema_version_minor to 04" },
   };
 
+#define U_v2105_ALTER_GROUPS_ADD_DATE_RELEASED \
+  "ALTER TABLE groups ADD COLUMN date_released INTEGER DEFAULT 0;"
+#define U_v2105_ALTER_GROUPS_ADD_DATA_KIND \
+  "ALTER TABLE groups ADD COLUMN data_kind INTEGER DEFAULT NULL;"
+#define U_v2105_ALTER_GROUPS_ADD_MEDIA_KIND \
+  "ALTER TABLE groups ADD COLUMN media_kind INTEGER DEFAULT NULL;"
+#define U_v2105_SCVER_MINOR                    \
+  "UPDATE admin SET value = '05' WHERE key = 'schema_version_minor';"
+
+static const struct db_upgrade_query db_upgrade_v2105_queries[] =
+  {
+    { U_v2105_ALTER_GROUPS_ADD_DATE_RELEASED, "alter table groups add column date_released" },
+    { U_v2105_ALTER_GROUPS_ADD_DATA_KIND, "alter table groups add column data_kind" },
+    { U_v2105_ALTER_GROUPS_ADD_MEDIA_KIND, "alter table groups add column media_kind" },
+
+    { U_v2105_SCVER_MINOR,    "set schema_version_minor to 05" },
+  };
+
 
 int
 db_upgrade(sqlite3 *hdl, int db_ver)
@@ -1235,6 +1253,14 @@ db_upgrade(sqlite3 *hdl, int db_ver)
       ret = db_generic_upgrade(hdl, db_upgrade_v2104_queries, ARRAY_SIZE(db_upgrade_v2104_queries));
       if (ret < 0)
 	return -1;
+
+      /* FALLTHROUGH */
+
+    case 2104:
+      ret = db_generic_upgrade(hdl, db_upgrade_v2105_queries, ARRAY_SIZE(db_upgrade_v2105_queries));
+      if (ret < 0)
+	return -1;
+
       break;
 
     default:

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -151,6 +151,7 @@ static json_object *
 artist_to_json(struct db_group_info *dbgri)
 {
   json_object *item;
+  int intval;
   char uri[100];
   char artwork_url[100];
   int ret;
@@ -158,6 +159,14 @@ artist_to_json(struct db_group_info *dbgri)
   item = json_object_new_object();
 
   safe_json_add_string(item, "id", dbgri->persistentid);
+
+  if (dbgri->media_kind)
+    {
+      ret = safe_atoi32(dbgri->media_kind, &intval);
+      if (ret == 0)
+	safe_json_add_string(item, "media_kind", db_media_kind_label(intval));
+    }
+
   safe_json_add_string(item, "name", dbgri->itemname);
   safe_json_add_string(item, "name_sort", dbgri->itemname_sort);
   safe_json_add_int_from_string(item, "album_count", dbgri->groupalbumcount);
@@ -179,6 +188,7 @@ static json_object *
 album_to_json(struct db_group_info *dbgri)
 {
   json_object *item;
+  int intval;
   char uri[100];
   char artwork_url[100];
   int ret;
@@ -186,6 +196,22 @@ album_to_json(struct db_group_info *dbgri)
   item = json_object_new_object();
 
   safe_json_add_string(item, "id", dbgri->persistentid);
+  safe_json_add_time_from_string(item, "date_released", dbgri->date_released, false);
+
+  if (dbgri->media_kind)
+    {
+      ret = safe_atoi32(dbgri->media_kind, &intval);
+      if (ret == 0)
+	safe_json_add_string(item, "media_kind", db_media_kind_label(intval));
+    }
+
+  if (dbgri->data_kind)
+    {
+      ret = safe_atoi32(dbgri->data_kind, &intval);
+      if (ret == 0)
+	safe_json_add_string(item, "data_kind", db_data_kind_label(intval));
+    }
+
   safe_json_add_string(item, "name", dbgri->itemname);
   safe_json_add_string(item, "name_sort", dbgri->itemname_sort);
   safe_json_add_string(item, "artist", dbgri->songalbumartist);

--- a/src/misc.c
+++ b/src/misc.c
@@ -791,14 +791,14 @@ djb_hash(const void *data, size_t len)
 }
 
 int64_t
-two_str_hash(const char *a, const char *b)
+persistentid_hash(const char *a, const char *b, int data_kind, int media_kind)
 {
   char hashbuf[2048];
   int64_t hash;
   int i;
   int ret;
 
-  ret = snprintf(hashbuf, sizeof(hashbuf), "%s==%s", (a) ? a : "", (b) ? b : "");
+  ret = snprintf(hashbuf, sizeof(hashbuf), "%s==%s==%d==%d", (a) ? a : "", (b) ? b : "", data_kind, media_kind);
   if (ret < 0 || ret == sizeof(hashbuf))
     {
       DPRINTF(E_LOG, L_MISC, "Buffer too large to calculate hash: '%s==%s'\n", a, b);

--- a/src/misc.h
+++ b/src/misc.h
@@ -134,7 +134,7 @@ uint32_t
 djb_hash(const void *data, size_t len);
 
 int64_t
-two_str_hash(const char *a, const char *b);
+persistentid_hash(const char *a, const char *b, int data_kind, int media_kind);
 
 uint8_t *
 b64_decode(int *dstlen, const char *src);


### PR DESCRIPTION
Would love to hear some feedback on this. It is currently not well tested and there is at least one issue left (see below).

Currently we have only limited metadata for albums and artists (groups table in the DB and the groups queries). This proposal implementation adds three additional fields:

- media_kind
- data_kind (only for albums)
- date_released (only for albums)

Additionally `media_kind` and `data_kind` are added to the persistent id generation of albums/artists. The rationale behind this is, that different media kinds (music, audiobooks, podcasts) and data kinds (files, spotify) should result in different persistent ids. This enables e. g. the web interface to directly identify if an album is a music album or an audiobook and link the correct view (would make it easier to enable search results for audiobooks, podcasts - ref #1039 ).
Having `data_kind` as an album metadata field would allow to filter by this attribute in the web interface (e. g. showing only local files).

Adding `date_released` to the albums metadata might also be done by only changing the groups query and fetch it based on the joined files table (i don't think it makes sense to separate albums with the same name and different release dates). Having the release date would be good to allow the web interface to sort album lists by release date (and also display the release date, at least for me this is of interest when browsing albums for one artist).

One problem i see is how to upgrade an existing db properly. It would require recalculating the persistent ids and therefore would require to rescan all files.
