### PR TITLE
[gh-actions] Add scan-build and build for more configurations

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,15 +17,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -51,8 +42,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -yq build-essential clang clang-tools git autotools-dev autoconf libtool gettext gawk gperf antlr3 libantlr3c-dev libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libmxml-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libsodium-dev libcurl4-openssl-dev libjson-c-dev libprotobuf-c-dev libpulse-dev libwebsockets-dev libgnutls28-dev
         autoreconf -vi
-        ./configure
-        make
+        ./configure --enable-lastfm --enable-chromecast
+        scan-build --status-bugs -disable-checker deadcode.DeadStores make
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,13 +17,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -yq build-essential clang clang-tools git autotools-dev autoconf libtool gettext gawk gperf antlr3 libantlr3c-dev libconfuse-dev libunistring-dev libsqlite3-dev libavcodec-dev libavformat-dev libavfilter-dev libswscale-dev libavutil-dev libasound2-dev libmxml-dev libgcrypt20-dev libavahi-client-dev zlib1g-dev libevent-dev libplist-dev libsodium-dev libcurl4-openssl-dev libjson-c-dev libprotobuf-c-dev libpulse-dev libwebsockets-dev libgnutls28-dev
-    - name: configure
+    - name: build and check
       run: |
         autoreconf -vi
         ./configure
-    - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
+        make
+        make check
+        make distcheck
+    - name: build with lastfm, chromecast, pulse
+      run: |
+        autoreconf -vi
+        ./configure --enable-lastfm --enable-chromecast --with-pulseaudio
+        make


### PR DESCRIPTION
These changes hopefully help us detect more errors automatically by gh-actions:

- in code ql analysis build with scan-build to detect errors and build with additional dependencies to cover more code in forked-daapd
- in code ql analysis remove the special git checkout command due to the warning from code ql action (e. g. https://github.com/ejurgensen/forked-daapd/actions/runs/651612902)
- in ubuntu add additional step to build with optional dependencies to cover more code

We don't have 100% coverage of our code, e. g. scan-build with pulse audio or building with spotify. I am not sure if we should add them.

ref: https://github.com/ejurgensen/forked-daapd/pull/1209#issuecomment-799758597