### PR TITLE
Metadata for albums and artists (alternative approach)

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -398,6 +398,10 @@ static const ssize_t dbgri_cols_map[] =
     dbgri_offsetof(songalbumartist),
     dbgri_offsetof(songartistid),
     dbgri_offsetof(song_length),
+    dbgri_offsetof(data_kind),
+    dbgri_offsetof(media_kind),
+    dbgri_offsetof(year),
+    dbgri_offsetof(date_released),
   };
 
 /* This list must be kept in sync with
@@ -1903,7 +1907,7 @@ db_build_query_group_albums(struct query_params *qp, struct query_clause *qc)
   char *query;
 
   count = sqlite3_mprintf("SELECT COUNT(DISTINCT f.songalbumid) FROM files f %s;", qc->where);
-  query = sqlite3_mprintf("SELECT g.id, g.persistentid, f.album, f.album_sort, COUNT(f.id) as track_count, 1 as album_count, f.album_artist, f.songartistid, SUM(f.song_length) FROM files f JOIN groups g ON f.songalbumid = g.persistentid %s GROUP BY f.songalbumid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
+  query = sqlite3_mprintf("SELECT g.id, g.persistentid, f.album, f.album_sort, COUNT(f.id) as track_count, 1 as album_count, f.album_artist, f.songartistid, SUM(f.song_length), MIN(f.data_kind), MIN(f.media_kind), MAX(f.year), MAX(f.date_released) FROM files f JOIN groups g ON f.songalbumid = g.persistentid %s GROUP BY f.songalbumid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
 
   return db_build_query_check(qp, count, query);
 }
@@ -1915,7 +1919,7 @@ db_build_query_group_artists(struct query_params *qp, struct query_clause *qc)
   char *query;
 
   count = sqlite3_mprintf("SELECT COUNT(DISTINCT f.songartistid) FROM files f %s;", qc->where);
-  query = sqlite3_mprintf("SELECT g.id, g.persistentid, f.album_artist, f.album_artist_sort, COUNT(f.id) as track_count, COUNT(DISTINCT f.songalbumid) as album_count, f.album_artist, f.songartistid, SUM(f.song_length) FROM files f JOIN groups g ON f.songartistid = g.persistentid %s GROUP BY f.songartistid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
+  query = sqlite3_mprintf("SELECT g.id, g.persistentid, f.album_artist, f.album_artist_sort, COUNT(f.id) as track_count, COUNT(DISTINCT f.songalbumid) as album_count, f.album_artist, f.songartistid, SUM(f.song_length), MIN(f.data_kind), MIN(f.media_kind), MAX(f.year), MAX(f.date_released) FROM files f JOIN groups g ON f.songartistid = g.persistentid %s GROUP BY f.songartistid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
 
   return db_build_query_check(qp, count, query);
 }

--- a/src/db.c
+++ b/src/db.c
@@ -402,6 +402,9 @@ static const ssize_t dbgri_cols_map[] =
     dbgri_offsetof(media_kind),
     dbgri_offsetof(year),
     dbgri_offsetof(date_released),
+    dbgri_offsetof(time_added),
+    dbgri_offsetof(time_played),
+    dbgri_offsetof(seek),
   };
 
 /* This list must be kept in sync with
@@ -1907,7 +1910,13 @@ db_build_query_group_albums(struct query_params *qp, struct query_clause *qc)
   char *query;
 
   count = sqlite3_mprintf("SELECT COUNT(DISTINCT f.songalbumid) FROM files f %s;", qc->where);
-  query = sqlite3_mprintf("SELECT g.id, g.persistentid, f.album, f.album_sort, COUNT(f.id) as track_count, 1 as album_count, f.album_artist, f.songartistid, SUM(f.song_length), MIN(f.data_kind), MIN(f.media_kind), MAX(f.year), MAX(f.date_released) FROM files f JOIN groups g ON f.songalbumid = g.persistentid %s GROUP BY f.songalbumid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
+  query = sqlite3_mprintf("SELECT " \
+			  "  g.id, g.persistentid, f.album, f.album_sort, COUNT(f.id) as track_count, " \
+			  "  1 as album_count, f.album_artist, f.songartistid, " \
+			  "  SUM(f.song_length), MIN(f.data_kind), MIN(f.media_kind), MAX(f.year), MAX(f.date_released), " \
+			  "  MAX(f.time_added), MAX(f.time_played), MAX(f.seek) " \
+			  "FROM files f JOIN groups g ON f.songalbumid = g.persistentid %s " \
+			  "GROUP BY f.songalbumid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
 
   return db_build_query_check(qp, count, query);
 }
@@ -1919,7 +1928,14 @@ db_build_query_group_artists(struct query_params *qp, struct query_clause *qc)
   char *query;
 
   count = sqlite3_mprintf("SELECT COUNT(DISTINCT f.songartistid) FROM files f %s;", qc->where);
-  query = sqlite3_mprintf("SELECT g.id, g.persistentid, f.album_artist, f.album_artist_sort, COUNT(f.id) as track_count, COUNT(DISTINCT f.songalbumid) as album_count, f.album_artist, f.songartistid, SUM(f.song_length), MIN(f.data_kind), MIN(f.media_kind), MAX(f.year), MAX(f.date_released) FROM files f JOIN groups g ON f.songartistid = g.persistentid %s GROUP BY f.songartistid %s %s %s;", qc->where, qc->having, qc->order, qc->index);
+  query = sqlite3_mprintf("SELECT " \
+			  "  g.id, g.persistentid, f.album_artist, f.album_artist_sort, COUNT(f.id) as track_count, " \
+			  "  COUNT(DISTINCT f.songalbumid) as album_count, f.album_artist, f.songartistid, " \
+			  "  SUM(f.song_length), MIN(f.data_kind), MIN(f.media_kind), MAX(f.year), MAX(f.date_released), " \
+			  "  MAX(f.time_added), MAX(f.time_played), MAX(f.seek) " \
+			  "FROM files f JOIN groups g ON f.songartistid = g.persistentid %s " \
+			  "GROUP BY f.songartistid %s %s %s;",
+			  qc->where, qc->having, qc->order, qc->index);
 
   return db_build_query_check(qp, count, query);
 }

--- a/src/db.h
+++ b/src/db.h
@@ -301,6 +301,9 @@ struct group_info {
   uint32_t media_kind;
   uint32_t year;
   uint32_t date_released;
+  uint32_t time_added;
+  uint32_t time_played;
+  uint32_t seek;
 };
 
 #define gri_offsetof(field) offsetof(struct group_info, field)
@@ -319,6 +322,9 @@ struct db_group_info {
   char *media_kind;
   char *year;
   char *date_released;
+  char *time_added;
+  char *time_played;
+  char *seek;
 };
 
 #define dbgri_offsetof(field) offsetof(struct db_group_info, field)

--- a/src/db.h
+++ b/src/db.h
@@ -297,6 +297,10 @@ struct group_info {
   char *songalbumartist; /* song album artist (asaa) */
   uint64_t songartistid; /* song artist id (asri) */
   uint32_t song_length;
