### PR TITLE
[web] playlist 'play' to use tracks alreaady retreived instead of playlist_id

### DIFF
--- a/web-src/src/pages/PagePlaylist.vue
+++ b/web-src/src/pages/PagePlaylist.vue
@@ -69,11 +69,11 @@ export default {
 
   methods: {
     play: function () {
-      webapi.player_play_uri(this.playlist.uri, true)
+      webapi.player_play_uri(this.tracks.map(a => a.uri).join(','), true)
     },
 
     play_track: function (position) {
-      webapi.player_play_uri(this.playlist.uri, false, position)
+      webapi.player_play_uri(this.tracks.map(a => a.uri).join(','), false, position)
     },
 
     open_dialog: function (track) {


### PR DESCRIPTION
SMART playlists have the ability to create _random_ selections whenever the playlist is queried at the server/playlist evaluated:  ie this playlist:
```
"random 3 tracks" {
  media_kind is music
  order by random desc
  limit 3
}
``` 
On the webui this is rendered on the `PagePlaylist.vue` but the `play` (clicking on the tracks on the screen) result in a call to the server with the `playlist_id`.  Being a smartpl that returns different tracks each time it is queried, the tracks that would be added to the `queue` are NOT what is shown on the web ui.

The simple fix is to request to `play` via the track uris that are already on the rendered playlist page.