### PR TITLE
[web-src] recently added albums enhancements

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -37,6 +37,7 @@ static struct settings_option webinterface_options[] =
       { "show_menu_item_radio", SETTINGS_TYPE_BOOL, { false } },
       { "show_menu_item_files", SETTINGS_TYPE_BOOL, { true } },
       { "show_menu_item_search", SETTINGS_TYPE_BOOL, { true } },
+      { "recently_added_limit", SETTINGS_TYPE_INT, { 100 } },
   };
 
 static struct settings_option artwork_options[] =

--- a/web-src/src/components/ModalDialogAlbums.vue
+++ b/web-src/src/components/ModalDialogAlbums.vue
@@ -1,0 +1,86 @@
+<template>
+  <div>
+    <transition name="fade">
+      <div class="modal is-active" v-if="show">
+        <div class="modal-background" @click="$emit('close')"></div>
+        <div class="modal-content fd-modal-card">
+          <div class="card">
+            <div class="card-content">
+              <p class="title is-4"> {{ title }}</p>
+              <div class="content is-small">
+                <p>
+                  <span class="heading">Albums</span>
+                  <span class="title is-6">{{ albums.total }}</span>
+                </p>
+                <p>
+                  <span class="heading">Artists</span>
+                  <span class="title is-6">{{ artist_count }}</span>
+                </p>
+                <p>
+                  <span class="heading">Tracks</span>
+                  <span class="title is-6">{{ track_count }}</span>
+                </p>
+              </div>
+            </div>
+            <footer class="card-footer">
+              <a class="card-footer-item has-text-dark" @click="queue_add">
+                <span class="icon"><i class="mdi mdi-playlist-plus"></i></span> <span class="is-size-7">Add</span>
+              </a>
+              <a class="card-footer-item has-text-dark" @click="queue_add_next">
+                <span class="icon"><i class="mdi mdi-playlist-play"></i></span> <span class="is-size-7">Add Next</span>
+              </a>
+              <a class="card-footer-item has-text-dark" @click="play">
+                <span class="icon"><i class="mdi mdi-play"></i></span> <span class="is-size-7">Play</span>
+              </a>
+            </footer>
+          </div>
+        </div>
+        <button class="modal-close is-large" aria-label="close" @click="$emit('close')"></button>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+import webapi from '@/webapi'
+
+export default {
+  name: 'ModalDialog',
+  props: ['show', 'title', 'albums'],
+
+  computed: {
+    uris () {
+      return this.albums.items.map(a => a.uri).join(',')
+    },
+    artist_count () {
+      return new Set(this.albums.items.map(a => a.artist_id)).size
+    },
+    track_count () {
+      return this.albums.items.reduce((acc, item) => {
+        acc += item.track_count
+        return acc
+      }, 0)
+    }
+  },
+
+  methods: {
+    play: function () {
+      this.$emit('close')
+      webapi.player_play_uri(this.uris, false)
+    },
+
+    queue_add: function () {
+      this.$emit('close')
+      webapi.queue_add(this.uris)
+    },
+
+    queue_add_next: function () {
+      this.$emit('close')
+      webapi.queue_add_next(this.uris)
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/web-src/src/components/SettingsIntfield.vue
+++ b/web-src/src/components/SettingsIntfield.vue
@@ -1,0 +1,116 @@
+<template>
+  <fieldset :disabled="disabled">
+    <div class="field">
+      <label class="label has-text-weight-normal">
+        <slot name="label"></slot>
+        <i class="is-size-7"
+            :class="{
+              'has-text-info': statusUpdate === 'success',
+              'has-text-danger': statusUpdate === 'error'
+            }"> {{ info }}</i>
+      </label>
+      <div class="control">
+        <input class="input" type="number" min="0" :placeholder="placeholder"
+            :value="value"
+            @input="set_update_timer"
+            ref="settings_number">
+      </div>
+      <p class="help" v-if="$slots['info']">
+        <slot name="info"></slot>
+      </p>
+    </div>
+  </fieldset>
+</template>
+
+<script>
+import webapi from '@/webapi'
+import * as types from '@/store/mutation_types'
+
+export default {
+  name: 'SettingsIntfield',
+
+  props: ['category_name', 'option_name', 'placeholder', 'disabled'],
+
+  data () {
+    return {
+      timerDelay: 2000,
+      timerId: -1,
+
+      statusUpdate: ''
+    }
+  },
+
+  computed: {
+    category () {
+      return this.$store.state.settings.categories.find(elem => elem.name === this.category_name)
+    },
+
+    option () {
+      if (!this.category) {
+        return {}
+      }
+      return this.category.options.find(elem => elem.name === this.option_name)
+    },
+
+    value () {
+      return this.option.value
+    },
+
+    info () {
+      if (this.statusUpdate === 'success') {
+        return '(setting saved)'
+      } else if (this.statusUpdate === 'error') {
+        return '(error saving setting)'
+      }
+      return ''
+    }
+  },
+
+  methods: {
+    set_update_timer () {
+      if (this.timerId > 0) {
+        window.clearTimeout(this.timerId)
+        this.timerId = -1
+      }
+
+      this.statusUpdate = ''
+      const newValue = this.$refs.settings_number.value
+      if (newValue !== this.value) {
+        this.timerId = window.setTimeout(this.update_setting, this.timerDelay)
+      }
+    },
+
+    update_setting () {
+      this.timerId = -1
+
+      const newValue = this.$refs.settings_number.value
+      if (newValue === this.value) {
+        this.statusUpdate = ''
+        return
+      }
+
+      const option = {
+        category: this.category.name,
+        name: this.option_name,
+        value: parseInt(newValue, 10)
+      }
+      webapi.settings_update(this.category.name, option).then(() => {
+        this.$store.commit(types.UPDATE_SETTINGS_OPTION, option)
+        this.statusUpdate = 'success'
+      }).catch(() => {
+        this.statusUpdate = 'error'
+        this.$refs.settings_number.value = this.value
+      }).finally(() => {
+        this.timerId = window.setTimeout(this.clear_status, this.timerDelay)
+      })
+    },
+
+    clear_status: function () {
+      this.statusUpdate = ''
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/web-src/src/pages/PageBrowseRecentlyAdded.vue
+++ b/web-src/src/pages/PageBrowseRecentlyAdded.vue
@@ -110,11 +110,6 @@ const browseData = {
         type: 'album',
         expression: 'time_added after last month and media_kind is music order by time_added desc',
         limit: recentlyAddedLimit
-      }),
-      webapi.search({
-        type: 'album',
-        expression: 'time_added before last month and media_kind is music order by time_added desc',
-        limit: recentlyAddedLimit
       })
     ])
   },
@@ -123,13 +118,6 @@ const browseData = {
     vm.recently_added_today = response[0].data.albums
     vm.recently_added_week = response[1].data.albums
     vm.recently_added_month = response[2].data.albums
-    vm.recently_added_older = response[3].data.albums
-
-    if (vm.recently_added_older.items.length) {
-      const keep = vm.recently_added_older.items.length - store.getters.settings_option_recently_added_limit - vm.recently_added_month.items.length
-      vm.recently_added_older.items.splice(keep)
-      vm.recently_added_older.total = keep
-    }
   }
 }
 
