### PR TITLE
[library] Directly notify listeners of db changes after adding new items

### DIFF
--- a/src/httpd_jsonapi.c
+++ b/src/httpd_jsonapi.c
@@ -3581,7 +3581,7 @@ jsonapi_reply_library_playlist_delete(struct httpd_request *hreq)
       return HTTP_BADREQUEST;
     }
 
-  db_pl_delete(pl_id);
+  library_playlist_remove_byid(pl_id);
 
   return HTTP_NOCONTENT;
 }

--- a/src/library.c
+++ b/src/library.c
@@ -743,6 +743,25 @@ library_playlist_remove(char *virtual_path)
 }
 
 int
+library_playlist_remove_byid(int pl_id)
+{
+  if (scanning)
+    {
+      DPRINTF(E_INFO, L_LIB, "Scan already running, ignoring request to remove playlist '%d'\n", pl_id);
+      return -1;
+    }
+
+  db_pl_delete(pl_id);
+
+  if (handle_deferred_update_notifications())
+    listener_notify(LISTENER_UPDATE | LISTENER_DATABASE);
+  else
+    listener_notify(LISTENER_UPDATE);
+
+  return 0;
+}
+
+int
 library_queue_save(char *path)
 {
   if (library_is_scanning())

--- a/src/library.h
+++ b/src/library.h
@@ -190,6 +190,9 @@ int
 library_playlist_remove(char *virtual_path);
 
 int
+library_playlist_remove_byid(int plid);
+
+int
 library_queue_save(char *path);
 
 int


### PR DESCRIPTION
Using the (default) delayed update trigger for adding podcasts to the library causes problems, if a JSON API client directly tries to reload the podcasts list after the (synchronous) call to add a new one returns. Instead of using the delayed update trigger, take care of notifying and updating the db timestamps (for cache invalidation) in the `librariy.c` `item_add` function.

Should fix #1132 