### PR TITLE
[spec] Update rpm spec to handle libplist-devel name variations

### DIFF
--- a/forked-daapd.spec.in
+++ b/forked-daapd.spec.in
@@ -29,7 +29,7 @@ BuildRequires: pkgconfig(libavformat), pkgconfig(libavcodec)
 BuildRequires: pkgconfig(libswscale), pkgconfig(libavutil)
 BuildRequires: pkgconfig(libavfilter), pkgconfig(libcurl)
 BuildRequires: pkgconfig(openssl), pkgconfig(libwebsockets) > 2.0.2
-BuildRequires: pkgconfig(libsodium), pkgconfig(libplist) >= 0.16
+BuildRequires: pkgconfig(libsodium), libplist-devel >= 0.16
 BuildRequires: pkgconfig(avahi-client) >= 0.6.24
 Requires(pre): shadow-utils
 %if %{with alsa}


### PR DESCRIPTION
Very minor fix to the rpm spec to handle Fedora 33 changing the libplist-devel provides from pkgconfig(libplist) to pkgconfig(libplist-2.0).  All distributions I checked appear to work with BuildRequires of libplist-devel though (but still support the pkgconfig discovery), and it's probably easier than special casing each distribution that changes pkgconfig(libplist) in the future... 