@@ -149,6 +137,19 @@ export default {
       show_modal_week: false,
       show_modal_month: false,
       show_modal_older: false
+    }
+  },
+
+  mounted () {
+    const more = store.getters.settings_option_recently_added_limit - this.recently_added_month.items.length
+    if (more) {
+      webapi.search({
+        type: 'album',
+        expression: 'time_added before last month and media_kind is music order by time_added desc',
+        limit: more
+      }).then(({ data }) => {
+        this.recently_added_older = data.albums
+      })
     }
   },
 

--- a/web-src/src/pages/PageBrowseRecentlyAdded.vue
+++ b/web-src/src/pages/PageBrowseRecentlyAdded.vue
@@ -124,6 +124,12 @@ const browseData = {
     vm.recently_added_week = response[1].data.albums
     vm.recently_added_month = response[2].data.albums
     vm.recently_added_older = response[3].data.albums
+
+    if (vm.recently_added_older.items.length) {
+      const keep = vm.recently_added_older.items.length - store.getters.settings_option_recently_added_limit - vm.recently_added_month.items.length
+      vm.recently_added_older.items.splice(keep)
+      vm.recently_added_older.total = keep
+    }
   }
 }
 
@@ -160,7 +166,7 @@ export default {
       return this.recently_added_older.items.length > 0
     },
     recently_added () {
-      return this.recently_added_today.items.length + this.recently_added_week.items.length + this.recently_added_month.items.length + this.recently_added_older.items.length
+      return this.recently_added_older.items.length + this.recently_added_month.items.length
     }
   }
 }

