### PR TITLE
[scan] files canner minor fixes: bulk_scan() count

### DIFF
--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -1032,6 +1032,7 @@ bulk_scan(int flags)
   dirstack = NULL;
 
   lib = cfg_getsec(cfg, "library");
+  counter = 0;
 
   ndirs = cfg_size(lib, "directories");
   for (i = 0; i < ndirs; i++)
@@ -1061,7 +1062,6 @@ bulk_scan(int flags)
 	  continue;
 	}
 
-      counter = 0;
       db_transaction_begin();
 
       process_directories(deref, parent_id, flags);


### PR DESCRIPTION
Minor fixes:

* `counter` is reset in each iteration of loop over `directories` - this means the _Scanned N files..._ log message can be inaccurate