### PR TITLE
[db] Remove break after v2103 db update and directly run update for v2104

### DIFF
--- a/src/db_upgrade.c
+++ b/src/db_upgrade.c
@@ -1249,7 +1249,6 @@ db_upgrade(sqlite3 *hdl, int db_ver)
       ret = db_generic_upgrade(hdl, db_upgrade_v2104_queries, ARRAY_SIZE(db_upgrade_v2104_queries));
       if (ret < 0)
 	return -1;
-      break;
 
       /* FALLTHROUGH */
 
@@ -1257,6 +1256,8 @@ db_upgrade(sqlite3 *hdl, int db_ver)
       ret = db_generic_upgrade(hdl, db_upgrade_v2105_queries, ARRAY_SIZE(db_upgrade_v2105_queries));
       if (ret < 0)
 	return -1;
+
+      /* Last case statement is the only one that ends with a break statement! */
       break;
 
     default:


### PR DESCRIPTION
The break results in the ugrade stopping at v2103 and only after another
restart of forked-daapd the update to v2104 happens. Removing it will
directly update to the latest DB version.