--- a/web-src/src/pages/PageBrowseRecentlyAdded.vue
+++ b/web-src/src/pages/PageBrowseRecentlyAdded.vue
@@ -90,10 +90,11 @@ import TabsMusic from '@/components/TabsMusic'
 import ListAlbums from '@/components/ListAlbums'
 import ModalDialogAlbums from '@/components/ModalDialogAlbums'
 import webapi from '@/webapi'
+import store from '@/store'
 
 const browseData = {
   load: function (to) {
-    const recentlyAddedLimit = 100
+    const recentlyAddedLimit = store.getters.settings_option_recently_added_limit
     return Promise.all([
       webapi.search({
         type: 'album',

--- a/web-src/src/pages/PageBrowseRecentlyAdded.vue
+++ b/web-src/src/pages/PageBrowseRecentlyAdded.vue
@@ -14,8 +14,16 @@
         <p class="title is-6">Today</p>
         <p class="heading">{{ recently_added_today.items.length }} albums</p>
       </template>
+      <template slot="heading-right">
+        <div class="buttons is-centered">
+          <a class="button is-small is-light is-rounded" @click="show_modal_today = true">
+            <span class="icon"><i class="mdi mdi-dots-horizontal mdi-18px"></i></span>
+          </a>
+        </div>
+      </template>
       <template slot="content">
         <list-albums :albums="recently_added_today.items"></list-albums>
+        <modal-dialog-albums :show="show_modal_today" title='Recently Added - Today' :albums="recently_added_today" @close="show_modal_today = false" />
       </template>
     </content-with-heading>
 
@@ -24,8 +32,16 @@
         <p class="title is-6">This Week</p>
         <p class="heading">{{ recently_added_week.items.length }} albums</p>
       </template>
+      <template slot="heading-right">
+        <div class="buttons is-centered">
+          <a class="button is-small is-light is-rounded" @click="show_modal_week = true">
+            <span class="icon"><i class="mdi mdi-dots-horizontal mdi-18px"></i></span>
+          </a>
+        </div>
+      </template>
       <template slot="content">
         <list-albums :albums="recently_added_week.items"></list-albums>
+        <modal-dialog-albums :show="show_modal_week" title='Recently Added - Past Week' :albums="recently_added_week" @close="show_modal_week = false" />
       </template>
     </content-with-heading>
 
@@ -34,8 +50,16 @@
         <p class="title is-6">This Month </p>
         <p class="heading">{{ recently_added_month.items.length }} albums</p>
       </template>
+      <template slot="heading-right">
+        <div class="buttons is-centered">
+          <a class="button is-small is-light is-rounded" @click="show_modal_month = true">
+            <span class="icon"><i class="mdi mdi-dots-horizontal mdi-18px"></i></span>
+          </a>
+        </div>
+      </template>
       <template slot="content">
         <list-albums :albums="recently_added_month.items"></list-albums>
+        <modal-dialog-albums :show="show_modal_month" title='Recently Added - Past Month' :albums="recently_added_month" @close="show_modal_month = false" />
       </template>
     </content-with-heading>
 
@@ -44,8 +68,16 @@
         <p class="title is-6">Older</p>
         <p class="heading">{{ recently_added_older.items.length }} albums</p>
       </template>
+      <template slot="heading-right">
+        <div class="buttons is-centered">
+          <a class="button is-small is-light is-rounded" @click="show_modal_older = true">
+            <span class="icon"><i class="mdi mdi-dots-horizontal mdi-18px"></i></span>
+          </a>
+        </div>
+      </template>
       <template slot="content">
         <list-albums :albums="recently_added_older.items"></list-albums>
+        <modal-dialog-albums :show="show_modal_older" title='Recently Added - Older than Month' :albums="recently_added_older" @close="show_modal_older = false" />
       </template>
     </content-with-heading>
   </div>
@@ -56,6 +88,7 @@ import { LoadDataBeforeEnterMixin } from './mixin'
 import ContentWithHeading from '@/templates/ContentWithHeading'
 import TabsMusic from '@/components/TabsMusic'
 import ListAlbums from '@/components/ListAlbums'
+import ModalDialogAlbums from '@/components/ModalDialogAlbums'
 import webapi from '@/webapi'
 
 const browseData = {
@@ -75,16 +108,19 @@ const browseData = {
 export default {
   name: 'PageBrowseType',
   mixins: [LoadDataBeforeEnterMixin(browseData)],
-  components: { ContentWithHeading, TabsMusic, ListAlbums },
-
+  components: { ContentWithHeading, TabsMusic, ListAlbums, ModalDialogAlbums },
   data () {
     return {
       recently_added_today: { items: [] },
       recently_added_week: { items: [] },
       recently_added_month: { items: [] },
       recently_added_older: { items: [] },
+      limit: 100,
 
-      limit: 100
+      show_modal_today: false,
+      show_modal_week: false,
+      show_modal_month: false,
+      show_modal_older: false
     }
   },
 

--- a/web-src/src/pages/PageBrowseRecentlyAdded.vue
+++ b/web-src/src/pages/PageBrowseRecentlyAdded.vue
@@ -5,10 +5,47 @@
     <content-with-heading>
       <template slot="heading-left">
         <p class="title is-4">Recently added</p>
-        <p class="heading">albums</p>
+        <p class="heading">{{ recently_added }} albums</p>
+      </template>
+    </content-with-heading>
+
+    <content-with-heading v-if="show_recent_today && recently_added_today.items.length">
+      <template slot="heading-left">
+        <p class="title is-6">Today</p>
+        <p class="heading">{{ recently_added_today.items.length }} albums</p>
       </template>
       <template slot="content">
-        <list-albums :albums="recently_added.items"></list-albums>
+        <list-albums :albums="recently_added_today.items"></list-albums>
+      </template>
+    </content-with-heading>
+
+    <content-with-heading v-if="show_recent_week && recently_added_week.items.length">
+      <template slot="heading-left">
+        <p class="title is-6">This Week</p>
+        <p class="heading">{{ recently_added_week.items.length }} albums</p>
+      </template>
+      <template slot="content">
+        <list-albums :albums="recently_added_week.items"></list-albums>
+      </template>
+    </content-with-heading>
+
+    <content-with-heading v-if="show_recent_month && recently_added_month.items.length">
+      <template slot="heading-left">
+        <p class="title is-6">This Month </p>
+        <p class="heading">{{ recently_added_month.items.length }} albums</p>
+      </template>
+      <template slot="content">
+        <list-albums :albums="recently_added_month.items"></list-albums>
+      </template>
+    </content-with-heading>
+
+    <content-with-heading v-if="show_recent_older && recently_added_older.items.length">
+      <template slot="heading-left">
+        <p class="title is-6">Older</p>
+        <p class="heading">{{ recently_added_older.items.length }} albums</p>
+      </template>
+      <template slot="content">
+        <list-albums :albums="recently_added_older.items"></list-albums>
       </template>
     </content-with-heading>
   </div>
@@ -25,13 +62,13 @@ const browseData = {
   load: function (to) {
     return webapi.search({
       type: 'album',
-      expression: 'media_kind is music having track_count > 3 order by time_added desc',
-      limit: 500
+      expression: 'time_added after today and media_kind is music order by time_added desc',
+      limit: 100
     })
   },
 
   set: function (vm, response) {
-    vm.recently_added = response.data.albums
+    vm.recently_added_today = response.data.albums
   }
 }
 
@@ -42,7 +79,62 @@ export default {
 
   data () {
     return {
-      recently_added: {}
+      recently_added_today: { items: [] },
+      recently_added_week: { items: [] },
+      recently_added_month: { items: [] },
+      recently_added_older: { items: [] },
+
+      limit: 100
+    }
+  },
+
+  created () {
+    if (this.recently_added < this.limit) {
+      webapi.search({
+        type: 'album',
+        expression: 'time_added after this week and media_kind is music order by time_added desc',
+        limit: this.limit - this.recently_added
+      }).then(({ data }) => {
+        this.recently_added_week = data.albums
+
+        if (this.recently_added < this.limit) {
+          webapi.search({
+            type: 'album',
+            expression: 'time_added after last month and media_kind is music order by time_added desc',
+            limit: this.limit - this.recently_added
+          }).then(({ data }) => {
+            this.recently_added_month = data.albums
+
+            if (this.recently_added < this.limit) {
+              webapi.search({
+                type: 'album',
+                expression: 'time_added before last month and media_kind is music order by time_added desc',
+                limit: this.limit - this.recently_added
+              }).then(({ data }) => {
+                this.recently_added_older = data.albums
+              })
+            }
+          })
+        }
+      })
+    }
+  },
+
+  computed: {
+    show_recent_today () {
+      return this.recently_added_today.items.length > 0
+    },
+    show_recent_week () {
+      return this.recently_added_week.items.length > 0
+    },
+    show_recent_month () {
+      return this.recently_added_month.items.length > 0
+    },
+    show_recent_older () {
+      return this.recently_added_older.items.length > 0
+    },
+    recently_added () {
+      return this.recently_added_today.items.length + this.recently_added_week.items.length + this.recently_added_month.items.length + this.recently_added_older.items.length
     }
   }
 }

--- a/web-src/src/pages/SettingsPageWebinterface.vue
+++ b/web-src/src/pages/SettingsPageWebinterface.vue
@@ -80,6 +80,18 @@
         </settings-textfield>
       </template>
     </content-with-heading>
+
+    <content-with-heading>
+      <template slot="heading-left">
+        <div class="title is-4">Recently Added</div>
+      </template>
+
+      <template slot="content">
+        <settings-intfield category_name="webinterface" option_name="recently_added_limit">
+          <template slot="label"> Limit on number of albums to show on 'Recently Added' page</template>
+        </settings-intfield>
+      </template>
+    </content-with-heading>
   </div>
 </template>
 
@@ -88,10 +100,11 @@ import ContentWithHeading from '@/templates/ContentWithHeading'
 import TabsSettings from '@/components/TabsSettings'
 import SettingsCheckbox from '@/components/SettingsCheckbox'
 import SettingsTextfield from '@/components/SettingsTextfield'
+import SettingsIntfield from '@/components/SettingsIntfield'
 
 export default {
   name: 'SettingsPageWebinterface',
-  components: { ContentWithHeading, TabsSettings, SettingsCheckbox, SettingsTextfield },
+  components: { ContentWithHeading, TabsSettings, SettingsCheckbox, SettingsTextfield, SettingsIntfield },
 
   computed: {
     settings_option_show_composer_now_playing () {

--- a/web-src/src/store/index.js
+++ b/web-src/src/store/index.js
@@ -77,6 +77,16 @@ export default new Vuex.Store({
       return null
     },
 
+    settings_option_recently_added_limit: (state, getters) => {
+      if (getters.settings_webinterface) {
+        const option = getters.settings_webinterface.options.find(elem => elem.name === 'recently_added_limit')
+        if (option) {
+          return option.value
+        }
+      }
+      return 100
+    },
+
     settings_option_show_composer_now_playing: (state, getters) => {
       if (getters.settings_webinterface) {
         const option = getters.settings_webinterface.options.find(elem => elem.name === 'show_composer_now_playing')


### PR DESCRIPTION
cc @chme 

`Recently added` enhancements:

* add new element in `settings -> webinterface` module to allow to manage the number albums retrieved for `Recently Added` ablums page
  * Defaulting to 100
* use `SMARTpl` to retrieve albums across 4 _sections_ - allow users to easy see recently add albums over a time period.  Each section will also incl the albums from previous section (album _added today_ will also be included in _added last week_ etc) expect for the last section
  * items added today
  * items added this wk
  * items added within last month
  * items added after last month 
* add standard `play / add / add next` dialogue for each _sections _ - `play` for _This Week_ section only plays items in that section.


![recent-add](https://user-images.githubusercontent.com/18466811/100739927-c9b10300-33cf-11eb-93f0-93eac4b3822a.png)