### PR TITLE
[alsa] Open PCM device before opening mixer

### DIFF
--- a/src/outputs/alsa.c
+++ b/src/outputs/alsa.c
@@ -1248,8 +1248,21 @@ static int
 alsa_device_probe(struct output_device *device, int callback_id)
 {
   struct alsa_session *as;
+  struct alsa_extra *ae;
+  snd_pcm_t *hdl;
+  int ret;
+
+  ae = device->extra_device_info;
+  ret = snd_pcm_open(&hdl, ae->card_name, SND_PCM_STREAM_PLAYBACK, 0);
+  if (ret < 0)
+    {
+      DPRINTF(E_LOG, L_LAUDIO, "Could not open playback device '%s': %s\n", ae->card_name, snd_strerror(ret));
+      return -1;
+    }
 
   as = alsa_session_make(device, callback_id);
+  snd_pcm_close(hdl);
+
   if (!as)
     return -1;
 


### PR DESCRIPTION
I am experimenting with a [PhatDAC](https://shop.pimoroni.com/products/phat-dac) attached to a RPi-Zero running forked-daapd. forked-daapd fails to open the ALSA output device. The problem is, that the PhatDAC does not have a hardware mixer and thus opening the mixer fails in `alsa_session_make`.

My `asound.conf` looks like this:

```
# Global alsa-lib configuration

pcm.!default {
  type plug
  slave.pcm "phatdac"
}
ctl.!default {
  type hw card 0
}
pcm.phatdac {
  type softvol
  slave.pcm "plughw:0"
  control.name "Master"
  control.card 0
}
``` 

The "softvol" mixer will only be created at first use of the device and therefor opening the mixer before the pcm device - like forked-daapd does - fails.
(forked-daapd plays to this output device fine, if I run e. g. speaker-test before starting forked-daapd)

Quote from the [ALSA documentation](https://alsa.opensrc.org/How_to_use_softvol_to_control_the_master_volume):

> Note: The new volume control won't appear immediately! Only after the first usage of the newly defined device (e.g. with the command above), should amixer controls | grep <control name> display your new control. 

@ejurgensen This PR fixes the problem for me, but looks to me like a hack. I would appreciate it, if you could take a look (and maybe propose a better solution).