### PR TITLE
[httpd] [ws] configurable network interfaces

### DIFF
--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -34,6 +34,12 @@ general {
 	# Websocket port for the web interface.
 #	websocket_port = 3688
 
+	# Websocket interface for the web interface.
+	# Options are interace names e.g. "lo" for loopback or an ipv4 address
+	# "127.0.0.1". The default is any interface "0.0.0.0".
+	# Useful with Nginx as SSL proxy on the same port as forked-daapd.
+#	websocket_interface = "0.0.0.0"
+
 	# Sets who is allowed to connect without authorisation. This applies to
 	# client types like Remotes, DAAP clients (iTunes) and to the web
 	# interface. Options are "any", "localhost" or the prefix to one or
@@ -68,6 +74,14 @@ library {
 
 	# TCP port to listen on. Default port is 3689 (daap)
 	port = 3689
+
+	# ipv4 interface to listen on. Options are an ipv4 address. 
+	# Defaults to 0.0.0.0 (any)
+#	interface = "0.0.0.0"
+
+	# ipv6 interface to listen on. Options are an ipv6 address.
+	# Defaults to :: (any)
+#	interface6 = "::"
 
 	# Password for the library. Optional.
 #	password = ""

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -32,15 +32,13 @@ general {
 	# "trusted_network" (see below) does not require password
 #	admin_password = ""
 
-	# Websocket port for the web interface.
+	# Websocket port for the web interface
 #	websocket_port = 3688
 
-	# Websocket interface for the web interface.
-	# Options are interface names e.g. "lo" for loopback or an
-	# ipv4 address "127.0.0.1". Defaults to 0.0.0.0 (any).
-	# Useful for Nginx with SSL as a reverse proxy on the same
-	# port as forked-daapd.
-#	websocket_interface = "0.0.0.0"
+	# Websocket interface for the web interface
+	# Options are interface names e.g. "lo" for loopback.
+	# Defaults to unset "" for any interface.
+#	websocket_interface = ""
 
 	# Sets who is allowed to connect without authorisation. This applies to
 	# client types like Remotes, DAAP clients (iTunes) and to the web

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -7,6 +7,7 @@
 #
 # In all likelihood, that's all you need to do!
 
+# General configuration
 general {
 	# Username
 	# Make sure the user has read access to the library directories you set
@@ -77,12 +78,13 @@ library {
 	port = 3689
 
 	# ipv4 interface to listen on. Options are an ipv4 address. 
-	# Defaults to 0.0.0.0 (any)
-#	interface = "0.0.0.0"
+	# Defaults to unset "" for any interface.
+#	interface = ""
 
 	# ipv6 interface to listen on. Options are an ipv6 address.
-	# Defaults to :: (any)
-#	interface6 = "::"
+	# Only used when IPv6 is enabled in general configuration.
+	# Defaults to unset "" for any interface.
+#	interface6 = ""
 
 	# Password for the library. Optional.
 #	password = ""

--- a/forked-daapd.conf.in
+++ b/forked-daapd.conf.in
@@ -35,9 +35,10 @@ general {
 #	websocket_port = 3688
 
 	# Websocket interface for the web interface.
-	# Options are interace names e.g. "lo" for loopback or an ipv4 address
-	# "127.0.0.1". The default is any interface "0.0.0.0".
-	# Useful with Nginx as SSL proxy on the same port as forked-daapd.
+	# Options are interface names e.g. "lo" for loopback or an
+	# ipv4 address "127.0.0.1". Defaults to 0.0.0.0 (any).
+	# Useful for Nginx with SSL as a reverse proxy on the same
+	# port as forked-daapd.
 #	websocket_interface = "0.0.0.0"
 
 	# Sets who is allowed to connect without authorisation. This applies to

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -51,6 +51,7 @@ static cfg_opt_t sec_general[] =
     CFG_INT_CB("loglevel", E_LOG, CFGF_NONE, &cb_loglevel),
     CFG_STR("admin_password", NULL, CFGF_NONE),
     CFG_INT("websocket_port", 3688, CFGF_NONE),
+    CFG_STR("websocket_interface", "0.0.0.0", CFGF_NONE),
     CFG_STR_LIST("trusted_networks", "{localhost,192.168,fd}", CFGF_NONE),
     CFG_BOOL("ipv6", cfg_true, CFGF_NONE),
     CFG_STR("cache_path", STATEDIR "/cache/" PACKAGE "/cache.db", CFGF_NONE),
@@ -76,6 +77,8 @@ static cfg_opt_t sec_library[] =
   {
     CFG_STR("name", "My Music on %h", CFGF_NONE),
     CFG_INT("port", 3689, CFGF_NONE),
+    CFG_STR("interface", "0.0.0.0", CFGF_NONE),
+    CFG_STR("interface6", "::", CFGF_NONE),
     CFG_STR("password", NULL, CFGF_NONE),
     CFG_STR_LIST("directories", NULL, CFGF_NONE),
     CFG_BOOL("follow_symlinks", cfg_true, CFGF_NONE),

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -1787,50 +1787,50 @@ httpd_init(const char *webroot)
 
   if (v6enabled)
     {
-	    if (strlen(httpd_interface6) != 0)     
+      if (strlen(httpd_interface6) != 0)     
         {
-		      ret = evhttp_bind_socket(evhttpd, httpd_interface6, httpd_port);
+          ret = evhttp_bind_socket(evhttpd, httpd_interface6, httpd_port);
           if (ret < 0)
-			      {
-         	    DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv6, falling back to IPv4\n", httpd_port);
-          	  v6enabled = 0;
-        	  }
- 		    }       
+            {
+              DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv6, falling back to IPv4\n", httpd_port);
+              v6enabled = 0;
+            }
+        }       
       else 
-      	{
-		      ret = evhttp_bind_socket(evhttpd, "::", httpd_port);
-      		if (ret < 0)
-			      {
-          		DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv6, falling back to IPv4\n", httpd_port);
-          		v6enabled = 0;
-        		}
-    		}
+        {
+          ret = evhttp_bind_socket(evhttpd, "::", httpd_port);
+          if (ret < 0)
+            {
+              DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv6, falling back to IPv4\n", httpd_port);
+              v6enabled = 0;
+            }
+        }
     }
  
   if (strlen(httpd_interface) != 0)
     {
-		  ret = evhttp_bind_socket(evhttpd, httpd_interface, httpd_port);
+      ret = evhttp_bind_socket(evhttpd, httpd_interface, httpd_port);
       if (ret < 0)
-			  {
+        {
           DPRINTF(E_FATAL, L_HTTPD, "Could not bind to port %d (forked-daapd already running?)\n", httpd_port);
-	        goto bind_fail;
+          goto bind_fail;
         }
- 		}       
+    }       
   else 
     {
-		  ret = evhttp_bind_socket(evhttpd, "0.0.0.0", httpd_port);
+      ret = evhttp_bind_socket(evhttpd, "0.0.0.0", httpd_port);
       if (ret < 0)
-			{  
-        if (!v6enabled)
-	        {
-	          DPRINTF(E_FATAL, L_HTTPD, "Could not bind to port %d (forked-daapd already running?)\n", httpd_port);
-	          goto bind_fail;
-	        }
-        #ifndef __linux__
-        // Linux will listen on both ipv6 and ipv4, but FreeBSD won't
-        DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv4, listening on IPv6 only\n", httpd_port);
-        #endif
-      }
+        {  
+          if (!v6enabled)
+            {
+              DPRINTF(E_FATAL, L_HTTPD, "Could not bind to port %d (forked-daapd already running?)\n", httpd_port);
+              goto bind_fail;
+            }
+          #ifndef __linux__
+          // Linux will listen on both ipv6 and ipv4, but FreeBSD won't
+          DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv4, listening on IPv6 only\n", httpd_port);
+          #endif
+        }
     }
 
   evhttp_set_gencb(evhttpd, httpd_gen_cb, NULL);

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -1848,8 +1848,8 @@ httpd_init(const char *webroot)
   return 0;
  
  bind_fail_ipv4:
-	DPRINTF(E_FATAL, L_HTTPD, "Could not bind to port %d (forked-daapd already running?)\n", httpd_port);
-	evhttp_free(evhttpd);
+  DPRINTF(E_FATAL, L_HTTPD, "Could not bind to port %d (forked-daapd already running?)\n", httpd_port);
+  evhttp_free(evhttpd);
  bind_fail_ipv6:
   DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv6, falling back to IPv4\n", httpd_port);
   v6enabled = 0;

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -136,6 +136,8 @@ static pthread_t tid_httpd;
 
 static const char *allow_origin;
 static int httpd_port;
+static const char *httpd_interface;
+static const char *httpd_interface6;
 
 #ifdef HAVE_LIBEVENT2_OLD
 struct stream_ctx *g_st;
@@ -1770,6 +1772,8 @@ httpd_init(const char *webroot)
 
   v6enabled = cfg_getbool(cfg_getsec(cfg, "general"), "ipv6");
   httpd_port = cfg_getint(cfg_getsec(cfg, "library"), "port");
+  httpd_interface = cfg_getstr(cfg_getsec(cfg, "library"), "interface");
+  httpd_interface6 = cfg_getstr(cfg_getsec(cfg, "library"), "interface6");
 
   // For CORS headers
   allow_origin = cfg_getstr(cfg_getsec(cfg, "general"), "allow_origin");
@@ -1783,7 +1787,7 @@ httpd_init(const char *webroot)
 
   if (v6enabled)
     {
-      ret = evhttp_bind_socket(evhttpd, "::", httpd_port);
+      ret = evhttp_bind_socket(evhttpd, httpd_interface6, httpd_port);
       if (ret < 0)
 	{
 	  DPRINTF(E_LOG, L_HTTPD, "Could not bind to port %d with IPv6, falling back to IPv4\n", httpd_port);
@@ -1791,7 +1795,7 @@ httpd_init(const char *webroot)
 	}
     }
 
-  ret = evhttp_bind_socket(evhttpd, "0.0.0.0", httpd_port);
+  ret = evhttp_bind_socket(evhttpd, httpd_interface, httpd_port);
   if (ret < 0)
     {
       if (!v6enabled)

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -40,6 +40,7 @@ static struct lws_context *context;
 static pthread_t tid_websocket;
 
 static int websocket_port;
+static const char *websocket_interface;
 static bool websocket_exit = false;
 
 // Event mask of events to notify websocket clients
@@ -384,10 +385,13 @@ websocket_init(void)
       DPRINTF(E_LOG, L_WEB, "Websocket disabled. To enable it, set websocket_port in config to a valid port number.\n");
       return 0;
     }
+  
+  websocket_interface = cfg_getstr(cfg_getsec(cfg, "general"), "websocket_interface");
 
   memset(&info, 0, sizeof(info));
   info.port = websocket_port;
   info.protocols = protocols;
+  info.iface = websocket_interface;
   if (!cfg_getbool(cfg_getsec(cfg, "general"), "ipv6"))
     info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
   info.gid = -1;

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -391,7 +391,8 @@ websocket_init(void)
   memset(&info, 0, sizeof(info));
   info.port = websocket_port;
   info.protocols = protocols;
-  info.iface = websocket_interface;
+  if (strlen(websocket_interface) != 0)
+    info.iface = websocket_interface;
   if (!cfg_getbool(cfg_getsec(cfg, "general"), "ipv6"))
     info.options |= LWS_SERVER_OPTION_DISABLE_IPV6;
   info.gid = -1;


### PR DESCRIPTION
This makes the network interfaces for websocket and web interface configurable via the config file. It is also necessary when using nginx as ssl proxy. See #664.