### PR TITLE
Remove unnecessary check for FreeBSD

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -65,7 +65,7 @@
 
 #ifdef HAVE_TIMERFD
 # include <sys/timerfd.h>
-#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#else
 # include <signal.h>
 #endif
 


### PR DESCRIPTION
The non-timerfd code path depends on SIGALRM being defined, so signal.h always needs to be included.

This allows forked-daapd to build and run on NetBSD and probably other BSD systems too.