+  uint32_t data_kind;
+  uint32_t media_kind;
+  uint32_t year;
+  uint32_t date_released;
 };
 
 #define gri_offsetof(field) offsetof(struct group_info, field)
@@ -311,6 +315,10 @@ struct db_group_info {
   char *songalbumartist;
   char *songartistid;
   char *song_length;
+  char *data_kind;
+  char *media_kind;
+  char *year;
+  char *date_released;
 };
 
 #define dbgri_offsetof(field) offsetof(struct db_group_info, field)

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -165,6 +165,13 @@ artist_to_json(struct db_group_info *dbgri)
   safe_json_add_int_from_string(item, "track_count", dbgri->itemcount);
   safe_json_add_int_from_string(item, "length_ms", dbgri->song_length);
 
+  safe_json_add_time_from_string(item, "time_played", dbgri->time_played, true);
+  safe_json_add_time_from_string(item, "time_added", dbgri->time_added, true);
+
+  ret = safe_atoi32(dbgri->seek, &intval);
+  if (ret == 0)
+    json_object_object_add(item, "in_progress", json_object_new_boolean(intval > 0));
+
   ret = safe_atoi32(dbgri->media_kind, &intval);
   if (ret == 0)
     safe_json_add_string(item, "media_kind", db_media_kind_label(intval));
