### PR TITLE
[alsa] dump_card() includes ALSA device name

### DIFF
--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -247,7 +247,7 @@ dump_card(int card, snd_ctl_card_info_t *info)
   if (mixerstr[0] == '\0')
     sprintf(mixerstr, " (no mixers found)");
 
-  DPRINTF(E_INFO, L_LAUDIO, "Available ALSA playback mixer(s) on '%s' (%s):%s\n", hwdev, snd_ctl_card_info_get_name(info), mixerstr);
+  DPRINTF(E_INFO, L_LAUDIO, "Available ALSA playback mixer(s) on %s CARD=%s (%s):%s\n", hwdev, snd_ctl_card_info_get_id(info), snd_ctl_card_info_get_name(info), mixerstr);
 
 errormixer:
   snd_mixer_close(mixer);


### PR DESCRIPTION
Include ALSA's device name in the ALSA modules 'info' logging to help identify sound devices as seen by the system for assisting config setup

Many configs use ALSA's hw ids to refer to device but ALSA can also use device names:
```
    laudio: Available ALSA playback mixer(s) on hw:0 CARD=Intel (HDA Intel): 'Master' 'Headphone' 'Speaker' 'PCM' 'Mic' 'Beep'
    laudio: Available ALSA playback mixer(s) on hw:1 CARD=E30 (E30): 'E30 '
```

From the example above can use these ALSA names interchangably:
* `hw:0` and `hw:Intel`
* `hw:1` and `hw:E30`

This is useful to allow configs to refer to ALSA devices rather than card numbers (0, 1, 2..).  This is predominantly useful for USB ALSA devices that may get assigned different ALSA card numbers depending on insert order.