### PR TITLE
[web-src] typo blocking podcast deletion dialog

### DIFF
--- a/web-src/src/pages/PagePodcast.vue
+++ b/web-src/src/pages/PagePodcast.vue
@@ -48,7 +48,7 @@
         :new_tracks="new_tracks"
         @close="show_album_details_modal = false"
         @play-count-changed="reload_tracks"
-        @remove_podcast="open_remove_podcast_dialog" />
+        @remove-podcast="open_remove_podcast_dialog" />
       <modal-dialog
         :show="show_remove_podcast_modal"
         title="Remove podcast"


### PR DESCRIPTION
@chme - matching this up with `components/ListAlbums.vue`; typo blocks deletion from indidivual `podcast` page.

To reproduce:
* goto any podcast page via `http://localhost:3689/#/podcasts`
* click elipisis to bring up dialog
* click `Remove Podcast` - no subsequent dialog box pops up to initiate the deletion