@@ -202,6 +209,13 @@ album_to_json(struct db_group_info *dbgri)
   safe_json_add_string(item, "artist_id", dbgri->songartistid);
   safe_json_add_int_from_string(item, "track_count", dbgri->itemcount);
   safe_json_add_int_from_string(item, "length_ms", dbgri->song_length);
+
+  safe_json_add_time_from_string(item, "time_played", dbgri->time_played, true);
+  safe_json_add_time_from_string(item, "time_added", dbgri->time_added, true);
+
+  ret = safe_atoi32(dbgri->seek, &intval);
+  if (ret == 0)
+    json_object_object_add(item, "in_progress", json_object_new_boolean(intval > 0));
 
   ret = safe_atoi32(dbgri->media_kind, &intval);
   if (ret == 0)

--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -151,6 +151,7 @@ static json_object *
 artist_to_json(struct db_group_info *dbgri)
 {
   json_object *item;
+  int intval;
   char uri[100];
   char artwork_url[100];
   int ret;
@@ -163,6 +164,14 @@ artist_to_json(struct db_group_info *dbgri)
   safe_json_add_int_from_string(item, "album_count", dbgri->groupalbumcount);
   safe_json_add_int_from_string(item, "track_count", dbgri->itemcount);
   safe_json_add_int_from_string(item, "length_ms", dbgri->song_length);
+
+  ret = safe_atoi32(dbgri->media_kind, &intval);
+  if (ret == 0)
+    safe_json_add_string(item, "media_kind", db_media_kind_label(intval));
+
+  ret = safe_atoi32(dbgri->data_kind, &intval);
+  if (ret == 0)
+    safe_json_add_string(item, "data_kind", db_data_kind_label(intval));
 
   ret = snprintf(uri, sizeof(uri), "%s:%s:%s", "library", "artist", dbgri->persistentid);
   if (ret < sizeof(uri))
@@ -179,6 +188,7 @@ static json_object *
 album_to_json(struct db_group_info *dbgri)
 {
   json_object *item;
+  int intval;
   char uri[100];
   char artwork_url[100];
   int ret;
@@ -192,6 +202,17 @@ album_to_json(struct db_group_info *dbgri)
   safe_json_add_string(item, "artist_id", dbgri->songartistid);
   safe_json_add_int_from_string(item, "track_count", dbgri->itemcount);
   safe_json_add_int_from_string(item, "length_ms", dbgri->song_length);
+
+  ret = safe_atoi32(dbgri->media_kind, &intval);
+  if (ret == 0)
+    safe_json_add_string(item, "media_kind", db_media_kind_label(intval));
+
+  ret = safe_atoi32(dbgri->data_kind, &intval);
+  if (ret == 0)
+    safe_json_add_string(item, "data_kind", db_data_kind_label(intval));
+
+  safe_json_add_time_from_string(item, "date_released", dbgri->date_released, false);
+  safe_json_add_int_from_string(item, "year", dbgri->year);
 
   ret = snprintf(uri, sizeof(uri), "%s:%s:%s", "library", "album", dbgri->persistentid);
   if (ret < sizeof(uri))


### PR DESCRIPTION
Alternative to #1043

This has the drawback, that the returned media_kind and data_kind are not guaranteed to be the only ones that the tracks for the artist/album have.