### PR TITLE
[web-src] random playlist playlist modal fix

### DIFF
--- a/web-src/src/components/ModalDialogPlaylist.vue
+++ b/web-src/src/components/ModalDialogPlaylist.vue
@@ -44,22 +44,22 @@ import webapi from '@/webapi'
 
 export default {
   name: 'ModalDialogPlaylist',
-  props: ['show', 'playlist', 'tracks'],
+  props: ['show', 'playlist', 'uris'],
 
   methods: {
     play: function () {
       this.$emit('close')
-      webapi.player_play_uri(this.playlist.uri, false)
+      webapi.player_play_uri(this.uris ? this.uris : this.playlist.uri, false)
     },
 
     queue_add: function () {
       this.$emit('close')
-      webapi.queue_add(this.playlist.uri)
+      webapi.queue_add(this.uris ? this.uris : this.playlist.uri)
     },
 
     queue_add_next: function () {
       this.$emit('close')
-      webapi.queue_add_next(this.playlist.uri)
+      webapi.queue_add_next(this.uris ? this.uris : this.playlist.uri)
     },
 
     open_playlist: function () {

--- a/web-src/src/pages/PagePlaylist.vue
+++ b/web-src/src/pages/PagePlaylist.vue
@@ -16,7 +16,7 @@
     <template slot="content">
       <p class="heading has-text-centered-mobile">{{ tracks.length }} tracks</p>
       <list-tracks :tracks="tracks" :uris="uris"></list-tracks>
-      <modal-dialog-playlist :show="show_playlist_details_modal" :playlist="playlist" :tracks="playlist.random ? tracks : undefined" @close="show_playlist_details_modal = false" />
+      <modal-dialog-playlist :show="show_playlist_details_modal" :playlist="playlist" :uris="uris" @close="show_playlist_details_modal = false" />
     </template>
   </content-with-heading>
 </template>


### PR DESCRIPTION
@chme - Follow up to https://github.com/ejurgensen/forked-daapd/pull/1082#issuecomment-683300664 / bug fix to 0.8.1

The `uris` is passed from `page/PagePlaylist.vue` to handle a dynamic _random_ smartpl playlist - we cannot add via `playlist.uri` because when it will ask the server for that uri it will generate another set of tracks, different to the ones on display of the playlist page
