### PR TITLE
[scan] Remove leftover iTunes #ifdefs

### DIFF
--- a/src/library/filescanner.c
+++ b/src/library/filescanner.c
@@ -338,10 +338,8 @@ file_type_get(const char *path) {
   if ((strcasecmp(ext, ".jpg") == 0) || (strcasecmp(ext, ".png") == 0))
     return FILE_IGNORE;
 
-#ifdef ITUNES
   if (strcasecmp(ext, ".xml") == 0)
     return FILE_ITUNES;
-#endif
 
   if (strcasecmp(ext, ".remote") == 0)
     return FILE_CTRL_REMOTE;
@@ -486,10 +484,8 @@ process_playlist(char *file, time_t mtime, int dir_id)
   ft = file_type_get(file);
   if (ft == FILE_PLAYLIST)
     scan_playlist(file, mtime, dir_id);
-#ifdef ITUNES
   else if (ft == FILE_ITUNES)
     scan_itunes_itml(file, mtime, dir_id);
-#endif
 }
 
 /* If we found a control file we want to kickoff some action */

--- a/src/library/filescanner.h
+++ b/src/library/filescanner.h
@@ -19,10 +19,8 @@ scan_playlist(const char *file, time_t mtime, int dir_id);
 void
 scan_smartpl(const char *file, time_t mtime, int dir_id);
 
-#ifdef ITUNES
 void
 scan_itunes_itml(const char *file, time_t mtime, int dir_id);
-#endif
 
 
 /* ------------  Common utility functions used by the scanners ------------ */


### PR DESCRIPTION
Now that the iTunes configuration option was removed in a5bd8b011e6aaa7c565939525592c11a1d235a9e, remove leftover `#ifdef`s that exclude the iTunes scanning implementation.